### PR TITLE
RTS camera and click-to-move hero controller

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -20,6 +20,17 @@ config/icon="res://icon.svg"
 window/stretch/mode="canvas_items"
 window/stretch/aspect="expand"
 
+[input]
+
+move_command={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"double_click":false,"factor":1.0,"button_index":2,"canceled":false,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"button_mask":0)]
+}
+
+[navigation]
+
+3d/default_cell_height=0.05
+
 [physics]
 
 3d/physics_engine="Jolt Physics"

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -1,10 +1,46 @@
 # scenes/
 
-Top-level game scenes.
+Top-level game scenes and their scripts.
 
-- `main.tscn` — the project's main scene, currently a placeholder Node2D with
-  a label whose only job is to prove the export pipeline produces a running
-  build. Replace it with the real game entry scene (map + hero) when gameplay
-  work starts.
+- `main.tscn` — the game entry scene (issue #5): a 40×40 walled test arena
+  with two offset "choke" walls to exercise pathfinding, a `NavigationRegion3D`
+  wrapping all level geometry, the instanced hero, lighting, and the RTS
+  camera. The maze proper replaces this arena in issue #6.
+- `main.gd` — attached to the root; bakes the navmesh at runtime in
+  `_ready()`. The bake is synchronous (`bake_navigation_mesh(false)`) because
+  the web export has threads disabled — don't switch it to on-thread baking.
+  Baking at runtime means the .tscn never contains stale baked polygons; level
+  geometry just needs to live under `NavigationRegion3D`.
 
-No scripts, signals, or dependencies yet.
+## Navmesh gotchas (learned the hard way)
+
+- The `NavigationMesh` parses **static colliders only**
+  (`geometry_parsed_geometry_type = 1`) — parsing visual meshes at runtime
+  reads geometry back from the GPU, which Godot warns is a serious perf hit.
+  New level geometry therefore *must* have collision shapes to be walkable.
+- `cell_height` is 0.05 on both the NavigationMesh and
+  `navigation/3d/default_cell_height` in `project.godot` (they must match or
+  Godot warns). With the default 0.25, the baked surface floats ~0.5 above the
+  floor, and `NavigationAgent3D`'s waypoint-advance check (a full 3D distance
+  against `path_desired_distance`) never triggers — the hero stalls at the
+  first waypoint, jittering in place.
+- `rts_camera.gd` — fixed-angle follow camera on the `RTSCamera` Camera3D
+  node. The camera angle is authored by *placing the node* relative to its
+  exported `target` (the hero); the script captures that offset in `_ready()`,
+  aims once with `look_at()`, and afterwards only translates with exponential
+  smoothing. It never rotates at runtime.
+
+## Physics layers (project convention, established here)
+
+| Layer | Used for |
+|-------|----------|
+| 1     | Ground/floor (click-to-move rays collide with this only) |
+| 2     | Walls & static obstacles |
+| 3     | Hero |
+
+## Dependencies / signals
+
+- Instances `scenes/hero/hero.tscn`; the camera's `target` export points at it.
+- Input action `move_command` (right mouse button) is defined in
+  `project.godot` and consumed by the hero, not by anything in this folder.
+- No signals emitted or consumed yet.

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -1,0 +1,30 @@
+# scenes/hero/
+
+The player-controlled hero (issue #5: movement; combat comes in issue #11).
+
+- `hero.tscn` — `CharacterBody3D` (collision layer 3, mask 1|2) with a
+  placeholder capsule + a small "nose" box marking the facing direction, a
+  `CollisionShape3D`, and a `NavigationAgent3D`. The visual gets replaced by
+  the KayKit Knight once the asset PR lands; the node forward direction is -Z
+  (Godot convention) so a rigged model drops in without a compensating
+  rotation.
+- `hero.gd` (`class_name Hero`) — click-to-move controller.
+  - **Input decision (documented per issue #5):** *right*-click issues the
+    move command (RTS convention); left-click is reserved for
+    targeting/attacks (issue #11). The action is `move_command` in
+    `project.godot`.
+  - The click ray collides only with physics layer 1 (ground), so clicking a
+    wall moves the hero to the floor at/behind that point instead of trying
+    to climb it.
+  - `command_move_to(world_point)` is the public move-order API — future AI,
+    skills, or tests should call this rather than poking the NavigationAgent.
+  - Movement: standard `NavigationAgent3D` loop in `_physics_process` +
+    `move_and_slide()`, simple gravity, `lerp_angle` turning toward the
+    movement direction.
+
+## Dependencies
+
+- Requires a baked navmesh in the scene it's placed in (`scenes/main.gd`
+  bakes at runtime) and a current `Camera3D` for the click raycast.
+- No signals emitted or consumed yet — HP/XP/attack signals arrive with
+  issues #7, #8, #11.

--- a/scenes/hero/hero.gd
+++ b/scenes/hero/hero.gd
@@ -1,0 +1,66 @@
+class_name Hero
+extends CharacterBody3D
+## Click-to-move hero controller (issue #5).
+##
+## Right-click ("move_command") raycasts from the camera into the world and
+## sets the NavigationAgent3D target. Left-click is deliberately left free for
+## targeting/attacks (issue #11). The ray only collides with the ground layer,
+## so clicking a wall orders a move to the floor behind it (RTS convention).
+
+const SPEED := 6.0
+const TURN_SPEED := 12.0
+
+## Ground is physics layer 1; walls (layer 2) are excluded so move commands
+## always land on walkable floor.
+const GROUND_MASK := 1
+const RAY_LENGTH := 1000.0
+
+var _gravity: float = ProjectSettings.get_setting("physics/3d/default_gravity")
+
+@onready var _nav_agent: NavigationAgent3D = $NavigationAgent3D
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed("move_command"):
+		var camera := get_viewport().get_camera_3d()
+		if camera == null:
+			return
+		var mouse_pos := get_viewport().get_mouse_position()
+		var origin := camera.project_ray_origin(mouse_pos)
+		var target := origin + camera.project_ray_normal(mouse_pos) * RAY_LENGTH
+		var query := PhysicsRayQueryParameters3D.create(origin, target, GROUND_MASK)
+		var result := get_world_3d().direct_space_state.intersect_ray(query)
+		if result:
+			command_move_to(result.position)
+
+
+## Public move order — also the entry point for future AI/skills/tests.
+func command_move_to(world_point: Vector3) -> void:
+	_nav_agent.target_position = world_point
+
+
+func _physics_process(delta: float) -> void:
+	if not is_on_floor():
+		velocity.y -= _gravity * delta
+	else:
+		velocity.y = 0.0
+
+	if _nav_agent.is_navigation_finished():
+		velocity.x = 0.0
+		velocity.z = 0.0
+		move_and_slide()
+		return
+
+	var next := _nav_agent.get_next_path_position()
+	var direction := next - global_position
+	direction.y = 0.0
+	direction = direction.normalized()
+	velocity.x = direction.x * SPEED
+	velocity.z = direction.z * SPEED
+	move_and_slide()
+
+	# Face the movement direction (-Z is forward, matching Godot's convention
+	# so a rigged model can be dropped in later without a compensating rotation).
+	if direction.length_squared() > 0.0:
+		var target_yaw := atan2(-direction.x, -direction.z)
+		rotation.y = lerp_angle(rotation.y, target_yaw, TURN_SPEED * delta)

--- a/scenes/hero/hero.gd.uid
+++ b/scenes/hero/hero.gd.uid
@@ -1,0 +1,1 @@
+uid://dl280fi2smtn6

--- a/scenes/hero/hero.tscn
+++ b/scenes/hero/hero.tscn
@@ -1,0 +1,43 @@
+[gd_scene load_steps=7 format=3]
+
+[ext_resource type="Script" path="res://scenes/hero/hero.gd" id="1_hero"]
+
+[sub_resource type="CapsuleMesh" id="CapsuleMesh_body"]
+radius = 0.4
+height = 1.8
+
+[sub_resource type="StandardMaterial3D" id="Material_body"]
+albedo_color = Color(0.25, 0.45, 0.9, 1)
+
+[sub_resource type="BoxMesh" id="BoxMesh_nose"]
+size = Vector3(0.2, 0.2, 0.5)
+
+[sub_resource type="StandardMaterial3D" id="Material_nose"]
+albedo_color = Color(0.9, 0.9, 0.95, 1)
+
+[sub_resource type="CapsuleShape3D" id="CapsuleShape_body"]
+radius = 0.4
+height = 1.8
+
+[node name="Hero" type="CharacterBody3D"]
+collision_layer = 4
+collision_mask = 3
+script = ExtResource("1_hero")
+
+[node name="BodyMesh" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.9, 0)
+mesh = SubResource("CapsuleMesh_body")
+surface_material_override/0 = SubResource("Material_body")
+
+[node name="NoseMesh" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.3, -0.5)
+mesh = SubResource("BoxMesh_nose")
+surface_material_override/0 = SubResource("Material_nose")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.9, 0)
+shape = SubResource("CapsuleShape_body")
+
+[node name="NavigationAgent3D" type="NavigationAgent3D" parent="."]
+path_desired_distance = 1.0
+target_desired_distance = 1.0

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -1,0 +1,13 @@
+extends Node3D
+## Game entry scene (issue #5).
+##
+## Bakes the navmesh at runtime so the hand-authored level geometry in the
+## scene stays the single source of truth (no stale baked data in the .tscn).
+## The bake is synchronous (on_thread = false) because the web export has
+## thread support disabled.
+
+@onready var _nav_region: NavigationRegion3D = $NavigationRegion3D
+
+
+func _ready() -> void:
+	_nav_region.bake_navigation_mesh(false)

--- a/scenes/main.gd.uid
+++ b/scenes/main.gd.uid
@@ -1,0 +1,1 @@
+uid://dxlcuf1w6o7w

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -1,11 +1,143 @@
-[gd_scene format=3]
+[gd_scene load_steps=16 format=3]
 
-[node name="Main" type="Node2D"]
+[ext_resource type="Script" path="res://scenes/main.gd" id="1_main"]
+[ext_resource type="Script" path="res://scenes/rts_camera.gd" id="2_camera"]
+[ext_resource type="PackedScene" path="res://scenes/hero/hero.tscn" id="3_hero"]
 
-[node name="Label" type="Label" parent="."]
-offset_left = 32.0
-offset_top = 32.0
-offset_right = 720.0
-offset_bottom = 80.0
-theme_override_font_sizes/font_size = 24
-text = "mg-zombies — placeholder scene. If you can read this, the build pipeline works."
+[sub_resource type="Environment" id="Environment_main"]
+background_mode = 1
+background_color = Color(0.1, 0.11, 0.13, 1)
+ambient_light_source = 2
+ambient_light_color = Color(0.75, 0.8, 0.9, 1)
+ambient_light_energy = 0.7
+
+[sub_resource type="NavigationMesh" id="NavigationMesh_main"]
+cell_height = 0.05
+geometry_parsed_geometry_type = 1
+
+[sub_resource type="BoxMesh" id="BoxMesh_floor"]
+size = Vector3(40, 1, 40)
+
+[sub_resource type="BoxShape3D" id="BoxShape_floor"]
+size = Vector3(40, 1, 40)
+
+[sub_resource type="StandardMaterial3D" id="Material_floor"]
+albedo_color = Color(0.32, 0.36, 0.3, 1)
+
+[sub_resource type="StandardMaterial3D" id="Material_wall"]
+albedo_color = Color(0.45, 0.42, 0.38, 1)
+
+[sub_resource type="BoxMesh" id="BoxMesh_wallx"]
+size = Vector3(40, 3, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape_wallx"]
+size = Vector3(40, 3, 1)
+
+[sub_resource type="BoxMesh" id="BoxMesh_wallz"]
+size = Vector3(1, 3, 38)
+
+[sub_resource type="BoxShape3D" id="BoxShape_wallz"]
+size = Vector3(1, 3, 38)
+
+[sub_resource type="BoxMesh" id="BoxMesh_choke"]
+size = Vector3(16, 3, 1)
+
+[sub_resource type="BoxShape3D" id="BoxShape_choke"]
+size = Vector3(16, 3, 1)
+
+[node name="Main" type="Node3D"]
+script = ExtResource("1_main")
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = SubResource("Environment_main")
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+transform = Transform3D(0.866025, 0.383022, -0.321394, 0, 0.642788, 0.766044, 0.5, -0.663414, 0.55667, 0, 10, 0)
+shadow_enabled = true
+
+[node name="NavigationRegion3D" type="NavigationRegion3D" parent="."]
+navigation_mesh = SubResource("NavigationMesh_main")
+
+[node name="Floor" type="StaticBody3D" parent="NavigationRegion3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.5, 0)
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="NavigationRegion3D/Floor"]
+mesh = SubResource("BoxMesh_floor")
+surface_material_override/0 = SubResource("Material_floor")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="NavigationRegion3D/Floor"]
+shape = SubResource("BoxShape_floor")
+
+[node name="WallNorth" type="StaticBody3D" parent="NavigationRegion3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, -19.5)
+collision_layer = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="NavigationRegion3D/WallNorth"]
+mesh = SubResource("BoxMesh_wallx")
+surface_material_override/0 = SubResource("Material_wall")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="NavigationRegion3D/WallNorth"]
+shape = SubResource("BoxShape_wallx")
+
+[node name="WallSouth" type="StaticBody3D" parent="NavigationRegion3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 19.5)
+collision_layer = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="NavigationRegion3D/WallSouth"]
+mesh = SubResource("BoxMesh_wallx")
+surface_material_override/0 = SubResource("Material_wall")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="NavigationRegion3D/WallSouth"]
+shape = SubResource("BoxShape_wallx")
+
+[node name="WallEast" type="StaticBody3D" parent="NavigationRegion3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 19.5, 1.5, 0)
+collision_layer = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="NavigationRegion3D/WallEast"]
+mesh = SubResource("BoxMesh_wallz")
+surface_material_override/0 = SubResource("Material_wall")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="NavigationRegion3D/WallEast"]
+shape = SubResource("BoxShape_wallz")
+
+[node name="WallWest" type="StaticBody3D" parent="NavigationRegion3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -19.5, 1.5, 0)
+collision_layer = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="NavigationRegion3D/WallWest"]
+mesh = SubResource("BoxMesh_wallz")
+surface_material_override/0 = SubResource("Material_wall")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="NavigationRegion3D/WallWest"]
+shape = SubResource("BoxShape_wallz")
+
+[node name="ChokeWallA" type="StaticBody3D" parent="NavigationRegion3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 1.5, 4)
+collision_layer = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="NavigationRegion3D/ChokeWallA"]
+mesh = SubResource("BoxMesh_choke")
+surface_material_override/0 = SubResource("Material_wall")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="NavigationRegion3D/ChokeWallA"]
+shape = SubResource("BoxShape_choke")
+
+[node name="ChokeWallB" type="StaticBody3D" parent="NavigationRegion3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 1.5, -4)
+collision_layer = 2
+
+[node name="MeshInstance3D" type="MeshInstance3D" parent="NavigationRegion3D/ChokeWallB"]
+mesh = SubResource("BoxMesh_choke")
+surface_material_override/0 = SubResource("Material_wall")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="NavigationRegion3D/ChokeWallB"]
+shape = SubResource("BoxShape_choke")
+
+[node name="Hero" parent="." instance=ExtResource("3_hero")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.1, 14)
+
+[node name="RTSCamera" type="Camera3D" parent="." node_paths=PackedStringArray("target")]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 16, 24)
+script = ExtResource("2_camera")
+target = NodePath("../Hero")

--- a/scenes/rts_camera.gd
+++ b/scenes/rts_camera.gd
@@ -1,0 +1,23 @@
+extends Camera3D
+## Fixed-angle RTS-style follow camera (issue #5).
+##
+## The angle is defined entirely by where the camera node is placed in the
+## scene relative to its target: _ready() captures that offset and aims at the
+## target once, then only translates — never rotates — so the view keeps the
+## classic StarCraft/Warcraft fixed perspective.
+
+@export var target: Node3D
+@export var follow_speed := 8.0
+
+var _offset := Vector3.ZERO
+
+
+func _ready() -> void:
+	_offset = global_position - target.global_position
+	look_at(target.global_position)
+
+
+func _physics_process(delta: float) -> void:
+	var desired := target.global_position + _offset
+	# Exponential smoothing that is stable regardless of frame rate.
+	global_position = global_position.lerp(desired, 1.0 - exp(-follow_speed * delta))

--- a/scenes/rts_camera.gd.uid
+++ b/scenes/rts_camera.gd.uid
@@ -1,0 +1,1 @@
+uid://dlt3avhowlgth


### PR DESCRIPTION
Fixes #5

## What

Replaces the placeholder 2D scene with the first real gameplay slice: a fixed-angle RTS-style camera and a right-click-to-move hero navigating a small walled test arena via `NavigationAgent3D` pathfinding.

- **Arena** (`scenes/main.tscn`): 40×40 floor, perimeter walls, and two offset "choke" walls so pathfinding actually has to route around something. This is a stand-in — the real maze is #6.
- **Hero** (`scenes/hero/`): `CharacterBody3D` + `NavigationAgent3D` + placeholder capsule with a "nose" box showing facing. `command_move_to(world_point)` is the public move-order API for future AI/skills/tests (#7, #11).
- **Camera** (`scenes/rts_camera.gd`): angle is authored purely by node placement relative to the hero; the script captures the offset, aims once, then only translates (exponential smoothing). Never rotates at runtime — classic StarCraft/Warcraft feel.
- **Navmesh**: baked at runtime in `main.gd::_ready`, synchronously because the web export has threads disabled.

## Design decisions (per the issue's "decide and document")

- **Right-click moves, left-click reserved.** RTS convention; leaves left-click free for targeting/attack in #11. Action `move_command` in `project.godot`.
- The click ray hits only physics layer 1 (ground), so clicking a wall walks the hero to the floor at that screen point rather than trying to climb.
- **Physics layer convention established:** 1 = ground, 2 = walls/obstacles, 3 = hero (documented in `scenes/CLAUDE.md`).
- Hero visual stays a capsule for now; swapping in the KayKit Knight from #14 is deliberately out of scope for this PR (folder doc notes -Z forward so the model drops in without a compensating rotation).

## Gotchas worth knowing (documented in `scenes/CLAUDE.md`)

- The `NavigationMesh` parses **static colliders only** — the default (visual meshes) triggers a GPU-readback warning at runtime bake. New level geometry must have collision shapes to be walkable.
- `cell_height` is 0.05 on both the mesh and `navigation/3d/default_cell_height`. With the 0.25 default the baked surface floats ~0.5 above the floor, and the agent's waypoint-advance check (full 3D distance vs `path_desired_distance`) never fires — the hero stalls at the first waypoint. Found via headless smoke test, not theory.

## Verification (Godot 4.7.1)

- `--headless --import`: clean, exit 0
- `--check-only` on all three scripts: pass
- Headless `SceneTree` smoke test: instanced `main.tscn`, called `command_move_to((0, 0, -14))` from the spawn at (0, 0, 14), hero routed through both chokepoints and arrived in 376 physics frames (~6.3 s simulated) with zero errors/warnings. Test was throwaway (not committed) — I'll file an issue about a permanent smoke-test harness.
- Normal headless boot (`--quit-after 120`): silent, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
