### PR TITLE
Correct two doc claims that contradict the repo

### DIFF
--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -4,10 +4,11 @@ The player-controlled hero (issue #5: movement; combat comes in issue #11).
 
 - `hero.tscn` — `CharacterBody3D` (collision layer 3, mask 1|2) with a
   placeholder capsule + a small "nose" box marking the facing direction, a
-  `CollisionShape3D`, and a `NavigationAgent3D`. The visual gets replaced by
-  the KayKit Knight once the asset PR lands; the node forward direction is -Z
-  (Godot convention) so a rigged model drops in without a compensating
-  rotation.
+  `CollisionShape3D`, and a `NavigationAgent3D`. The KayKit Knight is already
+  in the repo (`assets/characters/hero/Knight.glb`, imported in issue #12) —
+  swapping the capsule for it is outstanding work, not a pending dependency.
+  The node forward direction is -Z (Godot convention) so the rigged model drops
+  in without a compensating rotation.
 - `hero.gd` (`class_name Hero`) — click-to-move controller.
   - **Input decision (documented per issue #5):** *right*-click issues the
     move command (RTS convention); left-click is reserved for

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -25,6 +25,14 @@ Cells are `CELL_SIZE` = 4 units, matching the KayKit dungeon grid: `wall` is
 4×4×1 and `floor_tile_large` is 4×4. Corridors are one cell wide, which leaves
 ~3 units clear once the wall pieces straddle the cell edges.
 
+**Corridors are single-file.** The ~3 units of clear floor are not ~3 units of
+*walkable* floor: the navmesh bakes at `agent_radius` 1.0 (see the gotcha
+below), so the walkable ribbon down a one-cell corridor is only ~1 unit wide.
+Two 0.4-radius agents cannot pass each other in one, and nothing shuffles them
+sideways. Encounter and enemy-behaviour design should assume units queue up in
+corridors; anything that needs units to pass needs either wider corridors (a
+2-cell layout) or agent avoidance — a real design decision, not a tuning tweak.
+
 ## What gets built
 
 - **Floor** — `floor_tile_large` per open cell, `floor_dirt_large` for the

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -28,10 +28,14 @@ Cells are `CELL_SIZE` = 4 units, matching the KayKit dungeon grid: `wall` is
 **Corridors are single-file.** The ~3 units of clear floor are not ~3 units of
 *walkable* floor: the navmesh bakes at `agent_radius` 1.0 (see the gotcha
 below), so the walkable ribbon down a one-cell corridor is only ~1 unit wide.
-Two 0.4-radius agents cannot pass each other in one, and nothing shuffles them
-sideways. Encounter and enemy-behaviour design should assume units queue up in
-corridors; anything that needs units to pass needs either wider corridors (a
-2-cell layout) or agent avoidance — a real design decision, not a tuning tweak.
+Two 0.4-radius agents need 0.8 of separation, so they *geometrically* fit across
+that ribbon with ~0.2 to spare — what actually keeps them single-file is that
+nothing steers them to opposite edges: `avoidance_enabled` is off by default and
+no code sets it. Encounter and enemy-behaviour design should assume units queue
+up in corridors; anything that needs them to pass needs either wider corridors
+(a 2-cell layout) or agent avoidance — a real design decision, not a tuning
+tweak. Note the 0.2 of slack is why avoidance is a plausible remedy rather than
+a hopeless one, and why this paragraph must be re-checked if it is ever enabled.
 
 ## What gets built
 

--- a/scenes/map/maze.gd
+++ b/scenes/map/maze.gd
@@ -51,9 +51,10 @@ const EDGES := [
 ## Corridors are one cell (4 units) wide, which leaves ~3 units of clear space
 ## once the walls straddle the cell edges. Agents travel them single-file: the
 ## navmesh bakes at agent_radius 1.0 (see the gotcha in CLAUDE.md), so the
-## walkable ribbon is only ~1 unit wide and two units cannot pass each other.
-## Chokepoints are therefore the default, not the exception — encounter design
-## should assume a queue, not a brawl.
+## walkable ribbon is only ~1 unit wide. Two 0.4-radius agents fit across that
+## with ~0.2 to spare, but nothing steers them apart — avoidance_enabled is off
+## and no code sets it — so in practice they queue. Chokepoints are the default,
+## not the exception; encounter design should assume a queue, not a brawl.
 @export var layout: PackedStringArray = PackedStringArray([
 	"###############",
 	"#####.....#####",

--- a/scenes/map/maze.gd
+++ b/scenes/map/maze.gd
@@ -49,8 +49,11 @@ const EDGES := [
 ## The map. North is row 0. Must be rectangular; exactly one S and one B.
 ##
 ## Corridors are one cell (4 units) wide, which leaves ~3 units of clear space
-## once the walls straddle the cell edges — wide enough for the hero (0.4
-## radius) and a zombie to meet, tight enough to make chokepoints matter.
+## once the walls straddle the cell edges. Agents travel them single-file: the
+## navmesh bakes at agent_radius 1.0 (see the gotcha in CLAUDE.md), so the
+## walkable ribbon is only ~1 unit wide and two units cannot pass each other.
+## Chokepoints are therefore the default, not the exception — encounter design
+## should assume a queue, not a brawl.
 @export var layout: PackedStringArray = PackedStringArray([
 	"###############",
 	"#####.....#####",


### PR DESCRIPTION
Fixes #19

## What

Two documentation claims on `main` contradict the code they describe. Both are
corrected here; no behaviour changes.

### 1. Corridor width (`scenes/map/maze.gd`, `scenes/map/CLAUDE.md`)

The `layout` docstring claimed corridors are:

> wide enough for the hero (0.4 radius) and a zombie to meet

They are not. The navmesh bakes at `agent_radius` 1.0 (raised from 0.5 in #18 to
stop the hero wedging in corner pockets), so the walkable ribbon down a one-cell
corridor is only ~1 unit wide. Two 0.4-radius agents cannot pass each other, and
there is no avoidance logic to shuffle them sideways. Agents queue.

Gustav raised exactly this in the cross-review of #18 as a non-blocking finding,
and #18 merged with it outstanding. The PR's own review notes already stated the
true behaviour, so the repo has been asserting both since that merge.

This is not cosmetic. `scenes/CLAUDE.md` on the in-flight zombie branch already
reasons from the true behaviour — it explains that zombies are deliberately
non-colliding with each other because "mutually-colliding zombies jam solid in a
one-cell corridor". A reader who trusted the `maze.gd` comment instead would
design chase or body-blocking behaviour the navmesh cannot support.

Both the comment and the folder doc now state the design consequence, not just
the fact: encounters should assume a queue, and letting units pass needs either
wider (2-cell) corridors or agent avoidance — a design decision, not a tuning
tweak.

### 2. Stale asset dependency (`scenes/hero/CLAUDE.md`)

Said the placeholder capsule gets replaced by the KayKit Knight "once the asset
PR lands". That PR (#14, closing #12) landed *before* the hero controller — the
Knight has been sitting in `assets/characters/hero/Knight.glb` unused ever
since. Reworded so it reads as outstanding work rather than a blocked
dependency, which is what it is.

## Verification

- `--headless --import` then `--check-only --script res://scenes/map/maze.gd`:
  clean, no errors. (The `maze.gd` change is inside a `##` docstring; the
  check confirms it.)
- No functional lines touched — `git diff` is three prose hunks.

## Review notes

- Branched from `origin/main` at 4a272d6, developed in a separate git worktree
  because the shared checkout is currently on `feature/zombie-enemy`.
- That branch touches `maze.gd` too (it adds `Z` spawn cells). If it lands
  first this will need a trivial rebase — the hunks are in different parts of
  the file, and the docstring text it carries is the stale version being fixed
  here.
