### PR TITLE
Replace the test arena with a grid-driven maze map

### DIFF
--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -2,15 +2,16 @@
 
 Top-level game scenes and their scripts.
 
-- `main.tscn` — the game entry scene (issue #5): a 40×40 walled test arena
-  with two offset "choke" walls to exercise pathfinding, a `NavigationRegion3D`
-  wrapping all level geometry, the instanced hero, lighting, and the RTS
-  camera. The maze proper replaces this arena in issue #6.
-- `main.gd` — attached to the root; bakes the navmesh at runtime in
-  `_ready()`. The bake is synchronous (`bake_navigation_mesh(false)`) because
-  the web export has threads disabled — don't switch it to on-thread baking.
-  Baking at runtime means the .tscn never contains stale baked polygons; level
-  geometry just needs to live under `NavigationRegion3D`.
+- `main.tscn` — the game entry scene: a `NavigationRegion3D` wrapping the
+  maze (`scenes/map/`), the instanced hero, lighting, and the RTS camera. The
+  40×40 test arena that lived here for issue #5 is gone; issue #6 replaced it
+  with the real map.
+- `main.gd` — attached to the root. Owns the startup order: the maze builds
+  itself in its own `_ready()` (Godot readies children first), then this script
+  places the hero on the maze's start cell, snaps the camera, and bakes the
+  navmesh over the geometry that now exists. The bake is synchronous
+  (`bake_navigation_mesh(false)`) because the web export has threads disabled —
+  don't switch it to on-thread baking.
 
 ## Navmesh gotchas (learned the hard way)
 
@@ -24,11 +25,24 @@ Top-level game scenes and their scripts.
   floor, and `NavigationAgent3D`'s waypoint-advance check (a full 3D distance
   against `path_desired_distance`) never triggers — the hero stalls at the
   first waypoint, jittering in place.
-- `rts_camera.gd` — fixed-angle follow camera on the `RTSCamera` Camera3D
-  node. The camera angle is authored by *placing the node* relative to its
-  exported `target` (the hero); the script captures that offset in `_ready()`,
-  aims once with `look_at()`, and afterwards only translates with exponential
-  smoothing. It never rotates at runtime.
+- `agent_radius` is 1.0 — much wider than the hero's 0.4 capsule, on purpose.
+  See `scenes/map/CLAUDE.md`: a tight radius puts waypoints in the corner
+  pockets where two wall pieces meet and the hero wedges there. Keep it a
+  multiple of `cell_size` (0.25) or Godot warns about voxel rounding.
+
+## Camera
+
+- `rts_camera.gd` (`class_name RTSCamera`) — fixed-angle follow camera on the
+  `RTSCamera` `Camera3D`. The angle is authored by *placing the node* relative
+  to its exported `target` (the hero); the script captures that offset in
+  `_ready()`, aims once with `look_at()`, and afterwards only translates with
+  exponential smoothing. It never rotates at runtime.
+- `snap_to_target()` moves **and re-aims**. `main.gd` teleports the hero to the
+  maze start after the camera's `_ready()` has already run, so without the
+  re-aim the camera keeps pointing at wherever the hero sat in the .tscn.
+- The offset is `(0, 22.1, 14)` → a ~57° pitch. The old `(0, 16, 24)` (~33°)
+  was authored for the small arena; on the 60×72 maze that shallow angle showed
+  the map from the outside rather than the hero's corridor.
 
 ## Physics layers (project convention, established here)
 
@@ -40,7 +54,15 @@ Top-level game scenes and their scripts.
 
 ## Dependencies / signals
 
-- Instances `scenes/hero/hero.tscn`; the camera's `target` export points at it.
+- Instances `scenes/map/maze.tscn` and `scenes/hero/hero.tscn`; the camera's
+  `target` export points at the hero.
 - Input action `move_command` (right mouse button) is defined in
   `project.godot` and consumed by the hero, not by anything in this folder.
-- No signals emitted or consumed yet.
+- `Maze` emits `built`; nothing consumes it yet.
+
+## Tooling note
+
+`--headless --check-only --script` cannot resolve `class_name` types across
+files (it doesn't load the global class cache), so it reports a false
+"Could not find type" on scripts that reference `Hero`, `Maze`, or
+`RTSCamera`. Run the scene instead to check those.

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -1,13 +1,24 @@
 extends Node3D
-## Game entry scene (issue #5).
+## Game entry scene (issues #5, #6).
 ##
-## Bakes the navmesh at runtime so the hand-authored level geometry in the
-## scene stays the single source of truth (no stale baked data in the .tscn).
+## Owns the order the level comes up in: the maze builds itself in its own
+## _ready() (children run first), then this script places the hero on the maze's
+## start cell and bakes the navmesh over the geometry that now exists.
+##
 ## The bake is synchronous (on_thread = false) because the web export has
 ## thread support disabled.
 
+## Spawn the hero just above the floor surface and let gravity settle it, rather
+## than guessing the exact tile height.
+const SPAWN_CLEARANCE := 0.3
+
 @onready var _nav_region: NavigationRegion3D = $NavigationRegion3D
+@onready var _maze: Maze = $NavigationRegion3D/Maze
+@onready var _hero: Hero = $Hero
+@onready var _camera: RTSCamera = $RTSCamera
 
 
 func _ready() -> void:
+	_hero.global_position = _maze.start_position() + Vector3(0, SPAWN_CLEARANCE, 0)
+	_camera.snap_to_target()
 	_nav_region.bake_navigation_mesh(false)

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=16 format=3]
+[gd_scene load_steps=6 format=3]
 
 [ext_resource type="Script" path="res://scenes/main.gd" id="1_main"]
 [ext_resource type="Script" path="res://scenes/rts_camera.gd" id="2_camera"]
 [ext_resource type="PackedScene" path="res://scenes/hero/hero.tscn" id="3_hero"]
+[ext_resource type="PackedScene" path="res://scenes/map/maze.tscn" id="4_maze"]
 
 [sub_resource type="Environment" id="Environment_main"]
 background_mode = 1
@@ -13,37 +14,9 @@ ambient_light_energy = 0.7
 
 [sub_resource type="NavigationMesh" id="NavigationMesh_main"]
 cell_height = 0.05
+agent_height = 1.8
+agent_radius = 1.0
 geometry_parsed_geometry_type = 1
-
-[sub_resource type="BoxMesh" id="BoxMesh_floor"]
-size = Vector3(40, 1, 40)
-
-[sub_resource type="BoxShape3D" id="BoxShape_floor"]
-size = Vector3(40, 1, 40)
-
-[sub_resource type="StandardMaterial3D" id="Material_floor"]
-albedo_color = Color(0.32, 0.36, 0.3, 1)
-
-[sub_resource type="StandardMaterial3D" id="Material_wall"]
-albedo_color = Color(0.45, 0.42, 0.38, 1)
-
-[sub_resource type="BoxMesh" id="BoxMesh_wallx"]
-size = Vector3(40, 3, 1)
-
-[sub_resource type="BoxShape3D" id="BoxShape_wallx"]
-size = Vector3(40, 3, 1)
-
-[sub_resource type="BoxMesh" id="BoxMesh_wallz"]
-size = Vector3(1, 3, 38)
-
-[sub_resource type="BoxShape3D" id="BoxShape_wallz"]
-size = Vector3(1, 3, 38)
-
-[sub_resource type="BoxMesh" id="BoxMesh_choke"]
-size = Vector3(16, 3, 1)
-
-[sub_resource type="BoxShape3D" id="BoxShape_choke"]
-size = Vector3(16, 3, 1)
 
 [node name="Main" type="Node3D"]
 script = ExtResource("1_main")
@@ -58,86 +31,12 @@ shadow_enabled = true
 [node name="NavigationRegion3D" type="NavigationRegion3D" parent="."]
 navigation_mesh = SubResource("NavigationMesh_main")
 
-[node name="Floor" type="StaticBody3D" parent="NavigationRegion3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.5, 0)
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="NavigationRegion3D/Floor"]
-mesh = SubResource("BoxMesh_floor")
-surface_material_override/0 = SubResource("Material_floor")
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="NavigationRegion3D/Floor"]
-shape = SubResource("BoxShape_floor")
-
-[node name="WallNorth" type="StaticBody3D" parent="NavigationRegion3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, -19.5)
-collision_layer = 2
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="NavigationRegion3D/WallNorth"]
-mesh = SubResource("BoxMesh_wallx")
-surface_material_override/0 = SubResource("Material_wall")
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="NavigationRegion3D/WallNorth"]
-shape = SubResource("BoxShape_wallx")
-
-[node name="WallSouth" type="StaticBody3D" parent="NavigationRegion3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 19.5)
-collision_layer = 2
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="NavigationRegion3D/WallSouth"]
-mesh = SubResource("BoxMesh_wallx")
-surface_material_override/0 = SubResource("Material_wall")
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="NavigationRegion3D/WallSouth"]
-shape = SubResource("BoxShape_wallx")
-
-[node name="WallEast" type="StaticBody3D" parent="NavigationRegion3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 19.5, 1.5, 0)
-collision_layer = 2
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="NavigationRegion3D/WallEast"]
-mesh = SubResource("BoxMesh_wallz")
-surface_material_override/0 = SubResource("Material_wall")
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="NavigationRegion3D/WallEast"]
-shape = SubResource("BoxShape_wallz")
-
-[node name="WallWest" type="StaticBody3D" parent="NavigationRegion3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -19.5, 1.5, 0)
-collision_layer = 2
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="NavigationRegion3D/WallWest"]
-mesh = SubResource("BoxMesh_wallz")
-surface_material_override/0 = SubResource("Material_wall")
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="NavigationRegion3D/WallWest"]
-shape = SubResource("BoxShape_wallz")
-
-[node name="ChokeWallA" type="StaticBody3D" parent="NavigationRegion3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -4, 1.5, 4)
-collision_layer = 2
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="NavigationRegion3D/ChokeWallA"]
-mesh = SubResource("BoxMesh_choke")
-surface_material_override/0 = SubResource("Material_wall")
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="NavigationRegion3D/ChokeWallA"]
-shape = SubResource("BoxShape_choke")
-
-[node name="ChokeWallB" type="StaticBody3D" parent="NavigationRegion3D"]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4, 1.5, -4)
-collision_layer = 2
-
-[node name="MeshInstance3D" type="MeshInstance3D" parent="NavigationRegion3D/ChokeWallB"]
-mesh = SubResource("BoxMesh_choke")
-surface_material_override/0 = SubResource("Material_wall")
-
-[node name="CollisionShape3D" type="CollisionShape3D" parent="NavigationRegion3D/ChokeWallB"]
-shape = SubResource("BoxShape_choke")
+[node name="Maze" parent="NavigationRegion3D" instance=ExtResource("4_maze")]
 
 [node name="Hero" parent="." instance=ExtResource("3_hero")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.1, 14)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.1, 0)
 
 [node name="RTSCamera" type="Camera3D" parent="." node_paths=PackedStringArray("target")]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 16, 24)
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 22.1, 14)
 script = ExtResource("2_camera")
 target = NodePath("../Hero")

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -1,0 +1,76 @@
+# scenes/map/
+
+The playable map (issue #6). Replaces the 40×40 test arena that `main.tscn`
+used to carry.
+
+- `maze.tscn` — a bare `Node3D` with `maze.gd`. All geometry is generated at
+  runtime, so the .tscn stays a single node.
+- `maze.gd` (`class_name Maze`) — builds the map from ASCII.
+
+## Authoring a map
+
+The map is the `layout` export: one character per cell, north is row 0.
+
+| Char | Meaning |
+|------|---------|
+| `#`  | solid rock |
+| `.`  | corridor / room floor |
+| `S`  | start cell (hero spawns here) — exactly one |
+| `B`  | boss room centre — exactly one |
+
+Rows must all be the same length. `build()` refuses to build a malformed
+layout and `push_error`s instead of half-building one.
+
+Cells are `CELL_SIZE` = 4 units, matching the KayKit dungeon grid: `wall` is
+4×4×1 and `floor_tile_large` is 4×4. Corridors are one cell wide, which leaves
+~3 units clear once the wall pieces straddle the cell edges.
+
+## What gets built
+
+- **Floor** — `floor_tile_large` per open cell, `floor_dirt_large` for the
+  start and boss cells so they read as distinct places without custom art.
+- **Walls** — a `wall` piece on every edge where an open cell meets rock (or
+  the outside of the grid). Because only open cells place walls, a shared edge
+  between two open cells never gets one and no edge is ever built twice.
+- **Rock caps** — see the gotcha below.
+- **Zone markers** — flat emissive plates (green start, red boss). Plain
+  `MeshInstance3D`, no collision.
+- Public API: `start_position()`, `boss_position()`, and the `built` signal.
+
+Everything with collision is a `StaticBody3D` whose `BoxShape3D` is derived
+from the piece's own mesh AABB, so swapping a piece's art keeps its collider
+correct. Floors go on layer 1, walls on layer 2 (the table in
+`scenes/CLAUDE.md`); level geometry has `collision_mask = 0` since it only
+ever gets collided with.
+
+## Gotchas
+
+- **Collision is mandatory, not decoration.** The `NavigationMesh` parses
+  static colliders only, so anything without a collider is invisible to
+  pathfinding — and anything *with* one becomes navigation input.
+- **Rock caps are deliberately collision-free.** Wall pieces only sit on the
+  rock/floor boundary, so the middle of every rock cell is an open hole you can
+  see the void through from the camera angle. `_add_rock_cap` closes each one
+  with a floor tile flush with the top of the walls, tinted dark so rock never
+  competes with the lit walkable floor for the player's eye. Giving those caps
+  collision would bake navmesh islands *inside* solid rock — and since
+  `Hero.command_move_to()` clamps a click onto the nearest navmesh point,
+  clicking a wall could then order the hero somewhere he can never reach.
+- **`agent_radius` on the navmesh is 1.0, not the hero's 0.4.** At 0.5 the
+  baked surface hugged the walls, so waypoints landed in the pockets where two
+  wall pieces meet at a corner; the hero drove into one, wedged against both
+  faces, and `move_and_slide()` returned zero velocity — a dead stop a few
+  metres from spawn. Widening it keeps waypoints down the corridor centreline.
+  Keep it a multiple of the navmesh `cell_size` (0.25) or Godot warns that the
+  value is ceiled to voxel units.
+- `_boss_is_reachable()` flood-fills the grid after every build and
+  `push_error`s if the boss is walled off, so a bad map edit fails loudly
+  instead of being discovered by walking there.
+
+## Dependencies
+
+- Art: `assets/dungeon/` (`wall`, `floor_tile_large`, `floor_dirt_large`).
+- Instanced by `scenes/main.tscn` under `NavigationRegion3D`; `scenes/main.gd`
+  reads `start_position()` to place the hero and then bakes the navmesh. The
+  ordering is load-bearing — `Maze._ready()` runs before `Main._ready()`
+  because Godot readies children first, so the geometry exists before the bake.

--- a/scenes/map/maze.gd
+++ b/scenes/map/maze.gd
@@ -1,0 +1,299 @@
+class_name Maze
+extends Node3D
+## Grid-driven maze builder (issue #6).
+##
+## The map is authored as ASCII in [member layout] — one character per 4×4
+## cell — and turned into KayKit dungeon geometry at runtime. Authoring a map
+## is therefore editing a text block, not placing hundreds of nodes by hand,
+## and the .tscn stays tiny.
+##
+## Everything this builds is a StaticBody3D with a real collision shape,
+## because the NavigationMesh parses static colliders only (see
+## scenes/CLAUDE.md) — geometry without collision would be invisible to
+## pathfinding. The zone markers are the deliberate exception: they are plain
+## MeshInstance3Ds so they cannot affect the bake.
+
+## Emitted once the geometry exists, before the navmesh is baked.
+signal built
+
+const CELL_SIZE := 4.0
+
+## Measured from the KayKit pieces: `wall` is 4 tall, and `floor_tile_large`
+## sits with its walking surface 0.05 above the node origin.
+const WALL_HEIGHT := 4.0
+const FLOOR_TOP := 0.05
+
+const CELL_WALL := "#"
+const CELL_FLOOR := "."
+const CELL_START := "S"
+const CELL_BOSS := "B"
+
+## Physics layers, per the table in scenes/CLAUDE.md.
+const LAYER_GROUND := 1
+const LAYER_WALL := 2
+
+const FLOOR_SCENE := preload("res://assets/dungeon/floor_tile_large.gltf")
+const FLOOR_DIRT_SCENE := preload("res://assets/dungeon/floor_dirt_large.gltf")
+const WALL_SCENE := preload("res://assets/dungeon/wall.gltf")
+
+## Cell offsets for the four edges a cell can wall off, with the yaw the wall
+## piece needs. The `wall` mesh is 4 long on X and 1 thick on Z, so a
+## north/south edge is unrotated and an east/west edge is turned a quarter turn.
+const EDGES := [
+	{"cell": Vector2i(0, -1), "offset": Vector3(0, 0, -CELL_SIZE * 0.5), "yaw": 0.0},
+	{"cell": Vector2i(0, 1), "offset": Vector3(0, 0, CELL_SIZE * 0.5), "yaw": 0.0},
+	{"cell": Vector2i(-1, 0), "offset": Vector3(-CELL_SIZE * 0.5, 0, 0), "yaw": PI * 0.5},
+	{"cell": Vector2i(1, 0), "offset": Vector3(CELL_SIZE * 0.5, 0, 0), "yaw": PI * 0.5},
+]
+
+## The map. North is row 0. Must be rectangular; exactly one S and one B.
+##
+## Corridors are one cell (4 units) wide, which leaves ~3 units of clear space
+## once the walls straddle the cell edges — wide enough for the hero (0.4
+## radius) and a zombie to meet, tight enough to make chokepoints matter.
+@export var layout: PackedStringArray = PackedStringArray([
+	"###############",
+	"#####.....#####",
+	"#####.....#####",
+	"#####..B..#####",
+	"#####.....#####",
+	"#######.#######",
+	"#.....#.#.....#",
+	"#.###.#.#.###.#",
+	"#.#...#.#...#.#",
+	"#.#.###.###.#.#",
+	"#.#.#.......#.#",
+	"#.#.#.#####.#.#",
+	"#...#.#...#...#",
+	"###.#.#.#.#.###",
+	"#.....#.#.#...#",
+	"#.#####.#.###.#",
+	"#..S....#.....#",
+	"###############",
+])
+
+var _start_cell := Vector2i(-1, -1)
+var _boss_cell := Vector2i(-1, -1)
+var _rock_material_cache: StandardMaterial3D = null
+
+
+func _ready() -> void:
+	build()
+
+
+## World position of the cell the hero starts in.
+func start_position() -> Vector3:
+	return _cell_to_world(_start_cell)
+
+
+## World position of the boss room's centre — the end of the core loop.
+func boss_position() -> Vector3:
+	return _cell_to_world(_boss_cell)
+
+
+## Rebuild the maze from [member layout]. Safe to call again after editing it.
+func build() -> void:
+	for child in get_children():
+		remove_child(child)
+		child.queue_free()
+	_start_cell = Vector2i(-1, -1)
+	_boss_cell = Vector2i(-1, -1)
+
+	if not _validate_layout():
+		return
+
+	for row in layout.size():
+		for col in layout[row].length():
+			var cell := Vector2i(col, row)
+			var kind := _cell_kind(cell)
+			if kind == CELL_WALL:
+				_add_rock_cap(cell)
+				continue
+			if kind == CELL_START:
+				_start_cell = cell
+			elif kind == CELL_BOSS:
+				_boss_cell = cell
+			_build_open_cell(cell, kind)
+
+	if not _boss_is_reachable():
+		push_error(
+			"Maze: the boss cell is walled off from the start cell. " +
+			"Fix `layout` — the map is unplayable as authored."
+		)
+	built.emit()
+
+
+func _validate_layout() -> bool:
+	if layout.is_empty():
+		push_error("Maze: `layout` is empty.")
+		return false
+	var width := layout[0].length()
+	for row in layout.size():
+		if layout[row].length() != width:
+			push_error("Maze: row %d is %d cells wide, expected %d." % [
+				row, layout[row].length(), width,
+			])
+			return false
+	var starts := 0
+	var bosses := 0
+	for row in layout:
+		starts += row.count(CELL_START)
+		bosses += row.count(CELL_BOSS)
+	if starts != 1 or bosses != 1:
+		push_error("Maze: expected exactly one '%s' and one '%s', found %d and %d." % [
+			CELL_START, CELL_BOSS, starts, bosses,
+		])
+		return false
+	return true
+
+
+func _build_open_cell(cell: Vector2i, kind: String) -> void:
+	var centre := _cell_to_world(cell)
+	# Start and boss rooms get the dirt tile so they read as distinct places
+	# from a top-down camera without needing custom materials.
+	var floor_scene := FLOOR_SCENE
+	if kind == CELL_START or kind == CELL_BOSS:
+		floor_scene = FLOOR_DIRT_SCENE
+	_add_piece(floor_scene, centre, 0.0, LAYER_GROUND)
+
+	if kind == CELL_START:
+		_add_zone_marker(centre, Color(0.3, 0.9, 0.4))
+	elif kind == CELL_BOSS:
+		_add_zone_marker(centre, Color(0.95, 0.25, 0.2))
+
+	# Wall off every edge that faces a wall cell or the outside of the grid.
+	for edge in EDGES:
+		if _cell_kind(cell + edge["cell"]) == CELL_WALL:
+			_add_piece(WALL_SCENE, centre + edge["offset"], edge["yaw"], LAYER_WALL)
+
+
+## Cap a solid-rock cell at wall height.
+##
+## Wall pieces only ever sit on the boundary between rock and open floor, so
+## every rock cell is an open hole in the middle — from the camera angle you
+## see straight through the map into the void. A tile laid flush with the top
+## of the walls closes it and makes the rock read as one solid mass.
+##
+## Visual only — no StaticBody, deliberately. Giving these collision would bake
+## navmesh islands inside solid rock, and since Hero.command_move_to() clamps a
+## click onto the nearest navmesh point, clicking a wall could then order the
+## hero to a spot he can never reach.
+func _add_rock_cap(cell: Vector2i) -> void:
+	var cap := FLOOR_SCENE.instantiate()
+	cap.position = _cell_to_world(cell) + Vector3(0, WALL_HEIGHT - FLOOR_TOP, 0)
+	# Tinted well down so the rock mass never competes with the lit corridor
+	# floor for the player's eye — the whole point of the top-down view is that
+	# walkable and not-walkable are obvious at a glance.
+	for mesh_instance in _mesh_instances(cap):
+		mesh_instance.material_override = _rock_material()
+	add_child(cap)
+
+
+func _rock_material() -> StandardMaterial3D:
+	if _rock_material_cache == null:
+		_rock_material_cache = StandardMaterial3D.new()
+		_rock_material_cache.albedo_color = Color(0.16, 0.18, 0.23)
+		_rock_material_cache.roughness = 1.0
+	return _rock_material_cache
+
+
+## Instance a dungeon piece with a collision box derived from its own mesh
+## bounds, so the collider tracks the art if a piece is ever swapped out.
+func _add_piece(scene: PackedScene, position: Vector3, yaw: float, layer: int) -> void:
+	var body := StaticBody3D.new()
+	body.collision_layer = layer
+	# Level geometry never needs to detect anything; it only gets collided with.
+	body.collision_mask = 0
+	body.position = position
+	body.rotation.y = yaw
+	add_child(body)
+
+	var visual := scene.instantiate()
+	body.add_child(visual)
+
+	var bounds := _merged_aabb(visual)
+	var shape := BoxShape3D.new()
+	shape.size = bounds.size
+	var collider := CollisionShape3D.new()
+	collider.shape = shape
+	collider.position = bounds.position + bounds.size * 0.5
+	body.add_child(collider)
+
+
+## A flat, unshaded plate just above the floor marking a named area. Carries no
+## collision on purpose: the navmesh must not see it.
+func _add_zone_marker(centre: Vector3, colour: Color) -> void:
+	var mesh := BoxMesh.new()
+	mesh.size = Vector3(CELL_SIZE * 0.7, 0.02, CELL_SIZE * 0.7)
+	var material := StandardMaterial3D.new()
+	material.albedo_color = colour
+	material.emission_enabled = true
+	material.emission = colour
+	material.emission_energy_multiplier = 0.6
+	var marker := MeshInstance3D.new()
+	marker.mesh = mesh
+	marker.material_override = material
+	marker.position = centre + Vector3(0, 0.07, 0)
+	add_child(marker)
+
+
+func _merged_aabb(node: Node) -> AABB:
+	var bounds := AABB()
+	var found := false
+	for mesh_instance in _mesh_instances(node):
+		var box := mesh_instance.get_aabb()
+		box.position += mesh_instance.position
+		if found:
+			bounds = bounds.merge(box)
+		else:
+			bounds = box
+			found = true
+	return bounds
+
+
+func _mesh_instances(node: Node) -> Array[MeshInstance3D]:
+	var found: Array[MeshInstance3D] = []
+	if node is MeshInstance3D:
+		found.append(node)
+	for child in node.get_children():
+		found.append_array(_mesh_instances(child))
+	return found
+
+
+func _cell_kind(cell: Vector2i) -> String:
+	if cell.y < 0 or cell.y >= layout.size():
+		return CELL_WALL
+	var row := layout[cell.y]
+	if cell.x < 0 or cell.x >= row.length():
+		return CELL_WALL
+	return row[cell.x]
+
+
+func _cell_to_world(cell: Vector2i) -> Vector3:
+	var cols := float(layout[0].length())
+	var rows := float(layout.size())
+	return Vector3(
+		(float(cell.x) - (cols - 1.0) * 0.5) * CELL_SIZE,
+		0.0,
+		(float(cell.y) - (rows - 1.0) * 0.5) * CELL_SIZE
+	)
+
+
+## Flood-fill the open cells from the start. Catches a map edit that seals the
+## boss room off before anyone has to discover it by walking there.
+func _boss_is_reachable() -> bool:
+	if _start_cell.x < 0 or _boss_cell.x < 0:
+		return false
+	var seen := {_start_cell: true}
+	var queue: Array[Vector2i] = [_start_cell]
+	while not queue.is_empty():
+		var cell: Vector2i = queue.pop_front()
+		if cell == _boss_cell:
+			return true
+		for edge in EDGES:
+			var next: Vector2i = cell + edge["cell"]
+			if seen.has(next) or _cell_kind(next) == CELL_WALL:
+				continue
+			seen[next] = true
+			queue.append(next)
+	return false

--- a/scenes/map/maze.gd.uid
+++ b/scenes/map/maze.gd.uid
@@ -1,0 +1,1 @@
+uid://cbit6cdawquyk

--- a/scenes/map/maze.tscn
+++ b/scenes/map/maze.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scenes/map/maze.gd" id="1_maze"]
+
+[node name="Maze" type="Node3D"]
+script = ExtResource("1_maze")

--- a/scenes/rts_camera.gd
+++ b/scenes/rts_camera.gd
@@ -1,3 +1,4 @@
+class_name RTSCamera
 extends Camera3D
 ## Fixed-angle RTS-style follow camera (issue #5).
 ##
@@ -14,6 +15,19 @@ var _offset := Vector3.ZERO
 
 func _ready() -> void:
 	_offset = global_position - target.global_position
+	look_at(target.global_position)
+
+
+## Jump straight to the target instead of gliding to it. Call this after
+## teleporting the target — the hero is spawned at the map's start cell in
+## main.gd, which happens after this _ready(), and without a snap the camera
+## would visibly sail across the map on the first frames.
+##
+## Re-aims as well as moves: _ready() aimed at wherever the target was sitting
+## in the .tscn, which is the wrong point once it has been teleported. The
+## offset is unchanged, so the fixed viewing angle is preserved.
+func snap_to_target() -> void:
+	global_position = target.global_position + _offset
 	look_at(target.global_position)
 
 


### PR DESCRIPTION
Replaces the 40×40 test arena with the real map: a 15×18 cell maze (60×72 units) built at runtime from ASCII, using the KayKit dungeon pieces imported in #12.

Fixes #6.

## Approach

The map is authored as a text block in `Maze.layout`, one character per 4-unit cell (`#` rock, `.` floor, `S` start, `B` boss), rather than as hand-placed nodes. So `maze.tscn` is a single node, editing the level is editing a string, and the diff for a future map change stays readable.

Cell size is 4 to match the KayKit grid exactly — `wall` measures 4×4×1 and `floor_tile_large` 4×4, both centred on their origin. Walls are placed by *open* cells on every edge that faces rock, which means a shared edge between two open cells never gets a wall and no edge is ever built twice.

`build()` validates the layout (rectangular, exactly one `S` and one `B`) and then flood-fills from start to boss, calling `push_error` if the boss is walled off. A bad map edit fails loudly instead of being discovered by walking there.

## Two things this turned up

**The navmesh `agent_radius` had to go from 0.5 to 1.0.** At 0.5 the baked surface hugged the walls, so waypoints landed in the pockets where two wall pieces meet at a corner. The hero drove into one, wedged against both faces, and `move_and_slide()` returned zero velocity — a dead stop a few metres from spawn, with the agent still reporting `is_target_reachable() == true`. 1.0 keeps waypoints on the corridor centreline. It's also a multiple of `cell_size` (0.25); non-multiples make Godot warn that the value is ceiled to voxel units.

**The camera offset was authored for the old arena.** `(0, 16, 24)` is a ~33° pitch, which on a 60×72 map shows the maze from the outside rather than looking down into the hero's corridor. It's now `(0, 22.1, 14)`, ~57°. Related: `RTSCamera.snap_to_target()` re-aims as well as moves, because `main.gd` teleports the hero to the start cell *after* the camera's `_ready()` has already run `look_at` — without the re-aim the camera keeps pointing at wherever the hero sat in the .tscn.

## Rock caps

Wall pieces only sit on the rock/floor boundary, so the middle of every rock cell was an open hole you could see the void through. Each is now capped with a floor tile flush with the top of the walls, tinted dark so rock never competes with the lit walkable floor for the eye.

Those caps deliberately have **no collision**. With collision they would bake navmesh islands inside solid rock — and since `Hero.command_move_to()` clamps a click onto the nearest navmesh point, clicking a wall could then order the hero somewhere he can never reach.

## Verification

Headless, on this branch:

- Navmesh bakes 1 region, no warnings.
- `NavigationServer3D.map_get_path()` start → boss: 25 waypoints.
- Hero ordered to the boss room walks the full route and arrives in **12.2 s**, no wedging, no stalls.
- Scene boots with no errors or warnings on the console.

Rendered checks at the real gameplay camera: corridors read clearly against the dark rock, the hero is centred and legible, and the boss room reads as an open chamber behind a single chokepoint with the red marker at its centre.

## Review notes

- Corridors are one cell wide (~3 units clear). That's deliberate for chokepoints, but it's the number to revisit once zombies (#7) need to path past the hero — with `agent_radius` 1.0 the walkable ribbon is 1 unit, so agents will go single-file.
- `_add_piece` derives each collider from the piece's own mesh AABB rather than hardcoding sizes, so swapping art keeps the collider right. It does mean a piece with stray geometry would get an oversized box.
- The layout is an `@export`, so it's editable in the inspector, but the default lives in the script. If you'd rather maps were resources on disk, say so — that's a natural follow-up rather than something to block on.
- `--headless --check-only --script` can't resolve `class_name` types across files (it doesn't load the global class cache) and reports a false "Could not find type" on `main.gd`. Noted in `scenes/CLAUDE.md`; run the scene to check those instead.

Folder docs: new `scenes/map/CLAUDE.md`, and `scenes/CLAUDE.md` updated for the arena removal, the camera change, and the `agent_radius` gotcha.
