### PR TITLE
Document the solo-review path for one-person weeks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,11 @@ Two developers collaborate via feature branches and pull requests.
 - Never commit directly to `main`. All work happens on branches and lands through PRs (branch protection rejects direct pushes anyway).
 - One topic per branch/PR — keep PRs small and reviewable; flag unrelated changes for a separate branch.
 - Every PR is reviewed by the *other* developer's Claude before merging (cross-review). When the user asks you to review their partner's PR, do a genuine critical review: check it against this file's conventions, the game design goals, and the per-folder context docs — don't rubber-stamp.
+- **Solo review, when the other developer is away.** `main` requires zero approving reviews, so the author can merge their own PR. This is deliberate: GitHub blocks authors from approving their own PRs, so an approval gate would deadlock a one-person week. The *review* is not waived, it moves to the author's side:
+  - The `claude-review` workflow runs on every PR and is a required check. Read its comment and address the findings before merging.
+  - Have your own Claude review the diff too, held to the same bar as a cross-review. An author-side reviewer that softens its findings makes the whole gate worthless.
+  - Everything else still applies: one topic per PR, no direct commits to `main`, all checks green, threads resolved. Merging your own PR is the exception — when both developers are around, wait for the cross-review.
+  - Restoring the two-person gate: `gh api --method PATCH repos/hipsen-systems/mg-zombies/branches/main/protection/required_pull_request_reviews -F required_approving_review_count=1`
 - When creating a PR, write a body that gives the reviewer enough context to review without access to this conversation.
 
 ## Per-folder context docs


### PR DESCRIPTION
## Why

Gustav is going on vacation, so for a stretch there will only be one developer around to land PRs. Under the old settings that was a deadlock, not a slowdown:

- `main` required **1 approving review**.
- GitHub **does not permit a PR author to approve their own PR** — the *Approve* option is disabled for the author, and no branch-protection setting re-enables it.
- `enforce_admins` is `true`, so there was no admin bypass either.

Net effect: with one developer available, no PR could ever reach a mergeable state.

## What changed

**Repo setting (already applied, outside this diff):** `required_approving_review_count` on `main` set from `1` to `0`, via the scoped `required_pull_request_reviews` endpoint so the rest of the protection object was untouched. Verified after the change:

| Setting | Value |
|---|---|
| Required approving reviews | 0 (was 1) |
| Required checks | `docs-check`, `claude-review` |
| Require branch up to date | true |
| Enforce on admins | true |
| Conversation resolution required | true |
| Force push / branch deletion | blocked |

Requiring a pull request at all is still on — dropping the count to 0 keeps the PR requirement and only removes the approval gate. Direct pushes to `main` are still rejected.

**This diff:** documents that path in the Team workflow section of the root `CLAUDE.md`.

## The part worth reviewing

The obvious risk is that "review your own PR" quietly becomes "skip the review". The doc is written to push against that:

- `claude-review` remains a **required status check**, so an automated critical review still runs on every PR and still blocks the merge button. That gate did not move.
- The author is expected to also have their own Claude review the diff, explicitly held to the same bar as a cross-review, with a note that an author-side reviewer which softens findings makes the gate worthless.
- Solo merge is framed as the exception, not the new default — when both developers are around, cross-review still applies.
- The command to restore `required_approving_review_count=1` is recorded in the doc so putting the two-person gate back is a one-liner rather than an archaeology exercise.

An alternative considered and rejected: have `github-actions[bot]` submit a formal `APPROVE` review to satisfy a count of 1. That preserves the appearance of an approval gate while making it unconditional — strictly worse than honestly setting the count to 0.

## Out of scope (not fixed here)

Noticed while reading the protection config, left alone to keep this PR on one topic: the **Builds & releases** section of `CLAUDE.md` claims every PR must pass `build-check` before it can merge, but `build-check` is **not** in the required status checks — only `docs-check` and `claude-review` are. A PR that fails to export can currently merge. Happy to file an issue for it.
