### PR TITLE
Share the Flowdex knowledge-base config with both developers

### DIFF
--- a/.claude/hooks/CLAUDE.md
+++ b/.claude/hooks/CLAUDE.md
@@ -1,0 +1,38 @@
+# .claude/hooks
+
+Stop hooks that enforce two of this project's documentation rules. Both are
+wired up in `../settings.json` and run on every session stop, independently —
+one failing does not prevent the other from running.
+
+- `check-folder-docs.sh` — enforces the per-folder `CLAUDE.md` rule. Also runs
+  in CI via `--diff <range>`.
+- `check-flowdex.sh` — enforces the Flowdex write-back rule (see "Knowledge
+  base" in the root `CLAUDE.md`). No-ops for a developer who has not connected
+  the Flowdex MCP server.
+- `test-check-flowdex.sh` — test harness for the above. Run it after any change
+  to `check-flowdex.sh`:
+
+  ```bash
+  bash .claude/hooks/test-check-flowdex.sh
+  ```
+
+## The gotcha: these scripts read transcripts, so they can read themselves
+
+`check-flowdex.sh` decides what a session did by grepping that session's
+transcript — and a transcript contains the full text of every file the session
+read. **Any file in this repo that spells out, as adjacent literal text, a
+pattern the hook greps for will make the hook mis-read any session that merely
+opened that file.**
+
+This shipped twice before it was understood, both caught in cross-review of
+PR #23: once through the MCP tool names, and again through the merge command,
+which accused every reader of the hook of having merged a pull request.
+
+So patterns are assembled from parts at runtime rather than written out whole,
+in the hook *and* in its tests. Keep it that way when editing either, and keep
+the joined forms out of the root `CLAUDE.md` too — that file is injected into
+every session's context, so it reaches transcripts the same way.
+
+`test-check-flowdex.sh` covers this directly: it feeds the hook a transcript
+containing the hook's own source, and another containing the tests' source,
+and requires both to be treated as sessions that did nothing.

--- a/.claude/hooks/check-flowdex.sh
+++ b/.claude/hooks/check-flowdex.sh
@@ -65,8 +65,16 @@ fi
 #     `main` without this session editing a single file, which is exactly how
 #     the wiki drifted behind the repo before. Matches the gh CLI and the raw
 #     API call alike.
+#
+#     Assembled at runtime for the same reason as the tool names above, and it
+#     is not a hypothetical here: written out whole, the command string sits in
+#     this file, so any session that *read* this file — a review, a debug, an
+#     edit to this very hook — put it in its own transcript and got accused of
+#     merging a PR it never touched. Caught in cross-review of PR #23, after
+#     the identical defence had already been applied to the tool names.
+merge_verb='merge'
 merged_pr=0
-if grep -qE 'gh pr merge|/pulls/[0-9]+/merge' "$transcript" 2>/dev/null; then
+if grep -qE "gh pr ${merge_verb}|/pulls/[0-9]+/${merge_verb}" "$transcript" 2>/dev/null; then
   merged_pr=1
 fi
 

--- a/.claude/hooks/check-flowdex.sh
+++ b/.claude/hooks/check-flowdex.sh
@@ -52,9 +52,12 @@ fi
 #
 # (1) The session touched project code or docs. Scratchpad edits, questions and
 #     read-only sessions should never be nagged.
+#     LICENSES.md counts alongside CLAUDE.md: an asset addition may touch
+#     nothing else, and the asset policy is exactly the kind of decision the
+#     wiki is supposed to remember.
 touched_code=0
 if grep -E '"name": *"(Edit|Write|NotebookEdit)"' "$transcript" 2>/dev/null \
-   | grep -qE '\.(gd|gdshader|tscn|godot|cfg|yml)"|CLAUDE\.md"'; then
+   | grep -qE '\.(gd|gdshader|tscn|godot|cfg|yml)"|(CLAUDE|LICENSES)\.md"'; then
   touched_code=1
 fi
 
@@ -75,6 +78,16 @@ fi
 # mention. The tool names also appear in the session's tool listing, so a looser
 # pattern is satisfied by merely having Flowdex connected — which is what the
 # availability probe above deliberately uses it for.
+#
+# The distinction rests on the JSON key, so be careful changing it. A real call
+# is recorded as "name":"<tool>"; every other appearance of a tool name in a
+# transcript uses a different key or no key at all — a ToolSearch result stores
+# it as "tool_name":"<tool>" and as bare comma-separated names. Requiring a
+# quote immediately before `name` is what separates the two. Verified against
+# 15 real session transcripts: this pattern's hit count equalled the number of
+# genuine calls in every one, including a session where these tools' full
+# schemas were loaded via ToolSearch. If Claude Code ever renames that key to
+# `name`, enforcement dies silently — that is the thing to re-test.
 if grep -qE "\"name\"[[:space:]]*:[[:space:]]*\"${mcp_prefix}${writeback_tools}\"" "$transcript" 2>/dev/null; then
   exit 0
 fi

--- a/.claude/hooks/check-flowdex.sh
+++ b/.claude/hooks/check-flowdex.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Enforces the Flowdex write-back rule from the root CLAUDE.md: a session that
+# changed project code, or merged a PR, must also have recorded something in the
+# team wiki. Invoking the skill is not enough — the failure mode this exists for
+# is loading context, then ending the session without writing any of it back,
+# leaving the wiki describing a state of the project that no longer exists.
+#
+# No-ops for a developer who has not connected the Flowdex MCP server, so the
+# hook is safe to ship to everyone (see "Knowledge base" in the root CLAUDE.md
+# for how to connect it).
+set -u
+
+input=$(cat 2>/dev/null || true)
+
+# Already blocked once this turn — let the stop through so we can't loop.
+case "$input" in
+  *'"stop_hook_active":true'* | *'"stop_hook_active": true'*) exit 0 ;;
+esac
+
+# Locate the transcript. If we can't read it we cannot judge, so never block.
+# Any run of backslashes becomes one forward slash, so this copes with the
+# JSON-escaped Windows path ("C:\\Users\\...") and a raw one alike.
+transcript=$(printf '%s' "$input" \
+  | grep -o '"transcript_path"[[:space:]]*:[[:space:]]*"[^"]*"' \
+  | sed 's/.*:[[:space:]]*"//; s/"$//' \
+  | sed -E 's/\\+/\//g')
+# Git Bash resolves "C:/..." fine, but a leading drive letter from a stripped
+# path ("/c/...") is the form the POSIX layer expects.
+case "$transcript" in
+  [A-Za-z]:/*) transcript="/$(printf '%s' "${transcript%%:*}" | tr 'A-Z' 'a-z')${transcript#*:}" ;;
+esac
+[ -n "${transcript:-}" ] || exit 0
+[ -f "$transcript" ] || exit 0
+
+# The MCP tool names are assembled at runtime, never written out in full. The
+# probe below searches the transcript for those names, and the transcript
+# contains this file's own text whenever a session reads it — a literal here
+# would make the hook believe Flowdex was connected in any session that opened
+# it. Splitting the string keeps the file inert as evidence about itself.
+mcp_prefix='mcp__[A-Za-z0-9_-]+__'
+writeback_tools='(write_index|append_changelog)'
+
+# Is Flowdex connected at all? The tool names appear in the session's tool
+# listing whenever the MCP server is available, called or not. If they are
+# absent entirely, this developer has no Flowdex connector and there is nothing
+# to enforce — say nothing and get out of the way.
+if ! grep -qE "${mcp_prefix}${writeback_tools}" "$transcript" 2>/dev/null; then
+  exit 0
+fi
+
+# Two things oblige a write-back.
+#
+# (1) The session touched project code or docs. Scratchpad edits, questions and
+#     read-only sessions should never be nagged.
+touched_code=0
+if grep -E '"name": *"(Edit|Write|NotebookEdit)"' "$transcript" 2>/dev/null \
+   | grep -qE '\.(gd|gdshader|tscn|godot|cfg|yml)"|CLAUDE\.md"'; then
+  touched_code=1
+fi
+
+# (2) The session merged a PR. Accepting someone's work changes what is true on
+#     `main` without this session editing a single file, which is exactly how
+#     the wiki drifted behind the repo before. Matches the gh CLI and the raw
+#     API call alike.
+merged_pr=0
+if grep -qE 'gh pr merge|/pulls/[0-9]+/merge' "$transcript" 2>/dev/null; then
+  merged_pr=1
+fi
+
+if [ "$touched_code" -eq 0 ] && [ "$merged_pr" -eq 0 ]; then
+  exit 0
+fi
+
+# Did it write anything back? This must match an actual tool *call*, not a
+# mention. The tool names also appear in the session's tool listing, so a looser
+# pattern is satisfied by merely having Flowdex connected — which is what the
+# availability probe above deliberately uses it for.
+if grep -qE "\"name\"[[:space:]]*:[[:space:]]*\"${mcp_prefix}${writeback_tools}\"" "$transcript" 2>/dev/null; then
+  exit 0
+fi
+
+{
+  echo "Flowdex write-back missing (see 'Knowledge base' in the root CLAUDE.md)."
+  echo ""
+  if [ "$merged_pr" -eq 1 ]; then
+    echo "This session merged a pull request but never called write_index or"
+    echo "append_changelog. A merge changes what is true on 'main', and the wiki"
+    echo "tracks 'main' — leaving it unwritten is how it drifts."
+  else
+    echo "This session changed project code or folder docs but never called"
+    echo "write_index or append_changelog, so nothing durable was recorded."
+  fi
+  echo "Loading the skill at the start does not count — reading is half of it."
+  echo ""
+  echo "Before stopping:"
+  echo "  1. Save what outlives this chat — an architecture or design decision,"
+  echo "     a non-obvious gotcha, a convention — as a small single-topic page"
+  echo "     under the right category folder, linked with [[wiki-links]]."
+  echo "  2. Record the change itself with append_changelog."
+  echo "  3. Fix any page this session made stale rather than appending a"
+  echo "     correction to it."
+  if [ "$merged_pr" -eq 1 ]; then
+    echo "  4. Fold the merged PR's 'In flight — PR #N' block into the page body"
+    echo "     and drop the heading; it is no longer in flight."
+  fi
+  echo ""
+  echo "If this session genuinely produced nothing durable (a trivial rename, a"
+  echo "revert), say so explicitly in one sentence and stop again."
+} >&2
+exit 2

--- a/.claude/hooks/test-check-flowdex.sh
+++ b/.claude/hooks/test-check-flowdex.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Test harness for check-flowdex.sh. Run it from anywhere:
+#
+#   bash .claude/hooks/test-check-flowdex.sh
+#
+# Builds synthetic transcripts in a temp dir, runs the hook against each, and
+# asserts the exit code (0 = let the session stop, 2 = block it).
+#
+# ---------------------------------------------------------------------------
+# THE RULE THIS FILE OBEYS, AND WHY
+#
+# The hook decides what a session did by grepping that session's transcript.
+# A transcript contains the full text of every file the session read. So any
+# file in this repo that spells out — as adjacent literal text — a pattern the
+# hook greps for will make the hook mis-read any session that merely opened it.
+#
+# That is not theoretical. It shipped twice: once via the MCP tool names, and
+# again via the merge command, which accused every reader of this hook of
+# having merged a pull request. Both were caught in cross-review of PR #23.
+#
+# So: patterns are assembled from parts here, exactly as they are in the hook.
+# Nothing below spells out a matched string in one piece. If you add a case,
+# keep it that way, or this harness will start corrupting the sessions of
+# whoever reads it.
+# ---------------------------------------------------------------------------
+set -u
+
+HOOK="$(cd "$(dirname "$0")" && pwd)/check-flowdex.sh"
+[ -f "$HOOK" ] || { echo "cannot find check-flowdex.sh next to this script" >&2; exit 1; }
+
+TMP=$(mktemp -d 2>/dev/null || mktemp -d -t flowdex)
+trap 'rm -rf "$TMP"' EXIT
+
+# --- assembled literals (see header) ---------------------------------------
+w='write'; ix='index'; ap='append'; cl='changelog'
+prefix='mcp__testconnector__'
+write_tool="${prefix}${w}_${ix}"
+chg_tool="${prefix}${ap}_${cl}"
+mv='merge'
+merge_cmd="gh pr ${mv}"
+gd='gd'; md='md'
+
+# --- fixture pieces ---------------------------------------------------------
+avail="{\"deferred\":[\"${write_tool}\",\"${chg_tool}\"]}"
+call="{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"id\":\"toolu_01\",\"name\":\"${write_tool}\",\"input\":{}}]}}"
+edit_gd="{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"input\":{\"file_path\":\"C:\\\\repo\\\\scenes\\\\map\\\\maze.${gd}\"}}]}}"
+edit_lic="{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Edit\",\"input\":{\"file_path\":\"C:\\\\repo\\\\assets\\\\LICENSES.${md}\"}}]}}"
+edit_scratch="{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Write\",\"input\":{\"file_path\":\"C:\\\\Temp\\\\scratchpad\\\\notes.txt\"}}]}}"
+read_only="{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Read\",\"input\":{\"file_path\":\"C:\\\\repo\\\\README.txt\"}}]}}"
+merged="{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"input\":{\"command\":\"${merge_cmd} 23 --squash\"}}]}}"
+# A tool-listing / schema mention: the tool name appears, but never as a call.
+mention="{\"type\":\"tool_result\",\"content\":[{\"type\":\"tool_reference\",\"tool_name\":\"${write_tool}\"}]}"
+
+mk() { local name=$1; shift; printf '%s\n' "$@" > "$TMP/$name.jsonl"; }
+
+mk no_connector      "$edit_gd"
+mk no_writeback      "$avail" "$edit_gd"
+mk wrote_back        "$avail" "$edit_gd" "$call"
+mk merged_no_write   "$avail" "$merged"
+mk merged_wrote_back "$avail" "$merged" "$call"
+mk read_only         "$avail" "$read_only"
+mk scratchpad_only   "$avail" "$edit_scratch"
+mk licenses_only     "$avail" "$edit_lic"
+mk mention_not_call  "$avail" "$edit_gd" "$mention"
+
+# The regression that shipped: a session holding this hook's own text must not
+# be read as having merged a PR or written anything back. Grep is line-based,
+# so pasting the source in as raw lines exercises exactly what a real read does.
+{ printf '%s\n' "$avail"; cat "$HOOK"; } > "$TMP/read_the_hook.jsonl"
+# Same, for this harness — it is the other file full of tempting literals.
+{ printf '%s\n' "$avail"; cat "$0"; } > "$TMP/read_the_tests.jsonl"
+
+# --- runner -----------------------------------------------------------------
+pass=0; fail=0
+
+check() { # name expected description
+  local name=$1 want=$2 desc=$3 path got
+  path="$TMP/$name.jsonl"
+  printf '{"transcript_path":"%s","stop_hook_active":false}' "$path" \
+    | bash "$HOOK" >/dev/null 2>&1
+  got=$?
+  if [ "$got" = "$want" ]; then
+    pass=$((pass+1)); printf '  ok    %-22s %s\n' "$name" "$desc"
+  else
+    fail=$((fail+1)); printf '  FAIL  %-22s %s (want %s, got %s)\n' "$name" "$desc" "$want" "$got"
+  fi
+}
+
+echo "check-flowdex.sh"
+echo
+echo "no-op when Flowdex is not connected:"
+check no_connector      0 "code edited, no connector -> never block"
+echo
+echo "enforces a write-back when it should:"
+check no_writeback      2 "code edited, nothing written back"
+check merged_no_write   2 "PR merged, nothing written back"
+check licenses_only     2 "only LICENSES.md edited"
+check mention_not_call  2 "tool named but never called"
+echo
+echo "stays out of the way when it should:"
+check wrote_back        0 "code edited and written back"
+check merged_wrote_back 0 "PR merged and written back"
+check read_only         0 "read-only session"
+check scratchpad_only   0 "scratchpad edits only"
+echo
+echo "does not mistake a file's text for a session's actions:"
+check read_the_hook     0 "session that read the hook itself"
+check read_the_tests    0 "session that read these tests"
+echo
+echo "fails safe:"
+check missing           0 "transcript path does not exist"
+
+printf '{"transcript_path":"%s/no_writeback.jsonl","stop_hook_active":true}' "$TMP" \
+  | bash "$HOOK" >/dev/null 2>&1
+if [ $? = 0 ]; then
+  pass=$((pass+1)); printf '  ok    %-22s %s\n' "loop_guard" "already blocked once -> let it stop"
+else
+  fail=$((fail+1)); printf '  FAIL  %-22s %s\n' "loop_guard" "already blocked once -> let it stop"
+fi
+
+# Windows-only: the hook rewrites a drive-letter path into the POSIX form Git
+# Bash expects. Skipped elsewhere, where that branch is unreachable anyway.
+case "$(uname -s 2>/dev/null)" in
+  MINGW*|MSYS*|CYGWIN*)
+    win_path=$(printf '%s' "$TMP/no_writeback.jsonl" \
+      | sed -E 's#^/([a-z])/#\U\1:/#')
+    printf '{"transcript_path":"%s","stop_hook_active":false}' "$win_path" \
+      | bash "$HOOK" >/dev/null 2>&1
+    if [ $? = 2 ]; then
+      pass=$((pass+1)); printf '  ok    %-22s %s\n' "windows_path" "drive-letter transcript path resolves"
+    else
+      fail=$((fail+1)); printf '  FAIL  %-22s %s (path was %s)\n' "windows_path" "drive-letter transcript path resolves" "$win_path"
+    fi
+    ;;
+esac
+
+echo
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"SessionStart\",\"additionalContext\":\"Knowledge base: before substantive work on this repo, load existing context from the mg-zombies Flowdex project via the nexus-knowledge-base skill - get_project_structure, then read_index the pages relevant to the task. Reading one page is not enough. A Stop hook blocks the session from ending if project code or folder docs changed but nothing was written back with write_index / append_changelog. If you have not connected the Flowdex MCP server, see Knowledge base in the root CLAUDE.md; the hooks no-op until you do.\"}}'",
+            "shell": "bash",
+            "timeout": 10,
+            "suppressOutput": true
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [
@@ -9,6 +22,13 @@
             "shell": "bash",
             "timeout": 30,
             "statusMessage": "Checking per-folder docs..."
+          },
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-flowdex.sh",
+            "shell": "bash",
+            "timeout": 30,
+            "statusMessage": "Checking Flowdex write-back..."
           }
         ]
       }

--- a/.claude/skills/nexus-knowledge-base/SKILL.md
+++ b/.claude/skills/nexus-knowledge-base/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: nexus-knowledge-base
+description: Read and write your team's shared Flowdex knowledge base via its MCP tools. Use at the start of a task to load relevant project context before acting, and to save durable decisions, learnings, and activity back to Flowdex.
+---
+
+# Flowdex — team knowledge base
+
+Flowdex is your team's shared, AI-readable knowledge base, exposed through MCP tools.
+Use it so you build on what the team already knows and leave durable knowledge behind —
+don't start from zero, and don't let what you learn evaporate when the chat ends.
+
+## Golden rules
+1. **Read before you act.** At the start of a task, load the project context first — get_project_structure, then read_index on the relevant pages — so you build on what the team already knows instead of starting from zero.
+2. **Write durable knowledge back.** When you learn or decide something that outlives the current chat (architecture, conventions, how-tos, decisions), save it with write_index as a focused markdown page.
+3. **Log meaningful activity.** After a substantive change, record it with append_changelog so teammates — and their agents — can see what happened.
+4. **Link concepts with [[wiki-links]].** Reference other pages, people, and systems with [[Double Brackets]]. That is what turns isolated notes into a navigable knowledge graph.
+5. **Keep pages small and focused.** One concept per index page. Small, well-linked pages beat one giant page — easier for both humans and agents to find and keep current.
+6. **Don't duplicate — extend.** Before writing a new page, check the graph and existing pages. Update or link an existing page rather than creating a near-duplicate.
+
+## At the start of a task
+1. `list_projects` to find the project, then `get_project_structure` to see what exists.
+2. `read_index` the pages relevant to the task.
+3. Summarize what you found before proposing changes.
+
+## As you work
+- Save durable decisions and learnings with `write_index` — small, focused markdown pages.
+- Record meaningful changes with `append_changelog`.
+- Link related pages, people, and systems with [[wiki-links]].
+- Before creating a page, check `get_wiki_graph` and existing pages, and extend rather than duplicate.
+
+## Tools
+### Discover
+- `list_projects` — List the projects you can access. (use when: First call in a new workspace.)
+- `get_capabilities` — Server capabilities and usage guidance. (use when: When unsure what the server supports.)
+- `get_project_structure` — Files, index pages, and stats for a project. (use when: At the start of a task.)
+- `get_wiki_graph` — The project’s pages and [[wiki-link]] edges. (use when: To navigate related knowledge.)
+
+### Read
+- `read_index` — Read an index (wiki) page. (use when: To load specific context before working.)
+- `read_changelog` — Recent activity for a project. (use when: To catch up on what changed.)
+
+### Write
+- `write_index` — Create or update an index page (markdown). (use when: To save durable knowledge or decisions.)
+- `append_changelog` — Append an activity entry. (use when: After a meaningful change.)
+- `delete_index_page` — Remove an index page. (use when: When a page is obsolete (editor+).)
+
+### Files
+- `prepare / execute / complete_file_upload` — Upload a raw file (direct-to-storage). (use when: To add source documents to keep.)
+- `archive_file` — Move a file to the archive. (use when: To retire a file without deleting it.)
+
+### Team
+- `list_organization_members / list_project_members` — See who is in the org / project. (use when: To understand the team.)
+- `create_project / add_project_member` — Create a project or add a member. (use when: Create: org owner/admin. Add member: a project lead, or org owner/admin.)

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@
 
 # Per-developer Claude Code context (machine-specific paths etc.)
 CLAUDE.local.md
+
+# Per-developer Claude Code settings (local permissions, machine-specific hooks).
+# Shared hooks belong in .claude/settings.json — both files' hooks run, so a
+# hook duplicated here fires twice.
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,24 @@ Rules:
 - Keep them short and current — a stale doc is worse than none. Delete statements that no longer hold rather than appending corrections.
 - These folder docs are also what PR reviewers use to judge a change, so an out-of-date doc is a valid review finding.
 
+## Knowledge base (Flowdex)
+
+The team keeps a shared, AI-readable wiki in Flowdex, project slug **`mg-zombies`**. It is the long-term memory the folder docs can't hold: architecture decisions and *why* they were made, gotchas, conventions, and the state of the project. Both developers' Claude sessions read and write it.
+
+**Connecting (once per developer).** Flowdex reaches Claude Code as an MCP connector on your own Claude account, authenticated with your personal `nx_live_` token. Add it in your Claude account's connector settings. The token is a secret: it belongs in that connector config only — never in this repo, a PR, or an issue. Ask the other developer for a Flowdex org invite if you don't have an account yet. Until you connect it, the hooks below no-op and everything else here still works.
+
+**Using it — the two halves.**
+- **Read before you act.** At the start of substantive work (gameplay features, architecture decisions, asset or infra changes), invoke the `nexus-knowledge-base` skill: `get_project_structure`, then `read_index` the pages relevant to the task. Reading one page is not enough. Skip it for trivial one-liners.
+- **Write durable knowledge back.** Save what outlives the chat as a small single-topic page under the right category folder, and record the change with `append_changelog`. Loading context and writing nothing back is the failure this system exists to prevent.
+
+**The wiki tracks merged `main`, not the working tree.** Unmerged work may be documented, but only under an explicit `## In flight — PR #N <branch> (not merged)` heading. A reader must never have to check out a branch to learn whether a page is true. When in doubt read `git show main:<path>`, not the working copy — both developers' sessions share one checkout.
+
+**Merging a PR is a wiki event.** Whenever a PR is accepted — yours or your partner's — update Flowdex in the same session, before moving on: fold that PR's "In flight" block into the page body, correct whatever else it changed, add pages for new concepts, and `append_changelog` with the PR number and title.
+
+**Layout:** root `overview.md` hub plus category folders `game-design/`, `engine/`, `workflow/`, `build-release/`, `assets/`. Pages use the sections Overview / Key information / Relations / Last updated, stay single-topic, and link with `[[wiki-links]]`. Prefer correcting a page over appending to it — a stale statement left in place is worse than a missing one. Because both developers can read the wiki, citing pages in PR bodies and issues is encouraged.
+
+**Enforcement.** Two hooks in `.claude/settings.json` close the gap between invoking the skill and actually using it: `SessionStart` injects a reminder, and `Stop` runs `.claude/hooks/check-flowdex.sh`, which blocks the session from ending when it never wrote anything back but either edited `.gd`/`.tscn`/`CLAUDE.md`/config files or merged a PR. It never blocks a developer without the connector, a read-only session, a scratchpad-only session, or twice in a row.
+
 ## Running Godot
 
 The project uses Godot 4.7.1. Godot is not on PATH and the binary location is machine-specific, so it is deliberately not recorded here. Each developer keeps their local path in `CLAUDE.local.md` in the repo root (gitignored; Claude Code auto-loads it alongside this file). If that file doesn't exist yet, locate the install (try `Downloads` for `Godot_v4.7.1*`) and offer to create it with the path you found.


### PR DESCRIPTION
## What this is

We've been running a shared AI-readable wiki (**Flowdex**) for this project — architecture decisions and the reasoning behind them, gotchas, conventions, the current state of `main`. It has 27 pages and has been genuinely useful.

The problem: it was set up as a solo experiment. The skill, the hooks and the entire policy lived in one developer's *untracked local* config, so only one of us has been reading or writing it. A wiki one person writes to is a diary. This PR moves everything shareable into the repo so we both use it.

## What moves into version control

| Path | What it is |
|---|---|
| `.claude/skills/nexus-knowledge-base/` | The skill that exposes the wiki's tools. Committed unchanged. |
| `.claude/hooks/check-flowdex.sh` | Stop hook — the write-back check. Two fixes, below. |
| `.claude/settings.json` | The `SessionStart` + `Stop` hooks, moved here from a local settings file, alongside the existing folder-docs hook. |
| `CLAUDE.md` | New **"Knowledge base (Flowdex)"** section — the policy, previously local-only. |
| `.gitignore` | `.claude/settings.local.json` now ignored properly (it holds per-developer settings; both files' hooks run, so a hook duplicated there would fire twice). |

## What deliberately does *not* move

The MCP connector. It authenticates with a personal `nx_live_` token, so it can't live in a public repo under any arrangement — a repo-declared variant would still need you to supply your own token via an env var, plus an `npx` dependency, for the same result. You add it once to your own Claude account; `CLAUDE.md` says how.

**Until you do that, this PR changes nothing for you.** The hooks detect the missing connector and no-op. That's deliberate, so this can merge before your access is sorted.

## Two fixes to the hook — please look hardest at these

**1. It never fired.** The write-back check searched the transcript for the wiki's tool names. But Claude Code writes the *available-tool listing* into every transcript, so those names are present in any session where the connector is enabled — called or not. The check matched the listing and exited clean every time. Verified against real transcripts: sessions with **0** actual calls scored pattern hits and passed. Enforcement we believed was running had never run once. It now matches the tool-*use* form, so a mention no longer counts as a write.

**2. It now degrades instead of trapping you.** With fix 1 alone, a developer without the connector has no such tool, can never satisfy the check, and gets blocked on every session touching a `.gd`/`.tscn`/`CLAUDE.md`. The hook now first probes whether the wiki is reachable at all and exits silently if not.

There's a self-reference trap in fix 2 worth a look: the probe searches the transcript for the tool names, and the transcript contains the hook's own source whenever a session reads the file. A literal pattern would make the hook conclude the wiki was connected in any session that merely opened it. So the pattern is assembled at runtime from two halves and never written out whole. Same reason `CLAUDE.md` uses bare tool names — it's injected into every session's context and would otherwise trip the same wire. There's a test for it.

## Verification

Eight cases run against synthetic transcripts, all passing:

| Case | Expected |
|---|---|
| No connector + code edit | allow |
| Connected, no write-back, code edit | **block** ← the case that was broken |
| Connected + wrote back | allow |
| Merged a PR, no write-back | **block** |
| Read-only session | allow |
| Session that read the hook file itself | allow |
| Missing/unreadable transcript | allow |
| `stop_hook_active` (loop guard) | allow |

Both settings files validated as JSON; the folder-docs hook still runs exactly once.

## What you need to do

Nothing to merge this. To actually get on the wiki: I'll send a Flowdex org invite, you generate your own token and add the connector, and I'll add you to the project as `project_lead` so neither of us is a bottleneck for membership. Full steps are in `CLAUDE.md`.

## Note on a convention that flips

The old policy said *never cite the wiki in commits, PRs or issues* — it existed only because you couldn't follow the links. Once you're on it, citing pages is encouraged. This PR body deliberately still doesn't, since you can't read them yet.

## Review focus

- Is the no-connector degrade genuinely airtight? It's the thing standing between this hook and blocking your sessions with a demand you can't meet.
- Is the `CLAUDE.md` policy section clear to someone who hasn't used the wiki? You're the actual test of that — if a rule reads as arbitrary, say so and I'll rewrite it.
- Do the two Stop hooks in one `.claude/settings.json` entry sit right with you?
