### PR TITLE
Make the doc dependency graph machine-readable and check it

### DIFF
--- a/.claude/hooks/CLAUDE.md
+++ b/.claude/hooks/CLAUDE.md
@@ -24,6 +24,15 @@ one failing does not prevent the other from running.
   folder. It found real debt on its first run — `scenes/CLAUDE.md` was stale
   against two `scenes/map/maze.gd` commits.
 
+  **The frontmatter parser is the third thing here to hit the self-reference
+  trap.** `depends-on:` is read from line 2 to the first closing `---`, never
+  with a `/^---$/,/^---$/` range: sed restarts a range at every later match, so
+  a markdown horizontal rule further down a doc reopens it, and any prose line
+  starting `depends-on:` is then read as a real edge. A doc explaining this
+  convention would be misparsed by the parser it explains — the same shape as
+  the stamp parser taking the *last* match, and as the Flowdex hook reading its
+  own source. Assume any parser added here will hit it too.
+
   **Both graph and stamp checks must exclude nested subfolders.** A git pathspec
   of `scenes` also matches `scenes/map/` and `scenes/hero/`, so the first version
   of the graph check reported `scenes/map/CLAUDE.md` as stale against commits

--- a/.claude/hooks/CLAUDE.md
+++ b/.claude/hooks/CLAUDE.md
@@ -1,3 +1,7 @@
+---
+depends-on: []
+---
+
 # .claude/hooks
 
 Stop hooks that enforce two of this project's documentation rules. Both are
@@ -5,13 +9,27 @@ wired up in `../settings.json` and run on every session stop, independently —
 one failing does not prevent the other from running.
 
 - `check-folder-docs.sh` — enforces the documentation rules from the root
-  `CLAUDE.md`, in three layers: **same-change** (code changed in a folder =>
+  `CLAUDE.md`, in four layers: **same-change** (code changed in a folder =>
   that folder's doc changed too), **code map** (every code folder is linked from
-  the root's map, and every entry resolves), and **verification** (every folder
+  the root's map, and every entry resolves), **verification** (every folder
   doc carries a `verified-against: <sha>` stamp, and its folder has not changed
-  since without the doc being touched). Runs here as a Stop hook, in CI on every
+  since without the doc being touched), and **dependency graph** (each doc's
+  `depends-on:` frontmatter resolves, and no doc is left unread after code it
+  depends on moved). Runs here as a Stop hook, in CI on every
   PR via `--diff <range>`, and on push to `main` via `--audit` — the PR gate
   only sees one range, so it cannot see drift arriving another way.
+
+  The first three all examine a folder in isolation, which is why the fourth
+  exists: it is the only one that can see a doc invalidated from outside its own
+  folder. It found real debt on its first run — `scenes/CLAUDE.md` was stale
+  against two `scenes/map/maze.gd` commits.
+
+  **Both graph and stamp checks must exclude nested subfolders.** A git pathspec
+  of `scenes` also matches `scenes/map/` and `scenes/hero/`, so the first version
+  of the graph check reported `scenes/map/CLAUDE.md` as stale against commits
+  that had only touched `scenes/map/` itself. `direct_code_commits` filters to
+  direct children, matching the boundary the verification check already drew —
+  keep them in step if either is edited.
 
   `--audit` runs the history checks alone against any checkout, and is the
   one-command answer to "are these docs still trustworthy?".

--- a/.claude/hooks/CLAUDE.md
+++ b/.claude/hooks/CLAUDE.md
@@ -13,9 +13,10 @@ one failing does not prevent the other from running.
   that folder's doc changed too), **code map** (every code folder is linked from
   the root's map, and every entry resolves), **verification** (every folder
   doc carries a `verified-against: <sha>` stamp, and its folder has not changed
-  since without the doc being touched), and **dependency graph** (each doc's
-  `depends-on:` frontmatter resolves, and no doc is left unread after code it
-  depends on moved). Runs here as a Stop hook, in CI on every
+  since without the doc being touched), and **dependency graph** (every folder
+  doc *declares* `depends-on:` — `[]` if it has none — each entry resolves, and
+  no doc is left unread after code it depends on moved). Runs here as a Stop
+  hook, in CI on every
   PR via `--diff <range>`, and on push to `main` via `--audit` — the PR gate
   only sees one range, so it cannot see drift arriving another way.
 
@@ -43,7 +44,7 @@ one failing does not prevent the other from running.
   `--audit` runs the history checks alone against any checkout, and is the
   one-command answer to "are these docs still trustworthy?".
 
-  Note the ceiling: all three verify a doc was *edited*, never that it is
+  Note the ceiling: all four verify a doc was *edited*, never that it is
   *true*. The stamp does not change that — it makes the human judgement
   explicit and attributable, so a stale stamp becomes a reviewable finding.
   Bump one only after actually reading the doc against the code.
@@ -87,4 +88,4 @@ every session's context, so it reaches transcripts the same way.
 containing the hook's own source, and another containing the tests' source,
 and requires both to be treated as sessions that did nothing.
 
-<!-- verified-against: e6ba8dc -->
+<!-- verified-against: a0a19fc -->

--- a/.claude/hooks/CLAUDE.md
+++ b/.claude/hooks/CLAUDE.md
@@ -14,9 +14,9 @@ one failing does not prevent the other from running.
   the root's map, and every entry resolves), **verification** (every folder
   doc carries a `verified-against: <sha>` stamp, and its folder has not changed
   since without the doc being touched), and **dependency graph** (every folder
-  doc *declares* `depends-on:` — `[]` if it has none — each entry resolves, and
-  no doc is left unread after code it depends on moved). Runs here as a Stop
-  hook, in CI on every
+  doc *declares* `depends-on: [...]` — `[]` if it has none — each entry
+  resolves, and no doc is left unread after code it depends on moved). Runs
+  here as a Stop hook, in CI on every
   PR via `--diff <range>`, and on push to `main` via `--audit` — the PR gate
   only sees one range, so it cannot see drift arriving another way.
 
@@ -33,6 +33,15 @@ one failing does not prevent the other from running.
   convention would be misparsed by the parser it explains — the same shape as
   the stamp parser taking the *last* match, and as the Flowdex hook reading its
   own source. Assume any parser added here will hit it too.
+
+  **The bracket form is required, and the reason is not cosmetic.** An
+  unbracketed `depends-on: scenes` satisfies a bare key test while the parser
+  extracts nothing from it, so the doc reads as having no dependencies —
+  indistinguishable from a deliberate `[]`, with no `BADDEP` or `DEPSTALE` able
+  to fire for it ever again. That is this check's own failure mode reproduced
+  inside its parser, which is why the gate tests for `[...]` rather than for the
+  key alone. The general lesson: every gate here should ask whether a
+  *malformed* input is silently read as an *empty* one.
 
   **Both graph and stamp checks must exclude nested subfolders.** A git pathspec
   of `scenes` also matches `scenes/map/` and `scenes/hero/`, so the first version

--- a/.claude/hooks/check-folder-docs.sh
+++ b/.claude/hooks/check-folder-docs.sh
@@ -166,10 +166,86 @@ check_verification() {
   done
 }
 
+# --- D. dependency graph -----------------------------------------------------
+# Each folder doc declares `depends-on: [a, b]` in YAML frontmatter: the folders
+# whose code its own claims rest on. Only this direction is stored — the reverse
+# ("what do I affect?") is its inverse, and keeping both would only create two
+# records that can disagree.
+#
+# The check that earns its keep is not shape, it is staleness *across* an edge.
+# Check C asks whether a folder changed since its own stamp; D asks whether
+# anything it depends on did. That is the drift nothing else catches: change the
+# navmesh settings in scenes/ and scenes/map/CLAUDE.md can silently stop being
+# true, because its own folder never moved.
+declared_deps() {
+  sed -n '/^---$/,/^---$/p' "$1" \
+    | sed -n 's/^depends-on:[[:space:]]*\[\(.*\)\].*/\1/p' \
+    | tr ',' '\n' \
+    | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+    | grep -v '^$'
+}
+
+# Commits since <stamp> that changed code *directly* in <dir>. Nested subfolders
+# are excluded: they belong to their own docs, the same boundary check C draws.
+# Without this, a pathspec of `scenes` also matches scenes/map/ and scenes/hero/,
+# and every change anywhere under scenes/ would flag every doc depending on it.
+direct_code_commits() {
+  d="$1"
+  stamp="$2"
+  git rev-list --no-merges "${stamp}..HEAD" -- "$d" | while IFS= read -r c; do
+    hit=$(git show --pretty=format: --name-only "$c" -- "$d" \
+      | while IFS= read -r f; do
+          [ -n "$f" ] || continue
+          [ "$(dirname "$f")" = "$d" ] || continue
+          printf '%s\n' "$f"
+        done | grep -E "$CODE_RE")
+    [ -n "$hit" ] && git log -1 --format='%h %s' "$c"
+  done
+}
+
+check_graph() {
+  folder_docs | while IFS= read -r doc; do
+    d=$(dirname "$doc")
+
+    if ! sed -n '1p' "$doc" | grep -qx -- '---'; then
+      echo "NOFRONT     $doc"
+      echo "            no 'depends-on:' frontmatter block on line 1"
+      continue
+    fi
+
+    stamp=$(sed -n 's/.*verified-against:[[:space:]]*\([0-9a-fA-F]\{7,40\}\).*/\1/p' "$doc" | tail -1)
+
+    declared_deps "$doc" | while IFS= read -r dep; do
+      if [ "$dep" = "$d" ]; then
+        echo "SELFDEP     $doc"
+        echo "            depends-on lists its own folder"
+        continue
+      fi
+      if [ ! -f "$dep/CLAUDE.md" ]; then
+        echo "BADDEP      $doc"
+        echo "            depends-on: $dep — no such folder doc ($dep/CLAUDE.md)"
+        continue
+      fi
+
+      # Staleness across the edge. Skipped when this doc has no usable stamp;
+      # check C already reports that, and one fault should not produce two.
+      [ -n "$stamp" ] || continue
+      git rev-parse --verify --quiet "${stamp}^{commit}" >/dev/null 2>&1 || continue
+
+      upstream=$(direct_code_commits "$dep" "$stamp")
+      [ -n "$upstream" ] || continue
+      echo "DEPSTALE    $doc"
+      echo "            depends on $dep/, whose code changed since $stamp:"
+      printf '%s\n' "$upstream" | sed 's/^/              /'
+    done
+  done
+}
+
 problems=$(
   check_same_change
   check_code_map
   check_verification
+  check_graph
 )
 
 [ -z "$problems" ] && exit 0
@@ -186,6 +262,14 @@ problems=$(
   echo "            making a no-op edit to silence this."
   echo "UNLISTED    the root CLAUDE.md's code map is the one inventory it keeps;"
   echo "DANGLING    add the row, or drop it if the folder is gone."
+  echo "NOFRONT     add a frontmatter block on line 1 naming the folders this"
+  echo "            doc's claims rest on:  ---\\ndepends-on: [scenes, assets]\\n---"
+  echo "SELFDEP     drop the self-reference; a folder does not depend on itself."
+  echo "BADDEP      the named folder has no CLAUDE.md — fix the name or add the doc."
+  echo "DEPSTALE    a folder this doc depends on changed. Re-read this doc against"
+  echo "            those commits: its claims rest on code that moved. Correct what"
+  echo "            no longer holds, then bump this doc's stamp. This is the check"
+  echo "            that catches drift arriving from outside the folder."
   echo "NOSTAMP     append to the doc:  <!-- verified-against: \$(git rev-parse --short HEAD) -->"
   echo "UNVERIFIED  read the listed commits against the doc, correct whatever no"
   echo "            longer holds, then bump the stamp to the current HEAD. Bump it"

--- a/.claude/hooks/check-folder-docs.sh
+++ b/.claude/hooks/check-folder-docs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Enforces the documentation rules from the root CLAUDE.md.
 #
-# Three checks, deliberately layered — each catches what the previous cannot:
+# Four checks, deliberately layered — each catches what the previous cannot:
 #
 #   A. same-change   Code changed in a folder => that folder's CLAUDE.md changed
 #                    in the same set. Also: project.godot changed => the root
@@ -17,6 +17,12 @@
 #                    also touching the doc. Catches everything that bypasses A:
 #                    history predating these hooks, merge-conflict resolutions,
 #                    web edits, and contributors running without hooks.
+#
+#   D. dependency    Every folder doc declares `depends-on: [...]` — the folders
+#      graph         its own claims rest on — and no doc is left unread after
+#                    code in one of those moved. Catches what A–C structurally
+#                    cannot: each of them examines a folder alone, so none can
+#                    see a doc invalidated from *outside* its own folder.
 #
 # A commit that changes both a folder's files and its doc satisfies C on its
 # own, so the stamp never needs bumping for well-formed work. Re-stamping is
@@ -213,14 +219,17 @@ check_graph() {
   folder_docs | while IFS= read -r doc; do
     d=$(dirname "$doc")
 
-    # Both halves matter. A missing block is obvious; a block that simply omits
-    # the key is not, and silence there is indistinguishable from "no
-    # dependencies" -- which is why declaring none is written `depends-on: []`
-    # rather than left out.
+    # Three ways this goes wrong, and every one of them has to be loud. A
+    # missing block is obvious, and a block omitting the key nearly so. The
+    # third is not: an unbracketed `depends-on: scenes` satisfies a bare key
+    # test, while declared_deps extracts nothing from it -- so the doc reads as
+    # having no dependencies, indistinguishable from a deliberate `[]`, and no
+    # BADDEP or DEPSTALE can ever fire for it. That is this check's own failure
+    # mode reproduced inside its parser, so the gate demands the bracket form.
     if ! sed -n '1p' "$doc" | grep -qx -- '---' \
-       || ! sed -n '2,/^---$/p' "$doc" | grep -q '^depends-on:'; then
+       || ! sed -n '2,/^---$/p' "$doc" | grep -q '^depends-on:[[:space:]]*\[.*\]'; then
       echo "NOFRONT     $doc"
-      echo "            no 'depends-on:' key in a frontmatter block on line 1"
+      echo "            no 'depends-on: [...]' key in a frontmatter block on line 1"
       continue
     fi
 

--- a/.claude/hooks/check-folder-docs.sh
+++ b/.claude/hooks/check-folder-docs.sh
@@ -177,8 +177,14 @@ check_verification() {
 # anything it depends on did. That is the drift nothing else catches: change the
 # navmesh settings in scenes/ and scenes/map/CLAUDE.md can silently stop being
 # true, because its own folder never moved.
+# Frontmatter body only: line 2 through the first closing `---`. NOT a
+# /^---$/,/^---$/ range — sed restarts a range at every later match, so a
+# markdown horizontal rule further down the file reopens it and any prose line
+# beginning `depends-on:` is read as a real edge. That is the self-reference
+# trap again, in a third form: a doc explaining this convention would be
+# misparsed by the parser it explains. Callers check line 1 is `---` first.
 declared_deps() {
-  sed -n '/^---$/,/^---$/p' "$1" \
+  sed -n '2,/^---$/p' "$1" \
     | sed -n 's/^depends-on:[[:space:]]*\[\(.*\)\].*/\1/p' \
     | tr ',' '\n' \
     | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \

--- a/.claude/hooks/check-folder-docs.sh
+++ b/.claude/hooks/check-folder-docs.sh
@@ -213,9 +213,14 @@ check_graph() {
   folder_docs | while IFS= read -r doc; do
     d=$(dirname "$doc")
 
-    if ! sed -n '1p' "$doc" | grep -qx -- '---'; then
+    # Both halves matter. A missing block is obvious; a block that simply omits
+    # the key is not, and silence there is indistinguishable from "no
+    # dependencies" -- which is why declaring none is written `depends-on: []`
+    # rather than left out.
+    if ! sed -n '1p' "$doc" | grep -qx -- '---' \
+       || ! sed -n '2,/^---$/p' "$doc" | grep -q '^depends-on:'; then
       echo "NOFRONT     $doc"
-      echo "            no 'depends-on:' frontmatter block on line 1"
+      echo "            no 'depends-on:' key in a frontmatter block on line 1"
       continue
     fi
 
@@ -270,6 +275,8 @@ problems=$(
   echo "DANGLING    add the row, or drop it if the folder is gone."
   echo "NOFRONT     add a frontmatter block on line 1 naming the folders this"
   echo "            doc's claims rest on:  ---\\ndepends-on: [scenes, assets]\\n---"
+  echo "            Declaring none is 'depends-on: []' — an explicit claim, not"
+  echo "            an omitted key, which nothing could tell from forgetting."
   echo "SELFDEP     drop the self-reference; a folder does not depend on itself."
   echo "BADDEP      the named folder has no CLAUDE.md — fix the name or add the doc."
   echo "DEPSTALE    a folder this doc depends on changed. Re-read this doc against"

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -6,7 +6,8 @@ on:
     branches: [main]
 
 jobs:
-  # Blocking gate on every PR: same-change + code map + verification stamps.
+  # Blocking gate on every PR: same-change + code map + verification stamps +
+  # dependency graph.
   docs-check:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ code and corrected what drifted.
 ### What is enforced, and what is not
 
 `.claude/hooks/check-folder-docs.sh` runs as a Stop hook locally and in CI on
-every PR (`docs-check` workflow). It runs three checks:
+every PR (`docs-check` workflow). It runs four checks:
 
 | Check | Catches |
 |-------|---------|
@@ -121,11 +121,24 @@ re-stamps. That makes blast radius a query rather than a guess: *what else must
 I read before this change is safe?* is answered by following the edges, and the
 answer is checked rather than remembered.
 
-Two limits worth knowing. Edges are declared by hand, so a missing one is
-invisible — the check verifies the edges you wrote, never the ones you forgot.
-And nested folders are deliberately not transitive: `scenes/` means files
+Three limits worth knowing.
+
+**Edges are declared by hand**, so a missing one is invisible — the check
+verifies the edges you wrote, never the ones you forgot.
+
+**Nested folders are deliberately not transitive:** `scenes/` means files
 directly in `scenes/`, not everything beneath it, or every change anywhere under
 `scenes/` would flag every doc depending on it and the signal would drown.
+
+**Only upstream *code* is watched, not the upstream doc** — and that is a real
+gap, because several edges here exist to cite prose that lives in a `CLAUDE.md`
+and in no `.gd` file at all: the physics-layer table, the navmesh gotchas.
+Correcting that prose will not flag the docs citing it. Watching upstream docs
+was rejected rather than missed: edges here are mutual (`scenes/` ↔
+`scenes/map/`), and clearing a flag means bumping a stamp, which edits a doc,
+which would flag the folder at the other end — an oscillation with no fixed
+point. Until a substantive doc edit can be told apart from a stamp bump,
+prose-only drift stays a human responsibility.
 
 `bash .claude/hooks/check-folder-docs.sh --audit` runs the history checks alone,
 against any checkout.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,15 @@ Rules:
 - **Creating a new folder with code in it → create a `CLAUDE.md` in that folder**, and add it to the code map above.
 - **Adding or changing code in an existing folder → update that folder's `CLAUDE.md` in the same commit** if the change affects anything the doc describes (or should describe).
 - Contents: what this folder's part of the game does, the key scenes/scripts and how they relate, signals emitted/consumed, dependencies on other folders (autoloads, other systems), the constraints this folder imposes on the rest of the project — `scenes/map/`'s single-file corridors bind encounter design — and any non-obvious decisions or gotchas.
+- **Every folder doc opens with a frontmatter block naming the folders its claims rest on**, which is the prose "Dependencies" section made machine-readable:
+
+  ```markdown
+  ---
+  depends-on: [scenes, assets]
+  ---
+  ```
+
+  Only this direction is stored. "What do I affect?" is its exact inverse, and keeping both would create two records that can disagree — see the `depends-on` graph below for what the edges are actually used for.
 - Keep them short and current — a stale doc is worse than none. Delete statements that no longer hold rather than appending corrections.
 - These folder docs are also what PR reviewers use to judge a change, so an out-of-date doc is a valid review finding.
 
@@ -97,6 +106,26 @@ every PR (`docs-check` workflow). It runs three checks:
 | same-change | Code changed in a folder without its doc changing; `project.godot` changed without the root doc changing |
 | code map | A code folder missing from the root's code map, or a map entry pointing at a doc that does not exist |
 | verification | A folder whose files changed since its `verified-against` stamp without the doc being touched — including history that predates these hooks, merge-conflict resolutions, and commits from anyone running without hooks |
+| dependency graph | A `depends-on` entry naming a folder with no doc, or naming itself — and the one this check exists for: a doc left unread after code it *depends on* changed |
+
+### The `depends-on` graph
+
+Every check above looks at a folder in isolation, so all of them miss the same
+thing: a doc going stale because something it *rests on* moved. Change the
+navmesh settings in `scenes/` and `scenes/map/CLAUDE.md` can quietly stop being
+true, while its own folder never changes and every check stays green.
+
+The frontmatter edges close that. When code changes directly in a folder, every
+doc declaring `depends-on` that folder is flagged until someone re-reads it and
+re-stamps. That makes blast radius a query rather than a guess: *what else must
+I read before this change is safe?* is answered by following the edges, and the
+answer is checked rather than remembered.
+
+Two limits worth knowing. Edges are declared by hand, so a missing one is
+invisible — the check verifies the edges you wrote, never the ones you forgot.
+And nested folders are deliberately not transitive: `scenes/` means files
+directly in `scenes/`, not everything beneath it, or every change anywhere under
+`scenes/` would flag every doc depending on it and the signal would drown.
 
 `bash .claude/hooks/check-folder-docs.sh --audit` runs the history checks alone,
 against any checkout.

--- a/assets/CLAUDE.md
+++ b/assets/CLAUDE.md
@@ -1,3 +1,7 @@
+---
+depends-on: []
+---
+
 # assets/
 
 Third-party CC0 3D assets, trimmed to what the game actually uses. Provenance and licensing for every file: `LICENSES.md` (update it with every addition — reviewers should reject asset PRs that don't).

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -1,3 +1,7 @@
+---
+depends-on: [scenes/map, scenes/hero]
+---
+
 # scenes/
 
 Top-level game scenes and their scripts.
@@ -67,4 +71,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `Maze`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 4a272d6 -->
+<!-- verified-against: 521d769 -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -1,3 +1,7 @@
+---
+depends-on: [scenes, assets]
+---
+
 # scenes/hero/
 
 The player-controlled hero (issue #5: movement; combat comes in issue #11).

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -1,3 +1,7 @@
+---
+depends-on: [scenes, assets]
+---
+
 # scenes/map/
 
 The playable map (issue #6). Replaces the 40×40 test arena that `main.tscn`


### PR DESCRIPTION
## Why

All three existing doc checks examine a folder in isolation, so all three miss
the same failure: a doc going stale because something it *rests on* moved.
Change the navmesh settings in `scenes/` and `scenes/map/CLAUDE.md` can quietly
stop being true — its own folder never changed, every check stays green.

That is also the answer to "which docs do I need to read before this change is
safe?", which is currently a guess made from prose `## Dependencies` sections
that nothing verifies.

## What this adds

Frontmatter on every folder doc naming the folders its claims rest on:

```markdown
---
depends-on: [scenes, assets]
---
```

and a fourth check in `check-folder-docs.sh` that uses it:

| Catches | |
|---|---|
| `BADDEP` | a `depends-on` entry naming a folder with no `CLAUDE.md` |
| `SELFDEP` | a doc depending on its own folder |
| `NOFRONT` | a folder doc with no frontmatter block |
| `DEPSTALE` | **the point of it** — a doc left unread after code it depends on changed |

## Two design decisions worth reviewing

**Only one direction is stored.** The original sketch had `depends-on` *and*
`affects`, validated against each other by a symmetry check. That was dropped:
`affects` is the exact inverse of `depends-on`, so storing both creates two
records that can disagree, and a symmetry check only proves the bookkeeping is
self-consistent — not that it matches reality. Same weakness as
`verified-against`, which proves an edit happened rather than that anything is
true. The check budget went to staleness propagation instead, which catches a
real failure rather than a clerical one.

**Nested folders are not transitive.** A git pathspec of `scenes` also matches
`scenes/map/` and `scenes/hero/`. The first version of the check therefore
reported `scenes/map/CLAUDE.md` as stale against commits that had only touched
`scenes/map/` itself. `direct_code_commits` filters to direct children, matching
the boundary the verification check already draws — the two must be kept in
step, which is noted in `.claude/hooks/CLAUDE.md`.

## It found real debt on its first run

`scenes/CLAUDE.md` was stale against two `scenes/map/maze.gd` commits
(`ad105f8`, `e578535`). Audited rather than rubber-stamped:

- Both commits changed only `maze.gd`'s `layout` docstring, about whether two
  agents can *pass* in a corridor.
- `scenes/CLAUDE.md`'s dependent claim is about waypoints landing in corner
  pockets — untouched, still true.
- Since a stamp is a claim about the whole doc, the rest was checked too against
  `main.gd`, `rts_camera.gd`, `main.tscn` and `project.godot`: startup order,
  the synchronous bake, `cell_height` 0.05 matching `default_cell_height`,
  `agent_radius` 1.0, camera offset `(0, 22.1, 14)` (a 57.6° pitch, documented
  as ~57°), `target` pointing at the hero, `move_command` present, and `built`
  emitted-but-unconsumed. All hold.

Stamp bumped to `521d769` on that basis.

## Testing

- `--audit` clean (exit 0) with all five docs carrying frontmatter.
- Negative tests, both fire correctly: an unknown folder in `depends-on` →
  `BADDEP`; a folder listing itself → `SELFDEP`.
- `bash -n` clean.

## Known limits, stated rather than discovered later

- **Edges are declared by hand, so a missing one is invisible.** The check
  verifies the edges you wrote, never the ones you forgot. This is the same
  ceiling every check here has: it confirms a claim was made, not that the claim
  is complete.
- **`DEPSTALE` can only say "re-read this", not "this is wrong."** A docstring
  change in an upstream folder flags every dependent doc even when nothing they
  say is affected — as happened here. The remedy is the intended one: read it,
  and re-stamp if it still holds.

- **Only upstream *code* is watched, not the upstream doc.** Several edges here
  exist to cite prose living in a `CLAUDE.md` and in no `.gd` file — the
  physics-layer table, the navmesh gotchas — so correcting that prose flags
  nobody. Raised in review; watching upstream docs was considered and rejected,
  because the edges here are mutual (`scenes/` ↔ `scenes/map/`) and clearing a
  flag means bumping a stamp, which edits a doc, which flags the other end. That
  oscillates with no fixed point. Tractable only once a substantive doc edit can
  be told apart from a stamp bump.

Part of the doc-graph work discussed in #29. Does not close #32 (linting the
Flowdex altitude rule), which is a separate mechanism.
