### PR TITLE
Make every click issue a move order that interrupts the previous one

### DIFF
--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -16,8 +16,24 @@ The player-controlled hero (issue #5: movement; combat comes in issue #11).
   - The click ray collides only with physics layer 1 (ground), so clicking a
     wall moves the hero to the floor at/behind that point instead of trying
     to climb it.
+  - **Every click produces a move order.** The raycast alone silently dropped
+    clicks that hit no ground collider (dark background, past the level edge,
+    above a wall) — which read in play as "my second click was ignored", since
+    the hero just kept walking to its previous destination. `_ground_point_at`
+    therefore falls back to intersecting the camera ray with the hero's ground
+    plane, and `command_move_to` clamps the result onto the navigation map
+    (`NavigationServer3D.map_get_closest_point`), so an off-level click means
+    "walk as far that way as you can". Don't reintroduce an early-out that
+    drops a click.
+  - The handler uses the *event's* `position`, not
+    `get_viewport().get_mouse_position()` — the two can differ by the time the
+    event is handled, and it keeps the path drivable from headless tests.
   - `command_move_to(world_point)` is the public move-order API — future AI,
     skills, or tests should call this rather than poking the NavigationAgent.
+    It cancels the previous order outright: the agent repaths, and horizontal
+    velocity is zeroed so the hero can't coast another frame along the
+    abandoned heading. Emits `move_ordered(world_point)` with the clamped
+    point.
   - Movement: standard `NavigationAgent3D` loop in `_physics_process` +
     `move_and_slide()`, simple gravity, `lerp_angle` turning toward the
     movement direction.
@@ -25,6 +41,9 @@ The player-controlled hero (issue #5: movement; combat comes in issue #11).
 ## Dependencies
 
 - Requires a baked navmesh in the scene it's placed in (`scenes/main.gd`
-  bakes at runtime) and a current `Camera3D` for the click raycast.
-- No signals emitted or consumed yet — HP/XP/attack signals arrive with
-  issues #7, #8, #11.
+  bakes at runtime) and a current `Camera3D` for the click raycast. The
+  navmesh clamp in `command_move_to` reads `get_world_3d().navigation_map`,
+  so orders issued before the first bake resolve to the hero's own position.
+- Emits `move_ordered(world_point: Vector3)`; nothing consumes it yet (it
+  exists for movement/attack-cancel wiring in issue #11). No signals consumed
+  — HP/XP signals arrive with issues #7, #8.

--- a/scenes/hero/hero.gd
+++ b/scenes/hero/hero.gd
@@ -6,6 +6,11 @@ extends CharacterBody3D
 ## sets the NavigationAgent3D target. Left-click is deliberately left free for
 ## targeting/attacks (issue #11). The ray only collides with the ground layer,
 ## so clicking a wall orders a move to the floor behind it (RTS convention).
+##
+## Every move command supersedes the one before it immediately — see
+## command_move_to().
+
+signal move_ordered(world_point: Vector3)
 
 const SPEED := 6.0
 const TURN_SPEED := 12.0
@@ -21,22 +26,59 @@ var _gravity: float = ProjectSettings.get_setting("physics/3d/default_gravity")
 
 
 func _unhandled_input(event: InputEvent) -> void:
-	if event.is_action_pressed("move_command"):
-		var camera := get_viewport().get_camera_3d()
-		if camera == null:
-			return
-		var mouse_pos := get_viewport().get_mouse_position()
-		var origin := camera.project_ray_origin(mouse_pos)
-		var target := origin + camera.project_ray_normal(mouse_pos) * RAY_LENGTH
-		var query := PhysicsRayQueryParameters3D.create(origin, target, GROUND_MASK)
-		var result := get_world_3d().direct_space_state.intersect_ray(query)
-		if result:
-			command_move_to(result.position)
+	if not event.is_action_pressed("move_command"):
+		return
+	# Use the position carried by the click itself rather than the live mouse
+	# position: the two can differ by the time the event is handled, and it
+	# keeps this path deterministic for headless tests.
+	var screen_point := (event as InputEventMouseButton).position
+	var target = _ground_point_at(screen_point)
+	if target != null:
+		command_move_to(target)
+
+
+## Resolve a screen position to a point on the ground.
+##
+## The raycast alone is not enough: it only collides with the ground layer, so
+## a click on the dark background, past the edge of the level, or above a wall
+## produces no hit at all. Dropping those clicks is what made a second click
+## look like it was ignored — the hero silently kept walking to its previous
+## destination. Falling back to the hero's ground plane means every click
+## yields a point; command_move_to() then clamps it onto the navmesh.
+##
+## Returns a Vector3, or null if there is no camera to project from.
+func _ground_point_at(screen_point: Vector2):
+	var camera := get_viewport().get_camera_3d()
+	if camera == null:
+		return null
+	var origin := camera.project_ray_origin(screen_point)
+	var direction := camera.project_ray_normal(screen_point)
+	var query := PhysicsRayQueryParameters3D.create(
+		origin, origin + direction * RAY_LENGTH, GROUND_MASK
+	)
+	var result := get_world_3d().direct_space_state.intersect_ray(query)
+	if result:
+		return result.position
+	var ground := Plane(Vector3.UP, global_position.y)
+	return ground.intersects_ray(origin, direction)
 
 
 ## Public move order — also the entry point for future AI/skills/tests.
+##
+## Issuing an order cancels the previous one outright: the target is replaced
+## (NavigationAgent3D repaths on the next query) and the carried-over horizontal
+## velocity is dropped so the hero cannot coast another frame along the
+## abandoned heading. Rapid re-clicking therefore reads as an instant redirect.
 func command_move_to(world_point: Vector3) -> void:
-	_nav_agent.target_position = world_point
+	# Clamp onto the navigation map so an order is never unreachable — a click
+	# on the void outside the level becomes "walk as far that way as you can"
+	# instead of a path request that resolves to nothing.
+	var map := get_world_3d().navigation_map
+	var reachable := NavigationServer3D.map_get_closest_point(map, world_point)
+	_nav_agent.target_position = reachable
+	velocity.x = 0.0
+	velocity.z = 0.0
+	move_ordered.emit(reachable)
 
 
 func _physics_process(delta: float) -> void:


### PR DESCRIPTION
Right-clicking while the hero was already moving could appear to do nothing — the hero kept walking to its previous destination as if the click had never happened.

## Root cause

The click raycast collides only with the ground layer (layer 1); walls are deliberately excluded so that clicking a wall orders a move to the floor behind it. But any click that hit **no** ground collider — the dark background, past the edge of the arena, or above a wall — returned no result, and the handler just returned without issuing an order. The previous order therefore stood, and the hero kept walking.

I verified this headlessly before changing anything, and ruled out the two layers I first suspected:

- `NavigationAgent3D` handles a replacement target correctly: ordering A, then B mid-move, changes the velocity on the very next physics frame.
- The input action fires for back-to-back clicks, including the `double_click = true` event Godot sends for a rapid second click.
- Rays through screen points past the arena edge (e.g. world `(0, 0, -30)` from the current camera) miss every collider — those clicks were the ones being dropped.

This matters more after #6: a maze puts far more wall-top and void on screen than the current open arena does, so the dropped-click rate goes up.

## Changes

- `_ground_point_at()` falls back to intersecting the camera ray with the hero's ground plane when the raycast misses, so a click always resolves to a point.
- `command_move_to()` clamps the point onto the navigation map via `NavigationServer3D.map_get_closest_point()`, so a click on the void outside the level means "walk as far that way as you can" instead of a target that resolves to nothing.
- `command_move_to()` also zeroes horizontal velocity, so a new order can't coast a frame along the abandoned heading — rapid re-clicking reads as an instant redirect.
- The handler uses the event's own `position` rather than `get_viewport().get_mouse_position()`. The two can differ by the time the event is handled, and it makes the input path drivable from a headless test.
- Added a `move_ordered(world_point)` signal, unused for now — it's the hook for cancelling an attack on a move command in #11.

## Verification

Headless run driving the real `_unhandled_input` handler with synthesized clicks, on this branch:

| Click | Before | After |
|---|---|---|
| On-floor point | order issued | order issued |
| Interrupt mid-move | order issued, velocity zeroed same frame, hero heading east 4 frames later | same |
| Off-floor (`z = -30`) | **dropped** | clamped to navmesh edge `z = -18.25`, hero turns north |
| Far void (`z = -60`) | **dropped** | clamped to navmesh edge, order accepted |

The throwaway repro script isn't committed; `scenes/hero/CLAUDE.md` records the invariant ("don't reintroduce an early-out that drops a click") so it isn't lost. A permanent home for this kind of check is #16.

## Review notes

- The ground-plane fallback uses the hero's own `global_position.y`. Fine while levels are single-storey; it'll need revisiting if we ever get vertical layering.
- Zeroing velocity in `command_move_to` is a deliberate one-frame hard stop rather than a smooth turn. It's what makes the interrupt feel crisp, but say so if you'd rather keep momentum.

Part of #5
