### PR TITLE
Hero basic attack and the RTS command scheme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,12 @@ Engine configuration (from `project.godot`):
 - Renderer: Forward Plus, Direct3D 12 driver on Windows
 - 3D physics engine: Jolt Physics
 - Display stretch: `canvas_items` mode with `expand` aspect
+- Two registries also live in that file and are **owned elsewhere**: the physics
+  layer names and the input action names. `scenes/CLAUDE.md` holds both — what
+  each layer means, and the inventory of actions with the folder that consumes
+  them. Reproducing either here would create exactly the second copy the
+  ownership rule exists to prevent, so when you add a layer or an action, that
+  is the doc to update.
 
 ### Code map
 

--- a/project.godot
+++ b/project.godot
@@ -22,9 +22,21 @@ window/stretch/aspect="expand"
 
 [input]
 
+attack_move={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)]
+}
+cancel_command={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":4194305,"physical_keycode":0,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)]
+}
 move_command={
 "deadzone": 0.5,
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"double_click":false,"factor":1.0,"button_index":2,"canceled":false,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"button_mask":0)]
+}
+select_command={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"double_click":false,"factor":1.0,"button_index":1,"canceled":false,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"button_mask":0)]
 }
 
 [layer_names]

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -91,7 +91,7 @@ inspector reads properly.
 | Layer | Used for | Who is on it | Who masks it |
 |-------|----------|--------------|--------------|
 | 1     | Ground/floor (ground-click rays collide with this only) | floor tiles | hero, zombies |
-| 2     | Walls & static obstacles (also what the hero's and the zombie's line-of-sight rays test) | wall pieces | hero, zombies |
+| 2     | Walls & static obstacles (also tested by both line-of-sight rays and by the hero's attack-targeting click, so neither sees through rock) | wall pieces | hero, zombies |
 | 3     | Hero | hero | zombies |
 | 4     | Enemies (also what the hero's attack-targeting ray tests) | zombies | *nobody* |
 

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -90,10 +90,20 @@ inspector reads properly.
 
 | Layer | Used for | Who is on it | Who masks it |
 |-------|----------|--------------|--------------|
-| 1     | Ground/floor (click-to-move rays collide with this only) | floor tiles | hero, zombies |
+| 1     | Ground/floor (ground-click rays collide with this only) | floor tiles | hero, zombies |
 | 2     | Walls & static obstacles (also what the zombie line-of-sight ray tests) | wall pieces | hero, zombies |
 | 3     | Hero | hero | zombies |
-| 4     | Enemies | zombies | *nobody* |
+| 4     | Enemies (also what the hero's attack-targeting ray tests) | zombies | *nobody* |
+
+**"Who masks it" is about bodies, not queries.** A `collision_mask` decides what
+a body is stopped by; a ray query carries its own mask and is stopped by
+nothing. Three of the four layers now have a ray consumer and no body masking
+them for that purpose, so the two columns answer different questions — read
+`nobody` in the last row as "nothing is *blocked* by enemies", which is what the
+paragraph below depends on. Ray consumers belong in the "Used for" column, and
+adding one is a change to this table even though no mask moved. That distinction
+is what a cross-review of PR #41 caught: the hero gained an attack-targeting ray
+against layer 4 while this row still read as though nothing touched it.
 
 The asymmetry in the last two rows is intentional: zombies are blocked by the
 hero, the hero is not blocked by zombies, and zombies do not collide with each

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -135,4 +135,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `Maze`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 46564b4 -->
+<!-- verified-against: afd6d73 -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -27,14 +27,23 @@ Top-level game scenes and their scripts.
 
 ## HUD
 
-A deliberately minimal `CanvasLayer` in `main.tscn`, driven by three lines of
-`main.gd` rather than its own scene — there is not enough UI yet to justify a
-`scenes/ui/` folder, and issue #7 needed the hero's HP to be *visible* to be
-testable at all. Split it out when the skill tree or XP bar arrives.
+A deliberately minimal `CanvasLayer` in `main.tscn`, driven by a handful of
+lines in `main.gd` rather than its own scene — issue #7 needed the hero's HP to
+be *visible* to be testable at all, and issue #11 needed the armed-attack state
+to be visible for the same reason.
 
 - `HUD/HealthBar` (`ProgressBar`, bottom-left) with a `Value` `Label` child
   showing `current / max`, fed by `Hero.health`'s `health_changed`.
 - `HUD/DeathLabel` — hidden until the hero dies.
+- `HUD/AttackMoveLabel` — shown while the attack command is armed (`A`
+  pressed, waiting for the click). A mode the player cannot see is a mode they
+  will forget they are in. Driven by `Hero.attack_move_armed_changed`.
+- `HUD/ControlsLabel` — static one-liner naming the two commands, bottom-right.
+  The web build is the project's front door and arrives with no instructions.
+
+**This has now outgrown living here**, which is what issue #36 addresses: it
+adds a unit info bar and creates `scenes/ui/` to hold all of it. Add UI there,
+not here.
 
 ## Death and restart
 
@@ -97,11 +106,17 @@ describes. See `scenes/enemies/CLAUDE.md`.
 - Instances `scenes/map/maze.tscn` and `scenes/hero/hero.tscn` from the .tscn,
   and `scenes/enemies/zombie.tscn` at runtime; the camera's `target` export
   points at the hero.
-- Input action `move_command` (right mouse button) is defined in
-  `project.godot` and consumed by the hero, not by anything in this folder.
+- **Input actions** are defined in `project.godot` and every one of them is
+  consumed by `scenes/hero/`, not by anything in this folder. What each *means*
+  is that folder's to document; this is only the inventory:
+  `move_command` (right mouse), `select_command` (left mouse),
+  `attack_move` (`A`), `cancel_command` (`Escape`).
 - `Maze` emits `built`; nothing consumes it yet.
-- `main.gd` consumes `Hero.died` and `Hero.health.health_changed`.
-  `Zombie.died` is unconsumed — it is the XP hook for issue #8.
+- `main.gd` consumes `Hero.died`, `Hero.health.health_changed` and
+  `Hero.attack_move_armed_changed`. Unconsumed so far: `Hero.move_ordered` and
+  `Hero.attack_ordered` (for the selection UI, issue #36), and both death
+  signals — `Zombie.died` and the hero's attributed `Hero.killed`, which are
+  the XP hooks for issue #8.
 
 ## Tooling note
 

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -135,4 +135,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `Maze`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: afd6d73 -->
+<!-- verified-against: 362d9a2 -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -91,7 +91,7 @@ inspector reads properly.
 | Layer | Used for | Who is on it | Who masks it |
 |-------|----------|--------------|--------------|
 | 1     | Ground/floor (ground-click rays collide with this only) | floor tiles | hero, zombies |
-| 2     | Walls & static obstacles (also what the zombie line-of-sight ray tests) | wall pieces | hero, zombies |
+| 2     | Walls & static obstacles (also what the hero's and the zombie's line-of-sight rays test) | wall pieces | hero, zombies |
 | 3     | Hero | hero | zombies |
 | 4     | Enemies (also what the hero's attack-targeting ray tests) | zombies | *nobody* |
 

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -135,4 +135,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `Maze`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 362d9a2 -->
+<!-- verified-against: 0fc132f -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -125,4 +125,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `Maze`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 8a4044b -->
+<!-- verified-against: 46564b4 -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -9,7 +9,8 @@ Hostile actors. Currently just the basic zombie (issue #7).
 - `zombie.tscn` — `CharacterBody3D`, collision layer 4 (enemies), mask 1|2|3.
   Placeholder green capsule + facing "nose" under a `Visual` node, a
   `CollisionShape3D`, a `NavigationAgent3D`, and a `Health` child (30 HP). In
-  the `enemies` group.
+  the `enemies` group — that is how the hero finds and targets it, so don't
+  rename it: `scenes/hero/` looks enemies up by group, never by class.
 - `zombie.gd` (`class_name Zombie`) — roam / notice / chase / melee AI.
 
 ## The four radii
@@ -70,7 +71,24 @@ from where the map author placed them.
   the mask is the half that changes behaviour.
 
 `take_damage()` aggroes regardless of range, sight or leash — otherwise the
-hero could whittle a zombie down from outside its detection radius.
+hero could whittle a zombie down from outside its detection radius. It also
+flashes the body (see the gotcha below) and resets the regen timer.
+
+## Regeneration
+
+`regen_delay` (6 s) then `regen_per_second` (3.0) — a 30 HP zombie is whole
+again ten seconds after the last hit lands.
+
+Two conditions gate it, and they close different escapes:
+
+- The **timer** stops a zombie healing between the hero's swings.
+- The **state check** — only `ROAM` and `RETURN` — stops one healing while it
+  is chasing. A fight the player is slowly winning must not turn into one they
+  cannot win at all, and a zombie that heals mid-chase does exactly that.
+
+Together they mean the only way to undo damage is to actually break away. That
+is what closes the chip-and-retreat exploit `leash_radius` would otherwise hand
+the hero, now that he can deal damage at all (issue #11).
 
 ## Gotchas
 
@@ -89,9 +107,20 @@ hero could whittle a zombie down from outside its detection radius.
   it and zombies detect the hero through solid rock, then appear round a corner
   for no visible reason.
 - **Wander targets are clamped with `NavigationServer3D.map_get_closest_point`**,
-  the same way `Hero.command_move_to` clamps a click — a random point that lands
+  the same way every `Hero` order clamps its destination — a random point that lands
   inside rock becomes the nearest reachable spot instead of a path request that
   resolves to nothing.
+- **The hit flash needs its own material, and `_ready()` duplicates one.** The
+  body material is a sub-resource of `zombie.tscn`, and Godot shares a scene's
+  sub-resources across every instance of it — tinting one zombie would tint the
+  whole horde. `_claim_own_material()` duplicates it per instance. Done in code
+  rather than by ticking `resource_local_to_scene` on the resource: an editor
+  round-trip can quietly clear a flag, and nothing would fail until someone
+  noticed the entire map flashing at once. Anything else that animates a
+  material on this scene has the same problem.
+- **The flash fires *before* the damage is applied.** A killing blow runs
+  `_on_health_died()` synchronously inside `Health.take_damage()`, so a flash
+  started afterwards would be repainting a corpse.
 - **Zombies don't collide with each other** (mask omits layer 4). They *are*
   blocked by the world and by the hero, but the hero (mask 1|2) is never blocked
   by them. Zombies that collide jam solid in a one-cell corridor, and a hero who
@@ -104,8 +133,14 @@ hero could whittle a zombie down from outside its detection radius.
 - Finds the hero via `get_tree().get_first_node_in_group("hero")` — no scene
   path, so a zombie works in any scene that has a hero and a baked navmesh.
 - Calls `Hero.take_damage()`; reads `Hero.is_dead()` to stop hitting a corpse.
+- **Is damaged by the hero through the same two methods, in reverse.**
+  `scenes/hero/` calls `take_damage()` and reads `is_dead()` on whatever is in
+  the `enemies` group, without ever naming `Zombie`. So the pair of methods and
+  the group name are a two-way contract; changing either signature breaks a
+  folder that does not mention this one.
 - Emits `died(zombie)`. Nothing consumes it yet — it is the hook for XP
-  (issue #8).
+  (issue #8). Note the hero emits its own `killed(victim)` from the swing that
+  lands the blow, which is the *attributed* version of the same moment.
 - Spawned by `scenes/main.gd` at the `Z` cells of `scenes/map/maze.gd`; the
   spawner sets `position` *before* `add_child`, because `_ready()` captures
   `global_position` as home.

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -152,4 +152,4 @@ the hero, now that he can deal damage at all (issue #11).
 - Still a placeholder capsule. The Quaternius zombie models in
   `assets/characters/zombies/` are imported but unused, matching the hero.
 
-<!-- verified-against: 362d9a2 -->
+<!-- verified-against: 0fc132f -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -147,4 +147,4 @@ the hero, now that he can deal damage at all (issue #11).
 - Still a placeholder capsule. The Quaternius zombie models in
   `assets/characters/zombies/` are imported but unused, matching the hero.
 
-<!-- verified-against: 8a4044b -->
+<!-- verified-against: 46564b4 -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -149,4 +149,4 @@ the hero, now that he can deal damage at all (issue #11).
 - Still a placeholder capsule. The Quaternius zombie models in
   `assets/characters/zombies/` are imported but unused, matching the hero.
 
-<!-- verified-against: 46564b4 -->
+<!-- verified-against: afd6d73 -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -152,4 +152,4 @@ the hero, now that he can deal damage at all (issue #11).
 - Still a placeholder capsule. The Quaternius zombie models in
   `assets/characters/zombies/` are imported but unused, matching the hero.
 
-<!-- verified-against: afd6d73 -->
+<!-- verified-against: 362d9a2 -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -107,7 +107,10 @@ the hero, now that he can deal damage at all (issue #11).
   middle of the maze. Don't remove the await.
 - **Line of sight is a chest-to-chest ray against layer 2 only** (walls). Drop
   it and zombies detect the hero through solid rock, then appear round a corner
-  for no visible reason.
+  for no visible reason. `scenes/hero/` now casts the mirror image of this ray
+  for his own automatic acquisition, at the same eye height on purpose — if the
+  two heights ever diverge, one side sees through cover the other treats as
+  solid, and a fight starts that only one participant can explain.
 - **Wander targets are clamped with `NavigationServer3D.map_get_closest_point`**,
   the same way every `Hero` order clamps its destination — a random point that lands
   inside rock becomes the nearest reachable spot instead of a path request that

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -76,8 +76,10 @@ flashes the body (see the gotcha below) and resets the regen timer.
 
 ## Regeneration
 
-`regen_delay` (6 s) then `regen_per_second` (3.0) — a 30 HP zombie is whole
-again ten seconds after the last hit lands.
+`regen_delay` (6 s) with no damage taken, then `regen_per_second` (3.0) until
+full. A 30 HP zombie is therefore whole again about ten seconds after a single
+hero swing, but nearer sixteen if it was left on the brink — the delay dominates
+only for light damage.
 
 Two conditions gate it, and they close different escapes:
 

--- a/scenes/enemies/zombie.gd
+++ b/scenes/enemies/zombie.gd
@@ -61,6 +61,12 @@ const HERO_GROUP := "hero"
 ## How long the corpse lies there before it sinks and frees itself.
 const CORPSE_LINGER := 2.0
 
+## Damage feedback: the body washes out for a moment, then fades back. Short on
+## purpose — long enough to read at a glance, short enough that a zombie taking
+## hits on a 0.9 s cooldown is not permanently pink.
+const HIT_FLASH_TIME := 0.12
+const HIT_FLASH_COLOUR := Color(1.0, 0.88, 0.88)
+
 @export_group("Roaming")
 ## Radius of the patch this zombie wanders while idle, centred on its spawn.
 @export var roam_radius := 6.0
@@ -87,6 +93,11 @@ const CORPSE_LINGER := 2.0
 @export var attack_damage := 9.0
 @export var attack_cooldown := 1.3
 
+@export_group("Regeneration")
+## Seconds without taking damage before health starts coming back.
+@export var regen_delay := 6.0
+@export var regen_per_second := 3.0
+
 var _state: State = State.ROAM
 var _home := Vector3.ZERO
 var _hero: Hero = null
@@ -94,11 +105,16 @@ var _sense_timer := 0.0
 var _roam_pause := 0.0
 var _alert_timer := 0.0
 var _attack_timer := 0.0
+var _regen_timer := 0.0
 var _gravity: float = ProjectSettings.get_setting("physics/3d/default_gravity")
+var _body_material: StandardMaterial3D = null
+var _base_albedo := Color.WHITE
+var _flash_tween: Tween = null
 
 @onready var health: Health = $Health
 @onready var _nav_agent: NavigationAgent3D = $NavigationAgent3D
 @onready var _visual: Node3D = $Visual
+@onready var _body_mesh: MeshInstance3D = $Visual/BodyMesh
 
 
 func _ready() -> void:
@@ -106,6 +122,7 @@ func _ready() -> void:
 	# an encounter simply by putting a spawn marker on a cell.
 	_home = global_position
 	health.died.connect(_on_health_died)
+	_claim_own_material()
 	# Stagger the sense ticks so a room full of zombies does not raycast on the
 	# same frame, and so they never move in lockstep.
 	_sense_timer = randf() * SENSE_INTERVAL
@@ -131,6 +148,11 @@ func is_dead() -> bool:
 func take_damage(amount: float) -> void:
 	if is_dead():
 		return
+	_regen_timer = regen_delay
+	# Flash before applying the damage, not after: a killing blow runs
+	# _on_health_died() synchronously inside take_damage(), and a flash started
+	# after that would be repainting a corpse.
+	_flash_hit()
 	health.take_damage(amount)
 	# Being hit aggroes regardless of range, sight or leash — otherwise the
 	# hero could whittle a zombie down from outside its detection radius.
@@ -156,6 +178,7 @@ func _physics_process(delta: float) -> void:
 		velocity.y = 0.0
 
 	_attack_timer = maxf(_attack_timer - delta, 0.0)
+	_tick_regen(delta)
 
 	_sense_timer -= delta
 	if _sense_timer <= 0.0:
@@ -240,6 +263,53 @@ func _process_attack(delta: float) -> void:
 		return
 	_attack_timer = attack_cooldown
 	hero.take_damage(attack_damage)
+
+
+## Out-of-combat regeneration.
+##
+## Two conditions, and they cover different escapes. The timer stops a zombie
+## healing between the hero's swings. The state check stops one healing while it
+## is chasing him — a fight the player is slowly winning must not turn into one
+## they cannot win at all, and a zombie that heals mid-chase does exactly that.
+## Together they mean the only way to undo damage is to actually break away,
+## which is what closes the chip-and-retreat exploit the leash would otherwise
+## hand the hero.
+func _tick_regen(delta: float) -> void:
+	_regen_timer = maxf(_regen_timer - delta, 0.0)
+	if _regen_timer > 0.0:
+		return
+	if not (_state == State.ROAM or _state == State.RETURN):
+		return
+	if health.current >= health.max_health:
+		return
+	health.heal(regen_per_second * delta)
+
+
+## Give this zombie its own copy of the body material.
+##
+## The material is a sub-resource of zombie.tscn, and Godot shares a scene's
+## sub-resources across every instance of it — so tinting one zombie would tint
+## the entire horde. Duplicating in code rather than ticking
+## resource_local_to_scene on the resource: an editor round-trip can quietly
+## clear a flag, and nothing would fail until someone noticed the whole map
+## flashing at once.
+func _claim_own_material() -> void:
+	var material := _body_mesh.get_surface_override_material(0) as StandardMaterial3D
+	if material == null:
+		return
+	_body_material = material.duplicate()
+	_body_mesh.set_surface_override_material(0, _body_material)
+	_base_albedo = _body_material.albedo_color
+
+
+func _flash_hit() -> void:
+	if _body_material == null:
+		return
+	if _flash_tween != null and _flash_tween.is_valid():
+		_flash_tween.kill()
+	_body_material.albedo_color = HIT_FLASH_COLOUR
+	_flash_tween = create_tween()
+	_flash_tween.tween_property(_body_material, "albedo_color", _base_albedo, HIT_FLASH_TIME)
 
 
 func _enter_roam() -> void:

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -32,7 +32,10 @@ the control model the whole game is styled after. Actions are in
 | Right-click (`move_command`) | attack it | move there |
 | `A` then left-click (`attack_move` + `select_command`) | attack it | attack-move there |
 | Left-click alone (`select_command`) | *selection — issue #36* | *selection — issue #36* |
-| `Escape` (`cancel_command`) | disarms `A` | disarms `A` |
+| `A` again, or `Escape` (`cancel_command`) | disarms `A` | disarms `A` |
+
+`A` toggles rather than latching, and a right-click also disarms it, so there
+are three ways out of the armed state and none of them requires knowing which.
 
 **Left-click is deliberately never an attack.** An RTS where inspecting a unit
 also swings at it is unusable, so the button is reserved for selection even
@@ -128,9 +131,22 @@ numbers.
   (`NavigationServer3D.map_get_closest_point`), so an off-level click means
   "walk as far that way as you can". Don't reintroduce an early-out that drops
   a click.
-- **Enemies and ground are two separate ray queries, not one 1|8 mask.** A
-  single ray returns whichever surface is nearer, and the floor under a
-  zombie's feet sometimes wins.
+- **A click fires two rays, and they disagree about walls on purpose.** The
+  ground ray ignores them, so clicking a wall means the floor behind it (issue
+  #5). The enemy ray includes them, so clicking a wall never means the zombie
+  behind it. One combined query cannot hold both rules, and the floor under a
+  zombie's feet would sometimes win it anyway.
+- **The enemy ray was not always occlusion-aware, and the bug it caused is the
+  one to remember.** Masked on enemies alone it tunnelled straight through
+  rock: clicking a wall with a zombie behind it issued an *attack order* on a
+  zombie the player had never seen, and the hero walked off to fight it. Note
+  this is the mirror image of the click-slack rationale below — that one worries
+  about rejecting a visible enemy, this one silently accepted an invisible one,
+  and the doc claimed the first covered the second. Cross-review caught it.
+  It is not a general occlusion solve: rock caps carry no collider by design
+  (`scenes/map/CLAUDE.md`), so what stops the ray is the wall pieces bounding
+  the rock, which sit on every rock/floor boundary at full height. A ray
+  threading the corner gap where two meet would still get through.
 - **`CLICK_SLACK` (1.6) is a click-target grace radius.** A 0.4-radius capsule
   seen down a ~57° camera is small, and an attack order that quietly becomes a
   move order *into* a pack is the worst way to miss. If the enemy ray misses,

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -125,6 +125,15 @@ is to die on purpose, which is a miserable way to use a checkpoint.
   contract, which is why `scenes/enemies` is declared in the frontmatter above.
   A missing edge would be invisible; renaming the group would break the hero
   with nothing to catch it.
+- **Every range test measures horizontally**, through one helper, so the repath
+  check and the swing check cannot disagree at the boundary — a hero that
+  counted the height difference in one and not the other would repath and swing
+  on alternate ticks. The floor is flat today, so nothing would show it; the
+  first ramp would.
+- **The attack-targeting ray is a new consumer of physics layer 4**, which no
+  *body* masks. See the table in `scenes/CLAUDE.md`: a query mask and a body's
+  `collision_mask` answer different questions, and only the first one applies
+  here.
 - **A target that finishes its path while still out of reach is not dropped.**
   The hero stands and faces it instead. Giving up would re-acquire the same
   target on the next tick and flap; the player can always issue another order.

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -101,6 +101,20 @@ never regenerates mid-fight. It exists for issue #38: without it, clearing a
 fight at low health makes the next one unwinnable and the only remaining move
 is to die on purpose, which is a miserable way to use a checkpoint.
 
+**The gate is time only, where the zombie's is time *and* state.** That
+asymmetry is deliberate, not an oversight — cross-review raised it. A chasing
+zombie is in an ongoing fight it is losing, so healing mid-chase would undo
+damage the player already landed. A hero walking toward a target that has not
+noticed him is not in a fight at all, and the clock runs on him exactly as it
+would if he stood still for the same seconds. Note this is reachable today, not
+just in theory: an attack order has no range limit, so a long approach across
+the map easily outlasts `regen_delay`.
+
+What would change the answer is a stat that makes the *approach* part of the
+fight — a ranged attacker, or anything that lets an enemy hurt him on the way
+in. Issue #9 should re-read this paragraph before it starts moving these
+numbers.
+
 ## Picking things out of the world
 
 - The ground ray collides only with physics layer 1, so clicking a wall moves

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -1,15 +1,15 @@
 ---
-depends-on: [scenes, assets]
+depends-on: [scenes, scenes/components, scenes/enemies, assets]
 ---
 
 # scenes/hero/
 
 The player-controlled hero (issue #5: movement; issue #7: taking damage and
-dying; his own attack comes in issue #11).
+dying; issue #11: his own attack).
 
 - `hero.tscn` — `CharacterBody3D` (collision layer 3, mask 1|2 — see the
-  layer table in `scenes/CLAUDE.md`) with a
-  placeholder capsule + a small "nose" box marking the facing direction, a
+  layer table in `scenes/CLAUDE.md`) with a placeholder capsule + a small
+  "nose" box marking the facing direction **under a `Visual` node**, a
   `CollisionShape3D`, a `NavigationAgent3D`, and a `Health` child (100 HP,
   `scenes/components/`). In the `hero` group — that is how zombies find him,
   so don't rename it. The KayKit Knight is already in the repo
@@ -17,54 +17,141 @@ dying; his own attack comes in issue #11).
   capsule for it is outstanding work, not a pending dependency. The node
   forward direction is -Z (Godot convention) so the rigged model drops in
   without a compensating rotation.
-- `hero.gd` (`class_name Hero`) — click-to-move controller.
-  - **Input decision (documented per issue #5):** *right*-click issues the
-    move command (RTS convention); left-click is reserved for
-    targeting/attacks (issue #11). The action is `move_command` in
-    `project.godot`.
-  - The click ray collides only with physics layer 1 (ground), so clicking a
-    wall moves the hero to the floor at/behind that point instead of trying
-    to climb it.
-  - **Every click produces a move order.** The raycast alone silently dropped
-    clicks that hit no ground collider (dark background, past the level edge,
-    above a wall) — which read in play as "my second click was ignored", since
-    the hero just kept walking to its previous destination. `_ground_point_at`
-    therefore falls back to intersecting the camera ray with the hero's ground
-    plane, and `command_move_to` clamps the result onto the navigation map
-    (`NavigationServer3D.map_get_closest_point`), so an off-level click means
-    "walk as far that way as you can". Don't reintroduce an early-out that
-    drops a click.
-  - The handler uses the *event's* `position`, not
-    `get_viewport().get_mouse_position()` — the two can differ by the time the
-    event is handled, and it keeps the path drivable from headless tests.
-  - `command_move_to(world_point)` is the public move-order API — future AI,
-    skills, or tests should call this rather than poking the NavigationAgent.
-    It cancels the previous order outright: the agent repaths, and horizontal
-    velocity is zeroed so the hero can't coast another frame along the
-    abandoned heading. Emits `move_ordered(world_point)` with the clamped
-    point.
-  - Movement: standard `NavigationAgent3D` loop in `_physics_process` +
-    `move_and_slide()`, simple gravity, `lerp_angle` turning toward the
-    movement direction.
-  - **Damage and death (issue #7).** `take_damage(amount)` forwards to the
-    `Health` child — attackers call this and never touch the component, which
-    leaves room for armour or hit reactions later. On `Health.died` the hero
-    sets `_dead`, stops, and emits `died`; while dead he ignores input and
-    holds position (gravity still runs). `is_dead()` is public so a zombie
-    stops swinging at a corpse. `scenes/main.gd` listens for `died` and
-    restarts the run.
+  - The meshes sit under `Visual` (matching `zombie.tscn`) so the swing
+    animation can move the art without moving the collider or the nav agent.
+- `hero.gd` (`class_name Hero`) — command controller and basic attack.
+
+## Commands
+
+The scheme is StarCraft/Warcraft's **smart command**, chosen because that is
+the control model the whole game is styled after. Actions are in
+`project.godot`; `scenes/CLAUDE.md` lists them.
+
+| Input | On an enemy | On the ground |
+|-------|-------------|---------------|
+| Right-click (`move_command`) | attack it | move there |
+| `A` then left-click (`attack_move` + `select_command`) | attack it | attack-move there |
+| Left-click alone (`select_command`) | *selection — issue #36* | *selection — issue #36* |
+| `Escape` (`cancel_command`) | disarms `A` | disarms `A` |
+
+**Left-click is deliberately never an attack.** An RTS where inspecting a unit
+also swings at it is unusable, so the button is reserved for selection even
+though nothing consumes a bare left-click yet. `A` borrows it for exactly one
+click and hands it straight back.
+
+Public order API — future AI, skills and tests should call these rather than
+poking the `NavigationAgent3D`: `command_move_to(point)`,
+`command_attack(target)`, `command_attack_move(point)`, `command_stop()`.
+Each cancels the previous order outright: the agent repaths and horizontal
+velocity is zeroed so the hero can't coast a frame along the abandoned heading.
+
+## Which orders acquire targets
+
+Four orders (`IDLE`, `MOVE`, `ATTACK_TARGET`, `ATTACK_MOVE`), and the only
+interesting question is which of them pick up a target on their own. Every
+answer is a decision:
+
+- **`MOVE` does not.** A move order runs the gauntlet untouched. This is what
+  makes "sprint past the encounter" a real choice rather than a bug — worth
+  protecting, because the hero outruns every zombie (6.0 against a 3.4 chase)
+  and gating that would need a design answer, not a speed tweak.
+- **`ATTACK_MOVE` does.** That is the entire difference between it and `MOVE`.
+  The destination survives the fight: `_finish_engagement()` resumes it once
+  the target dies.
+- **`IDLE` does.** A hero standing still defends himself. This also removes the
+  need for a separate retaliate-when-hit rule — nothing can reach him from
+  outside `acquire_radius` in the first place.
+
+Acquisition and repathing run on a 0.2 s tick (`RETARGET_INTERVAL`), matching
+the sensing budget in `scenes/enemies/`. Only the cooldown, gravity and
+movement need per-frame precision.
+
+## Stats
+
+All exports, not constants, because the skill tree (issue #9) will want to
+modify them and a `const` is not a seam. There is deliberately **no stat or
+modifier system yet** — that is issue #9's job, and inventing one here would
+prejudge it.
+
+| Export | Default | Note |
+|--------|---------|------|
+| `move_speed` | 6.0 | Faster than any zombie, on purpose |
+| `attack_range` | 2.2 | Slightly out-reaches the zombie's 2.0 |
+| `attack_damage` | 12.0 | 3 swings kill a 30 HP zombie |
+| `attack_cooldown` | 0.9 | Attack speed, expressed as the zombie's is |
+| `acquire_radius` | 9.0 | Under the zombie's 12 detection: he is noticed first |
+| `regen_delay` / `regen_per_second` | 5.0 / 4.0 | See below |
+
+Measured 1v1 against one zombie: ~18 HP lost per kill, ~6 s of fighting.
+
+**Out-of-combat regeneration** starts `regen_delay` after the last combat
+event, where *both* taking a hit and landing one count — a hero trading blows
+never regenerates mid-fight. It exists for issue #38: without it, clearing a
+fight at low health makes the next one unwinnable and the only remaining move
+is to die on purpose, which is a miserable way to use a checkpoint.
+
+## Picking things out of the world
+
+- The ground ray collides only with physics layer 1, so clicking a wall moves
+  the hero to the floor at/behind that point instead of trying to climb it.
+- **Every click produces an order.** The raycast alone silently dropped clicks
+  that hit no ground collider (dark background, past the level edge, above a
+  wall) — which read in play as "my second click was ignored", since the hero
+  just kept walking to its previous destination. `_ground_point_at` therefore
+  falls back to intersecting the camera ray with the hero's ground plane, and
+  the order clamps the result onto the navigation map
+  (`NavigationServer3D.map_get_closest_point`), so an off-level click means
+  "walk as far that way as you can". Don't reintroduce an early-out that drops
+  a click.
+- **Enemies and ground are two separate ray queries, not one 1|8 mask.** A
+  single ray returns whichever surface is nearer, and the floor under a
+  zombie's feet sometimes wins.
+- **`CLICK_SLACK` (1.6) is a click-target grace radius.** A 0.4-radius capsule
+  seen down a ~57° camera is small, and an attack order that quietly becomes a
+  move order *into* a pack is the worst way to miss. If the enemy ray misses,
+  the nearest living enemy within 1.6 units of the clicked ground point is
+  taken instead. Keep it under half a cell (2.0) or clicking the floor beside a
+  zombie stops meaning the floor.
+- The handler uses the *event's* `position`, not
+  `get_viewport().get_mouse_position()` — the two can differ by the time the
+  event is handled, and it keeps the path drivable from headless tests.
+
+## Gotchas
+
+- **`hero.gd` never names an enemy class.** Targets are found through the
+  `enemies` group and used through `take_damage()` / `is_dead()`. There is no
+  compile-time dependency on `scenes/enemies/`, so a second enemy type needs no
+  change here — but the group name and those two methods are a real runtime
+  contract, which is why `scenes/enemies` is declared in the frontmatter above.
+  A missing edge would be invisible; renaming the group would break the hero
+  with nothing to catch it.
+- **A target that finishes its path while still out of reach is not dropped.**
+  The hero stands and faces it instead. Giving up would re-acquire the same
+  target on the next tick and flap; the player can always issue another order.
+  Only reachable through a navmesh clamp that lands the goal somewhere
+  unreachable, so it is rare rather than fixed.
+- **Damage and death (issue #7).** `take_damage(amount)` forwards to the
+  `Health` child — attackers call this and never touch the component, which
+  leaves room for armour or hit reactions later. On `Health.died` the hero sets
+  `_dead`, drops every order, and emits `died`; while dead he ignores input and
+  holds position (gravity still runs). `is_dead()` is public so a zombie stops
+  swinging at a corpse.
 
 ## Dependencies
 
 - Requires a baked navmesh in the scene it's placed in (`scenes/main.gd`
   bakes at runtime) and a current `Camera3D` for the click raycast. The
-  navmesh clamp in `command_move_to` reads `get_world_3d().navigation_map`,
-  so orders issued before the first bake resolve to the hero's own position.
-- Emits `move_ordered(world_point: Vector3)`; nothing consumes it yet (it
-  exists for movement/attack-cancel wiring in issue #11). Emits `died`, which
-  `scenes/main.gd` consumes. Consumes `Health.died` from its own child; XP
-  signals arrive with issue #8.
-- Damaged by `scenes/enemies/zombie.gd`, which finds him through the `hero`
-  group.
+  navmesh clamp reads `get_world_3d().navigation_map`, so orders issued before
+  the first bake resolve to the hero's own position.
+- Emits `move_ordered(world_point)` (move *and* attack-move) and
+  `attack_ordered(target)` — neither is consumed yet; they exist for the
+  selection UI in issue #36. Emits `killed(victim)`, the XP hook for issue #8,
+  fired from the swing that lands the killing blow so attribution is exact
+  rather than "something died". Emits `attack_move_armed_changed(armed)`, which
+  `scenes/main.gd` consumes to show the armed-attack indicator, and `died`,
+  which `scenes/main.gd` consumes to restart the run. Consumes `Health.died`
+  from its own child.
+- Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
+  the `hero` group.
 
 <!-- verified-against: 8a4044b -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -154,4 +154,4 @@ is to die on purpose, which is a miserable way to use a checkpoint.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: 8a4044b -->
+<!-- verified-against: 46564b4 -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -62,6 +62,17 @@ answer is a decision:
   need for a separate retaliate-when-hit rule — nothing can reach him from
   outside `acquire_radius` in the first place.
 
+**Automatic acquisition requires line of sight; clicking does not.** Both are
+deliberate and they are not the same question. A raycast against walls stops the
+hero picking up a target through solid rock and walking off to fight something
+the player never saw — the complaint `scenes/enemies/` records in reverse, and
+worse here, because this is the unit the player is meant to be commanding. The
+click paths skip the check because the player can only click what is already
+drawn on screen; a second opinion from a raycast could only reject clicks that
+were visibly valid. Note the consequence that *is* kept: once a target is
+acquired in sight, the hero will pursue it around a corner. That is ordinary RTS
+behaviour and the player can always issue another order.
+
 Acquisition and repathing run on a 0.2 s tick (`RETARGET_INTERVAL`), matching
 the sensing budget in `scenes/enemies/`. Only the cooldown, gravity and
 movement need per-frame precision.
@@ -125,15 +136,18 @@ is to die on purpose, which is a miserable way to use a checkpoint.
   contract, which is why `scenes/enemies` is declared in the frontmatter above.
   A missing edge would be invisible; renaming the group would break the hero
   with nothing to catch it.
-- **Every range test measures horizontally**, through one helper, so the repath
-  check and the swing check cannot disagree at the boundary — a hero that
-  counted the height difference in one and not the other would repath and swing
-  on alternate ticks. The floor is flat today, so nothing would show it; the
-  first ramp would.
-- **The attack-targeting ray is a new consumer of physics layer 4**, which no
-  *body* masks. See the table in `scenes/CLAUDE.md`: a query mask and a body's
-  `collision_mask` answer different questions, and only the first one applies
-  here.
+- **Every range test measures horizontally, through `_horizontal_distance_to`.**
+  Both the repath check and the swing check call it, so they are one code path
+  and cannot disagree at the boundary — a hero counting the height difference in
+  one and not the other would repath and swing on alternate ticks. The floor is
+  flat today, so nothing would show it; the first ramp would. Cross-review
+  caught the first attempt at this: the two computations *matched* but were
+  written twice, so the guarantee this doc claimed did not actually exist. If
+  you add a third range test, route it through the helper too.
+- **The hero uses two ray masks of his own**, and both are new consumers of
+  layers no *body* of his masks: layer 4 for attack targeting and layer 2 for
+  line of sight. See the table in `scenes/CLAUDE.md` — a query mask and a body's
+  `collision_mask` answer different questions, and only the first applies here.
 - **A target that finishes its path while still out of reach is not dropped.**
   The hero stands and faces it instead. Giving up would re-acquire the same
   target on the next tick and flap; the player can always issue another order.

--- a/scenes/hero/hero.gd
+++ b/scenes/hero/hero.gd
@@ -330,7 +330,7 @@ func _reassess() -> void:
 				return
 			# Repath only while out of reach. Repathing inside attack range
 			# would fight the "stand still and swing" branch every tick.
-			if global_position.distance_to(_target.global_position) > attack_range:
+			if _horizontal_distance_to(_target.global_position) > attack_range:
 				_nav_agent.target_position = _on_navmesh(_target.global_position)
 
 		Order.MOVE:
@@ -444,6 +444,18 @@ func _travel(delta: float, speed: float) -> void:
 	velocity.z = direction.z * speed
 	move_and_slide()
 	_face(direction, delta)
+
+
+## Every range test in this script measures horizontally, and they must all
+## agree. `_reassess()` decides whether to repath and `_process_attack()`
+## decides whether to swing, both against `attack_range`; if one of them counted
+## the height difference and the other did not, they would disagree at the
+## boundary and the hero would repath and swing in alternate ticks. Flat floors
+## hide that today — the first ramp or ledge would not.
+func _horizontal_distance_to(point: Vector3) -> float:
+	var offset := point - global_position
+	offset.y = 0.0
+	return offset.length()
 
 
 ## Hold position but keep stepping the body, so gravity still settles it.

--- a/scenes/hero/hero.gd
+++ b/scenes/hero/hero.gd
@@ -72,6 +72,15 @@ const GROUND_MASK := 1
 const ENEMY_MASK := 8
 const RAY_LENGTH := 1000.0
 
+## Walls and static obstacles (physics layer 2) — the same blocker mask
+## scenes/enemies/ tests its own line of sight against.
+const SIGHT_BLOCKER_MASK := 2
+
+## Roughly chest height on the 1.8-unit capsule. Matches the zombie's so both
+## sight rays agree about what "can see" means; a mismatch would let one side
+## see through cover the other treats as solid.
+const EYE_HEIGHT := 1.2
+
 const ENEMY_GROUP := "enemies"
 
 ## How far from the clicked ground point an enemy still counts as clicked.
@@ -320,7 +329,7 @@ func _reassess() -> void:
 		# _finish_engagement()'s job: an attack-move keeps its destination and
 		# carries on, an idle hero simply stands down again.
 		Order.IDLE, Order.ATTACK_MOVE:
-			var found := _nearest_enemy_to(global_position, acquire_radius)
+			var found := _nearest_enemy_to(global_position, acquire_radius, true)
 			if found != null:
 				_engage(found)
 
@@ -370,9 +379,12 @@ func _process_attack(delta: float) -> void:
 		_halt()
 		return
 
+	# `to_target` is the facing direction only. The range test goes through the
+	# shared helper, so this check and the repath check in _reassess() are one
+	# code path rather than two that happen to agree today.
 	var to_target := _target.global_position - global_position
 	to_target.y = 0.0
-	if to_target.length() > attack_range:
+	if _horizontal_distance_to(_target.global_position) > attack_range:
 		if _nav_agent.is_navigation_finished():
 			# The path says we arrived and the target is still out of reach, so
 			# it is not reachable from here — the navmesh clamp put its goal
@@ -532,7 +544,13 @@ func _target_at(screen_point: Vector2, ground_point) -> Node3D:
 
 ## Nearest living enemy to a point, measured horizontally so a unit's height
 ## never decides which of two is closer. Returns null if none is within range.
-func _nearest_enemy_to(point: Vector3, radius: float) -> Node3D:
+##
+## `require_sight` is true only for automatic acquisition, and it is measured
+## from the hero rather than from `point` — the two are the same thing there.
+## The click paths pass false on purpose: the player can only click something
+## already drawn on screen, so demanding a second opinion from a raycast would
+## only reject clicks the player could plainly see were valid.
+func _nearest_enemy_to(point: Vector3, radius: float, require_sight := false) -> Node3D:
 	var best: Node3D = null
 	var best_distance := radius
 	for candidate in get_tree().get_nodes_in_group(ENEMY_GROUP):
@@ -542,10 +560,29 @@ func _nearest_enemy_to(point: Vector3, radius: float) -> Node3D:
 		var offset := enemy.global_position - point
 		offset.y = 0.0
 		var distance := offset.length()
-		if distance <= best_distance:
-			best = enemy
-			best_distance = distance
+		if distance > best_distance:
+			continue
+		# Sight last: it is a raycast, and the cheap distance test has already
+		# thrown out most of the group by the time we get here.
+		if require_sight and not _can_see(enemy):
+			continue
+		best = enemy
+		best_distance = distance
 	return best
+
+
+## Chest-to-chest ray against walls only, mirroring the zombie's.
+##
+## Without it the hero picks up targets through solid rock and walks off to
+## fight something the player never saw — the same complaint scenes/enemies/
+## records in reverse ("zombies detect the hero through solid rock, then appear
+## round a corner for no visible reason"), and worse here, because this is the
+## unit the player is supposed to be commanding.
+func _can_see(target: Node3D) -> bool:
+	var from := global_position + Vector3.UP * EYE_HEIGHT
+	var to := target.global_position + Vector3.UP * EYE_HEIGHT
+	var query := PhysicsRayQueryParameters3D.create(from, to, SIGHT_BLOCKER_MASK)
+	return get_world_3d().direct_space_state.intersect_ray(query).is_empty()
 
 
 ## Everything this script assumes about an enemy, in one place: it is a live

--- a/scenes/hero/hero.gd
+++ b/scenes/hero/hero.gd
@@ -65,9 +65,12 @@ enum Order {
 }
 
 ## Ground is physics layer 1, enemies are layer 4 — see the table in
-## scenes/CLAUDE.md. The two click rays are separate queries rather than one
-## masked 1|8 query, because a single ray returns whichever surface is nearer
-## and the floor under a zombie's feet would sometimes win.
+## scenes/CLAUDE.md. A click fires two rays rather than one, because the two
+## questions want opposite tie-breaks. The ground ray must ignore walls, so
+## clicking a wall means the floor behind it (issue #5). The enemy ray must
+## respect them, so clicking a wall never means the zombie behind it. One
+## combined query cannot do both, and the floor under a zombie's feet would
+## sometimes win it anyway.
 const GROUND_MASK := 1
 const ENEMY_MASK := 8
 const RAY_LENGTH := 1000.0
@@ -523,8 +526,21 @@ func _ground_point_at(screen_point: Vector2):
 	return ground.intersects_ray(origin, direction)
 
 
-## The enemy a click means, if any: whatever the enemy ray hits, else the
-## nearest living enemy within CLICK_SLACK of where the click met the ground.
+## The enemy a click means, if any.
+##
+## **Walls are in this ray's mask, and that is the whole point of it.** With
+## enemies alone the ray tunnelled: clicking a wall with a zombie behind it
+## resolved to an attack order on a zombie the player could not see, and the
+## hero walked off to fight it. Including layer 2 makes the nearer surface win,
+## which is what the renderer decides too, so a click can only name an enemy
+## that is actually drawn.
+##
+## Not a general occlusion solve, and the reason is worth knowing: rock caps
+## carry no collider on purpose (see scenes/map/CLAUDE.md), so a ray into a rock
+## mass is stopped by the wall pieces bounding it rather than by the rock
+## itself. Those sit on every rock/floor boundary at full wall height, so a
+## descending click ray meets one on its way out — everything except a ray
+## threading the corner gap where two of them meet.
 func _target_at(screen_point: Vector2, ground_point) -> Node3D:
 	var camera := get_viewport().get_camera_3d()
 	if camera == null:
@@ -532,11 +548,18 @@ func _target_at(screen_point: Vector2, ground_point) -> Node3D:
 	var origin := camera.project_ray_origin(screen_point)
 	var direction := camera.project_ray_normal(screen_point)
 	var query := PhysicsRayQueryParameters3D.create(
-		origin, origin + direction * RAY_LENGTH, ENEMY_MASK
+		origin, origin + direction * RAY_LENGTH, ENEMY_MASK | SIGHT_BLOCKER_MASK
 	)
 	var result := get_world_3d().direct_space_state.intersect_ray(query)
-	if result and _is_valid_target(result.collider):
-		return result.collider
+	if result:
+		if _is_valid_target(result.collider):
+			return result.collider
+		# A wall got there first, so whatever is past it is off screen. The
+		# click stays a ground order rather than becoming an attack.
+		return null
+	# The ray met neither enemy nor wall, so the click landed on open floor or
+	# past the edge of the level. Only here is the slack radius safe to apply —
+	# there is nothing between the camera and that ground to hide a zombie.
 	if ground_point == null:
 		return null
 	return _nearest_enemy_to(ground_point, CLICK_SLACK)

--- a/scenes/hero/hero.gd
+++ b/scenes/hero/hero.gd
@@ -1,37 +1,139 @@
 class_name Hero
 extends CharacterBody3D
-## Click-to-move hero controller (issue #5).
+## The player-controlled hero: click-to-move (issue #5), takes damage and dies
+## (issue #7), and now fights back (issue #11).
 ##
-## Right-click ("move_command") raycasts from the camera into the world and
-## sets the NavigationAgent3D target. Left-click is deliberately left free for
-## targeting/attacks (issue #11). The ray only collides with the ground layer,
-## so clicking a wall orders a move to the floor behind it (RTS convention).
+## Commands follow the StarCraft/Warcraft [b]smart command[/b] model, because
+## that is the control scheme the whole game is styled after:
 ##
-## Every move command supersedes the one before it immediately — see
-## command_move_to().
+## - [b]Right-click[/b] is the smart command: on the ground it is a move order,
+##   on an enemy it is an attack order.
+## - [b]Left-click[/b] is selection, and never an attack. Nothing consumes a
+##   bare left-click yet — the unit info bar is issue #36 — but the binding is
+##   reserved now so the two never end up fighting over the button.
+## - [b]A, then left-click[/b] is the attack command: on an enemy it attacks
+##   that enemy, on the ground it is an attack-move — walk there, but stop to
+##   kill anything that comes within [member acquire_radius] on the way, then
+##   carry on to where you pointed.
 ##
-## Hit points live in the [Health] child (issue #7); the hero is in the "hero"
-## group so enemies can find him without a scene path.
+## Which orders pick up targets by themselves is the part worth keeping
+## straight, and each answer is a decision rather than a side effect:
+##
+## - [b]MOVE does not.[/b] A move order runs the gauntlet untouched. This is
+##   what makes "sprint past the encounter" a real choice instead of a bug.
+## - [b]ATTACK_MOVE does.[/b] That is the entire difference between it and MOVE.
+## - [b]IDLE does.[/b] A hero standing still defends himself, so a player who
+##   is reading the rest of the screen is not chewed on for free. It also makes
+##   a separate retaliate-when-hit rule unnecessary: nothing can reach the hero
+##   from outside [member acquire_radius] anyway.
+##
+## [b]This script never names an enemy class.[/b] Targets are found through the
+## "enemies" group and used through take_damage()/is_dead(), so scenes/hero/
+## does not depend on scenes/enemies/ — the dependency runs one way, enemies to
+## hero. A second enemy type needs no change in here.
 
+## Emitted with the clamped destination of a move or attack-move order.
 signal move_ordered(world_point: Vector3)
 
-## Emitted once when the hero's health hits zero. scenes/main.gd listens and
-## restarts the run.
+## Emitted when the hero is told to attack something — by right-click, by
+## A+click, or by acquiring a target on his own.
+signal attack_ordered(target: Node3D)
+
+## Emitted when a target dies from this hero's damage. The XP hook for issue #8;
+## nothing consumes it yet. Attribution is exact — it fires from the swing that
+## landed the killing blow, not from the victim's own death signal, which any
+## source of damage would trigger.
+signal killed(victim: Node3D)
+
+## Emitted when the attack command is armed or disarmed, so the HUD can show
+## the player that the next left-click means "attack" rather than "select".
+signal attack_move_armed_changed(armed: bool)
+
+## Emitted once when the hero's health hits zero. scenes/main.gd listens.
 signal died
 
-const SPEED := 6.0
-const TURN_SPEED := 12.0
+## What the hero is currently under orders to do.
+enum Order {
+	## No orders. Holds position, but will defend itself.
+	IDLE,
+	## Walking somewhere, ignoring everything on the way.
+	MOVE,
+	## Closing on a specific enemy and swinging once in range.
+	ATTACK_TARGET,
+	## Walking somewhere, engaging whatever it meets and then resuming.
+	ATTACK_MOVE,
+}
 
-## Ground is physics layer 1; walls (layer 2) are excluded so move commands
-## always land on walkable floor.
+## Ground is physics layer 1, enemies are layer 4 — see the table in
+## scenes/CLAUDE.md. The two click rays are separate queries rather than one
+## masked 1|8 query, because a single ray returns whichever surface is nearer
+## and the floor under a zombie's feet would sometimes win.
 const GROUND_MASK := 1
+const ENEMY_MASK := 8
 const RAY_LENGTH := 1000.0
+
+const ENEMY_GROUP := "enemies"
+
+## How far from the clicked ground point an enemy still counts as clicked.
+##
+## A 0.4-radius capsule seen down a ~57° camera is a small thing to hit, and an
+## attack order that silently becomes a move order into a pack is the worst
+## possible way to miss. If the enemy ray misses, the nearest living enemy
+## within this distance of the ground point is taken instead. Keep it under half
+## a cell (2.0) or clicking the floor beside a zombie stops meaning the floor.
+const CLICK_SLACK := 1.6
+
+## Target reassessment runs on a fixed tick rather than every frame, matching
+## the sensing budget scenes/enemies/ already uses. Retargeting is a group scan
+## and a repath; neither needs 60 Hz.
+const RETARGET_INTERVAL := 0.2
+
+## How far the visual jabs forward on a swing, in metres.
+const SWING_LUNGE := 0.45
+
+@export_group("Movement")
+@export var move_speed := 6.0
+@export var turn_speed := 12.0
+
+@export_group("Combat")
+## Reach of the basic attack. Slightly longer than the zombie's, so trading
+## blows toe-to-toe is not purely a coin flip.
+@export var attack_range := 2.2
+@export var attack_damage := 12.0
+## Seconds between swings — attack speed, expressed the same way the zombie's is.
+@export var attack_cooldown := 0.9
+## Radius the hero picks up his own targets in, while idle or attack-moving.
+## Well under the zombie's detection radius (12): the hero should be noticed
+## before he notices, so a fight starts because the player walked into it.
+@export var acquire_radius := 9.0
+
+@export_group("Regeneration")
+## Seconds out of combat — neither taking damage nor swinging — before health
+## starts coming back. Without this, clearing a fight at low health makes the
+## next one unwinnable and the only move is to die on purpose, which is a
+## miserable way to use a checkpoint (issue #38).
+@export var regen_delay := 5.0
+@export var regen_per_second := 4.0
 
 var _gravity: float = ProjectSettings.get_setting("physics/3d/default_gravity")
 var _dead := false
 
+var _order: Order = Order.IDLE
+var _target: Node3D = null
+## Where an interrupted attack-move resumes once its fight is over. Guarded by
+## a flag rather than a null sentinel so the type stays Vector3.
+var _resume_point := Vector3.ZERO
+var _has_resume_point := false
+var _attack_move_armed := false
+
+var _attack_timer := 0.0
+var _retarget_timer := 0.0
+var _regen_timer := 0.0
+var _swing_tween: Tween = null
+
 @onready var health: Health = $Health
 @onready var _nav_agent: NavigationAgent3D = $NavigationAgent3D
+@onready var _visual: Node3D = $Visual
 
 
 func _ready() -> void:
@@ -48,22 +150,328 @@ func is_dead() -> bool:
 func take_damage(amount: float) -> void:
 	if _dead:
 		return
+	_mark_in_combat()
 	health.take_damage(amount)
 
+
+## What the hero is currently doing, for the HUD and for tests.
+func current_order() -> Order:
+	return _order
+
+
+## The enemy the hero is currently attacking, or null.
+func current_target() -> Node3D:
+	return _target if _is_valid_target(_target) else null
+
+
+# --- Commands ----------------------------------------------------------------
+
+## Public move order — also the entry point for future AI/skills/tests.
+##
+## Issuing an order cancels the previous one outright: the target is replaced
+## (NavigationAgent3D repaths on the next query) and the carried-over horizontal
+## velocity is dropped so the hero cannot coast another frame along the
+## abandoned heading. Rapid re-clicking therefore reads as an instant redirect.
+func command_move_to(world_point: Vector3) -> void:
+	var reachable := _on_navmesh(world_point)
+	_clear_orders()
+	_order = Order.MOVE
+	_nav_agent.target_position = reachable
+	move_ordered.emit(reachable)
+
+
+## Attack a specific enemy: close on it, then swing on cooldown until it dies.
+## Ignored for anything that is not a living enemy, so a stale click cannot
+## leave the hero attacking a corpse.
+func command_attack(target: Node3D) -> void:
+	if not _is_valid_target(target):
+		return
+	_clear_orders()
+	_order = Order.ATTACK_TARGET
+	_target = target
+	_nav_agent.target_position = _on_navmesh(target.global_position)
+	attack_ordered.emit(target)
+
+
+## Attack-move: walk to a point, engaging anything that comes within
+## [member acquire_radius] and resuming afterwards.
+func command_attack_move(world_point: Vector3) -> void:
+	var reachable := _on_navmesh(world_point)
+	_clear_orders()
+	_order = Order.ATTACK_MOVE
+	_resume_point = reachable
+	_has_resume_point = true
+	_nav_agent.target_position = reachable
+	move_ordered.emit(reachable)
+
+
+## Drop every order and hold position.
+func command_stop() -> void:
+	_clear_orders()
+
+
+func _clear_orders() -> void:
+	_order = Order.IDLE
+	_target = null
+	_has_resume_point = false
+	# Drop the carried-over heading so a new order never coasts a frame along
+	# the old one.
+	velocity.x = 0.0
+	velocity.z = 0.0
+
+
+# --- Input -------------------------------------------------------------------
 
 func _unhandled_input(event: InputEvent) -> void:
 	if _dead:
 		return
-	if not event.is_action_pressed("move_command"):
+
+	if event.is_action_pressed("attack_move"):
+		_set_attack_move_armed(not _attack_move_armed)
 		return
+
+	if event.is_action_pressed("cancel_command"):
+		_set_attack_move_armed(false)
+		return
+
 	# Use the position carried by the click itself rather than the live mouse
 	# position: the two can differ by the time the event is handled, and it
 	# keeps this path deterministic for headless tests.
-	var screen_point := (event as InputEventMouseButton).position
-	var target = _ground_point_at(screen_point)
-	if target != null:
-		command_move_to(target)
+	if event.is_action_pressed("select_command"):
+		if not _attack_move_armed:
+			# A bare left-click is selection (issue #36), which this script does
+			# not own. Deliberately not an attack: an RTS where inspecting a unit
+			# also swings at it is unusable.
+			return
+		_set_attack_move_armed(false)
+		_issue_attack_click((event as InputEventMouseButton).position)
+		return
 
+	if event.is_action_pressed("move_command"):
+		# Any world command cancels an armed attack — otherwise the arming
+		# survives the click that was meant to replace it.
+		_set_attack_move_armed(false)
+		_issue_smart_click((event as InputEventMouseButton).position)
+
+
+## Right-click: attack what is under the cursor, or move to the ground.
+func _issue_smart_click(screen_point: Vector2) -> void:
+	var ground = _ground_point_at(screen_point)
+	var enemy := _target_at(screen_point, ground)
+	if enemy != null:
+		command_attack(enemy)
+	elif ground != null:
+		command_move_to(ground)
+
+
+## A + left-click: attack what is under the cursor, or attack-move to the ground.
+func _issue_attack_click(screen_point: Vector2) -> void:
+	var ground = _ground_point_at(screen_point)
+	var enemy := _target_at(screen_point, ground)
+	if enemy != null:
+		command_attack(enemy)
+	elif ground != null:
+		command_attack_move(ground)
+
+
+func _set_attack_move_armed(armed: bool) -> void:
+	if _attack_move_armed == armed:
+		return
+	_attack_move_armed = armed
+	attack_move_armed_changed.emit(armed)
+
+
+# --- Per-frame ---------------------------------------------------------------
+
+func _physics_process(delta: float) -> void:
+	if not is_on_floor():
+		velocity.y -= _gravity * delta
+	else:
+		velocity.y = 0.0
+
+	if _dead:
+		_halt()
+		return
+
+	_attack_timer = maxf(_attack_timer - delta, 0.0)
+	_tick_regen(delta)
+
+	_retarget_timer -= delta
+	if _retarget_timer <= 0.0:
+		_retarget_timer = RETARGET_INTERVAL
+		_reassess()
+
+	match _order:
+		Order.IDLE:
+			_halt()
+		Order.MOVE, Order.ATTACK_MOVE:
+			_process_travel(delta)
+		Order.ATTACK_TARGET:
+			_process_attack(delta)
+
+
+## Order bookkeeping and target acquisition. Runs on the retarget tick, not
+## every frame — everything that needs per-frame precision (the cooldown,
+## gravity, movement) lives in _physics_process instead.
+func _reassess() -> void:
+	match _order:
+		# The two acquiring orders, sharing one branch because they acquire
+		# identically. What differs is what happens after the kill, and that is
+		# _finish_engagement()'s job: an attack-move keeps its destination and
+		# carries on, an idle hero simply stands down again.
+		Order.IDLE, Order.ATTACK_MOVE:
+			var found := _nearest_enemy_to(global_position, acquire_radius)
+			if found != null:
+				_engage(found)
+
+		Order.ATTACK_TARGET:
+			if not _is_valid_target(_target):
+				_finish_engagement()
+				return
+			# Repath only while out of reach. Repathing inside attack range
+			# would fight the "stand still and swing" branch every tick.
+			if global_position.distance_to(_target.global_position) > attack_range:
+				_nav_agent.target_position = _on_navmesh(_target.global_position)
+
+		Order.MOVE:
+			pass
+
+
+## Take a target without disturbing a pending attack-move destination.
+func _engage(target: Node3D) -> void:
+	_order = Order.ATTACK_TARGET
+	_target = target
+	_nav_agent.target_position = _on_navmesh(target.global_position)
+	attack_ordered.emit(target)
+
+
+## The target is gone: resume the attack-move that was interrupted, or stand down.
+func _finish_engagement() -> void:
+	_target = null
+	if _has_resume_point:
+		_order = Order.ATTACK_MOVE
+		_nav_agent.target_position = _resume_point
+	else:
+		_order = Order.IDLE
+
+
+func _process_travel(delta: float) -> void:
+	if _nav_agent.is_navigation_finished():
+		_order = Order.IDLE
+		_has_resume_point = false
+		_halt()
+		return
+	_travel(delta, move_speed)
+
+
+func _process_attack(delta: float) -> void:
+	if not _is_valid_target(_target):
+		# _reassess() cleans this up on the next tick; until then, stand.
+		_halt()
+		return
+
+	var to_target := _target.global_position - global_position
+	to_target.y = 0.0
+	if to_target.length() > attack_range:
+		if _nav_agent.is_navigation_finished():
+			# The path says we arrived and the target is still out of reach, so
+			# it is not reachable from here — the navmesh clamp put its goal
+			# somewhere we cannot close on. Stand and face rather than jitter.
+			# Deliberately not "give up": dropping the target would re-acquire
+			# the same one on the next tick and flap. The player can always
+			# issue another order.
+			_face(to_target, delta)
+			_halt()
+			return
+		_travel(delta, move_speed)
+		return
+
+	_halt()
+	_face(to_target, delta)
+	if _attack_timer > 0.0:
+		return
+	_attack_timer = attack_cooldown
+	_swing(_target)
+
+
+## Land a hit. There is no wind-up: the blow arrives the instant the cooldown
+## expires, matching the zombie. Add a telegraph on both when there are attack
+## animations to hang one on.
+func _swing(target: Node3D) -> void:
+	_mark_in_combat()
+	_play_swing()
+	target.take_damage(attack_damage)
+	# Health.died fires synchronously inside take_damage(), so the victim
+	# already knows it is dead by the time this returns.
+	if target.has_method("is_dead") and target.is_dead():
+		killed.emit(target)
+		_finish_engagement()
+
+
+func _play_swing() -> void:
+	if _swing_tween != null and _swing_tween.is_valid():
+		_swing_tween.kill()
+	_visual.position.z = 0.0
+	# Forward is -Z, matching the node's facing convention.
+	_swing_tween = create_tween()
+	_swing_tween.tween_property(_visual, "position:z", -SWING_LUNGE, 0.08)
+	_swing_tween.tween_property(_visual, "position:z", 0.0, 0.16)
+
+
+func _tick_regen(delta: float) -> void:
+	_regen_timer = maxf(_regen_timer - delta, 0.0)
+	if _regen_timer > 0.0:
+		return
+	if health.current >= health.max_health:
+		return
+	health.heal(regen_per_second * delta)
+
+
+## Both taking a hit and landing one count as combat, so a hero trading blows
+## never regenerates mid-fight.
+func _mark_in_combat() -> void:
+	_regen_timer = regen_delay
+
+
+# --- Movement helpers --------------------------------------------------------
+
+func _travel(delta: float, speed: float) -> void:
+	var next := _nav_agent.get_next_path_position()
+	var direction := next - global_position
+	direction.y = 0.0
+	direction = direction.normalized()
+	velocity.x = direction.x * speed
+	velocity.z = direction.z * speed
+	move_and_slide()
+	_face(direction, delta)
+
+
+## Hold position but keep stepping the body, so gravity still settles it.
+func _halt() -> void:
+	velocity.x = 0.0
+	velocity.z = 0.0
+	move_and_slide()
+
+
+## Turn toward a horizontal direction. Forward is -Z (Godot's convention), so a
+## rigged model drops in later without a compensating rotation.
+func _face(direction: Vector3, delta: float) -> void:
+	direction.y = 0.0
+	if direction.length_squared() <= 0.0001:
+		return
+	direction = direction.normalized()
+	var target_yaw := atan2(-direction.x, -direction.z)
+	rotation.y = lerp_angle(rotation.y, target_yaw, turn_speed * delta)
+
+
+## Clamp a world point onto the navigation map, so an order is never
+## unreachable — a click on the void outside the level becomes "walk as far
+## that way as you can" instead of a path request that resolves to nothing.
+func _on_navmesh(point: Vector3) -> Vector3:
+	return NavigationServer3D.map_get_closest_point(get_world_3d().navigation_map, point)
+
+
+# --- Picking things out of the world -----------------------------------------
 
 ## Resolve a screen position to a point on the ground.
 ##
@@ -72,7 +480,7 @@ func _unhandled_input(event: InputEvent) -> void:
 ## produces no hit at all. Dropping those clicks is what made a second click
 ## look like it was ignored — the hero silently kept walking to its previous
 ## destination. Falling back to the hero's ground plane means every click
-## yields a point; command_move_to() then clamps it onto the navmesh.
+## yields a point; the order it turns into then clamps it onto the navmesh.
 ##
 ## Returns a Vector3, or null if there is no camera to project from.
 func _ground_point_at(screen_point: Vector2):
@@ -91,52 +499,63 @@ func _ground_point_at(screen_point: Vector2):
 	return ground.intersects_ray(origin, direction)
 
 
-## Public move order — also the entry point for future AI/skills/tests.
-##
-## Issuing an order cancels the previous one outright: the target is replaced
-## (NavigationAgent3D repaths on the next query) and the carried-over horizontal
-## velocity is dropped so the hero cannot coast another frame along the
-## abandoned heading. Rapid re-clicking therefore reads as an instant redirect.
-func command_move_to(world_point: Vector3) -> void:
-	# Clamp onto the navigation map so an order is never unreachable — a click
-	# on the void outside the level becomes "walk as far that way as you can"
-	# instead of a path request that resolves to nothing.
-	var map := get_world_3d().navigation_map
-	var reachable := NavigationServer3D.map_get_closest_point(map, world_point)
-	_nav_agent.target_position = reachable
-	velocity.x = 0.0
-	velocity.z = 0.0
-	move_ordered.emit(reachable)
+## The enemy a click means, if any: whatever the enemy ray hits, else the
+## nearest living enemy within CLICK_SLACK of where the click met the ground.
+func _target_at(screen_point: Vector2, ground_point) -> Node3D:
+	var camera := get_viewport().get_camera_3d()
+	if camera == null:
+		return null
+	var origin := camera.project_ray_origin(screen_point)
+	var direction := camera.project_ray_normal(screen_point)
+	var query := PhysicsRayQueryParameters3D.create(
+		origin, origin + direction * RAY_LENGTH, ENEMY_MASK
+	)
+	var result := get_world_3d().direct_space_state.intersect_ray(query)
+	if result and _is_valid_target(result.collider):
+		return result.collider
+	if ground_point == null:
+		return null
+	return _nearest_enemy_to(ground_point, CLICK_SLACK)
 
 
-func _physics_process(delta: float) -> void:
-	if not is_on_floor():
-		velocity.y -= _gravity * delta
-	else:
-		velocity.y = 0.0
+## Nearest living enemy to a point, measured horizontally so a unit's height
+## never decides which of two is closer. Returns null if none is within range.
+func _nearest_enemy_to(point: Vector3, radius: float) -> Node3D:
+	var best: Node3D = null
+	var best_distance := radius
+	for candidate in get_tree().get_nodes_in_group(ENEMY_GROUP):
+		if not _is_valid_target(candidate):
+			continue
+		var enemy := candidate as Node3D
+		var offset := enemy.global_position - point
+		offset.y = 0.0
+		var distance := offset.length()
+		if distance <= best_distance:
+			best = enemy
+			best_distance = distance
+	return best
 
-	if _dead or _nav_agent.is_navigation_finished():
-		velocity.x = 0.0
-		velocity.z = 0.0
-		move_and_slide()
-		return
 
-	var next := _nav_agent.get_next_path_position()
-	var direction := next - global_position
-	direction.y = 0.0
-	direction = direction.normalized()
-	velocity.x = direction.x * SPEED
-	velocity.z = direction.z * SPEED
-	move_and_slide()
-
-	# Face the movement direction (-Z is forward, matching Godot's convention
-	# so a rigged model can be dropped in later without a compensating rotation).
-	if direction.length_squared() > 0.0:
-		var target_yaw := atan2(-direction.x, -direction.z)
-		rotation.y = lerp_angle(rotation.y, target_yaw, TURN_SPEED * delta)
+## Everything this script assumes about an enemy, in one place: it is a live
+## node in the tree, it is in the enemies group, and it is not already dead.
+## Deliberately duck-typed — see the note at the top about the dependency
+## direction between scenes/hero/ and scenes/enemies/.
+func _is_valid_target(candidate) -> bool:
+	if not is_instance_valid(candidate):
+		return false
+	var node := candidate as Node3D
+	if node == null or not node.is_inside_tree():
+		return false
+	if not node.is_in_group(ENEMY_GROUP):
+		return false
+	if node.has_method("is_dead") and node.is_dead():
+		return false
+	return true
 
 
 func _on_health_died() -> void:
 	_dead = true
+	_clear_orders()
+	_set_attack_move_armed(false)
 	velocity = Vector3.ZERO
 	died.emit()

--- a/scenes/hero/hero.tscn
+++ b/scenes/hero/hero.tscn
@@ -25,12 +25,14 @@ collision_layer = 4
 collision_mask = 3
 script = ExtResource("1_hero")
 
-[node name="BodyMesh" type="MeshInstance3D" parent="."]
+[node name="Visual" type="Node3D" parent="."]
+
+[node name="BodyMesh" type="MeshInstance3D" parent="Visual"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.9, 0)
 mesh = SubResource("CapsuleMesh_body")
 surface_material_override/0 = SubResource("Material_body")
 
-[node name="NoseMesh" type="MeshInstance3D" parent="."]
+[node name="NoseMesh" type="MeshInstance3D" parent="Visual"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.3, -0.5)
 mesh = SubResource("BoxMesh_nose")
 surface_material_override/0 = SubResource("Material_nose")

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -1,5 +1,5 @@
 extends Node3D
-## Game entry scene (issues #5, #6, #7).
+## Game entry scene (issues #5, #6, #7, #11).
 ##
 ## Owns the order the level comes up in: the maze builds itself in its own
 ## _ready() (children run first), then this script places the hero on the maze's
@@ -26,6 +26,7 @@ const RESTART_DELAY := 2.5
 @onready var _health_bar: ProgressBar = $HUD/HealthBar
 @onready var _health_value: Label = $HUD/HealthBar/Value
 @onready var _death_label: Label = $HUD/DeathLabel
+@onready var _attack_move_label: Label = $HUD/AttackMoveLabel
 
 
 func _ready() -> void:
@@ -36,6 +37,7 @@ func _ready() -> void:
 
 	_hero.health.health_changed.connect(_on_hero_health_changed)
 	_hero.died.connect(_on_hero_died)
+	_hero.attack_move_armed_changed.connect(_on_attack_move_armed_changed)
 	_on_hero_health_changed(_hero.health.current, _hero.health.max_health)
 
 
@@ -56,6 +58,12 @@ func _on_hero_health_changed(current: float, maximum: float) -> void:
 	_health_bar.max_value = maximum
 	_health_bar.value = current
 	_health_value.text = "%d / %d" % [roundi(current), roundi(maximum)]
+
+
+## Arming the attack command changes what the *next* left-click means, and a
+## mode the player cannot see is a mode they will forget they are in.
+func _on_attack_move_armed_changed(armed: bool) -> void:
+	_attack_move_label.visible = armed
 
 
 func _on_hero_died() -> void:

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -64,6 +64,37 @@ text = "100 / 100"
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="AttackMoveLabel" type="Label" parent="HUD"]
+visible = false
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -280.0
+offset_top = 24.0
+offset_right = 280.0
+offset_bottom = 56.0
+grow_horizontal = 2
+theme_override_colors/font_color = Color(1, 0.68, 0.3, 1)
+theme_override_font_sizes/font_size = 22
+text = "ATTACK — left-click a target, or the ground to attack-move"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="ControlsLabel" type="Label" parent="HUD"]
+anchor_left = 1.0
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -540.0
+offset_top = -48.0
+offset_right = -24.0
+offset_bottom = -24.0
+grow_horizontal = 0
+grow_vertical = 0
+theme_override_colors/font_color = Color(0.72, 0.76, 0.84, 1)
+text = "Right-click: move / attack          A + left-click: attack-move"
+horizontal_alignment = 2
+vertical_alignment = 1
+
 [node name="DeathLabel" type="Label" parent="HUD"]
 visible = false
 anchor_left = 0.5

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -82,7 +82,7 @@ ever gets collided with.
   with a floor tile flush with the top of the walls, tinted dark so rock never
   competes with the lit walkable floor for the player's eye. Giving those caps
   collision would bake navmesh islands *inside* solid rock — and since
-  `Hero.command_move_to()` clamps a click onto the nearest navmesh point,
+  every `Hero` order clamps its destination onto the nearest navmesh point,
   clicking a wall could then order the hero somewhere he can never reach.
 - **`agent_radius` on the navmesh is 1.0, not the hero's 0.4.** At 0.5 the
   baked surface hugged the walls, so waypoints landed in the pockets where two

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -104,4 +104,4 @@ ever gets collided with.
   ordering is load-bearing — `Maze._ready()` runs before `Main._ready()`
   because Godot readies children first, so the geometry exists before the bake.
 
-<!-- verified-against: 8a4044b -->
+<!-- verified-against: 46564b4 -->


### PR DESCRIPTION
Closes the one gap in the core loop: zombies could kill the player, the player could not
kill them. `Fixes #11`.

This is **PR 1 of 5** toward a winnable run. The rest are filed and scoped: #36 selection
and the unit info bar, #37 the open single-path level, #38 checkpoints and respawn, #39
the end boss and victory screen. Reviewing this one on its own is fine — nothing here
depends on the other four.

## The command scheme (the design decision #11 asked for)

StarCraft/Warcraft **smart command**, because that is the control model the whole game is
styled after.

| Input | On an enemy | On the ground |
|-------|-------------|---------------|
| Right-click | attack it | move there |
| `A` then left-click | attack it | attack-move there |
| Left-click alone | *selection — #36* | *selection — #36* |
| `Escape` | disarms `A` | disarms `A` |

**A bare left-click is deliberately never an attack.** An RTS where inspecting a unit also
swings at it is unusable, so the button stays reserved for selection even though nothing
consumes it yet. `A` borrows it for exactly one click and hands it straight back. This is
also what `scenes/hero/CLAUDE.md` has said since #5 — "left-click is reserved for
targeting" — so nothing had to be walked back.

**Which orders acquire targets** is the part worth looking at closely, because each answer
is a decision rather than a side effect:

- **MOVE does not.** A move order runs the gauntlet untouched — this is what makes
  "sprint past the encounter" a real choice instead of a bug. Worth protecting: the hero
  outruns every zombie (6.0 vs a 3.4 chase), so if we ever want to stop players skipping
  the map that needs a design answer (a gate, an objective), not a speed nerf.
- **ATTACK_MOVE does.** That is the entire difference between it and MOVE. The destination
  survives the fight and resumes once the target dies.
- **IDLE does.** A hero standing still defends himself. This also removes the need for a
  separate retaliate-on-hit rule: nothing can reach him from outside `acquire_radius`.

## Also in here

- **Out-of-combat regen on both actors.** The hero's is not decoration — it exists for
  #38. Without it, clearing a fight at low health makes the next one unwinnable and the
  only move left is to die on purpose, which is a miserable way to use a checkpoint. The
  zombie's is gated on *state* as well as time (only ROAM/RETURN), so it can never heal
  mid-chase and turn a fight the player is slowly winning into one they cannot win. Those
  two conditions close different exploits — see `scenes/enemies/CLAUDE.md`.
- **Hero stats are exports, not consts** (`move_speed` was `const SPEED`). The skill tree
  (#9) will want to modify them and a `const` is not a seam. There is deliberately **no
  stat/modifier system** here — that is #9's to design, and inventing one now would
  prejudge it.
- **Feedback:** a swing lunge on the hero (which is why `hero.tscn` gained a `Visual`
  node, matching `zombie.tscn`) and a hit flash on the zombie. Plus a HUD indicator while
  `A` is armed — a mode the player cannot see is a mode they forget they are in — and a
  one-line controls hint, since the web build is the project's front door and arrives with
  no instructions.

## Two things to check me on

**1. `hero.gd` never names an enemy class.** Targets come from the `enemies` group and are
used through `take_damage()`/`is_dead()`, so the compile-time dependency still runs one
way, enemies → hero, and a second enemy type needs no change in the hero. But that group
name and those two methods *are* a real runtime contract, so I declared `scenes/enemies`
in the hero doc's frontmatter anyway. Declaring a runtime-only edge is a judgement call
and I'd like a second opinion on it. (I also added the `scenes/components` edge, which was
always real — `hero.gd` types `var health: Health` — and had simply never been written
down. Exactly the "a missing edge is invisible" limitation the root doc warns about.)

**2. The unreachable-target case.** If the path completes and the target is still out of
range, the hero stands and faces it rather than dropping it. Dropping would re-acquire the
same target next tick and flap. Only reachable via a navmesh clamp that lands a goal
somewhere unreachable, so it is rare — but it is a deliberate "looks stuck" over "visibly
flaps", and if you'd rather have the other one, say so.

## Verification

No test framework in the repo (#16 is still open), so I drove the real scene headless with
a throwaway `SceneTree` script — posted on #16 since that is the harness it wants:

```
zombies spawned: 6
nearest zombie: 31.2 units away, 30 hp
PASS attack order: kill in 583 steps (9.7 s); hero 100 -> 82 hp
attack-moving toward a zombie 27.2 units away
PASS attack-move: engaged and killed in 386 steps (6.4 s)
killed signal fired 1 time(s)
regen: 64 -> 84 hp over 10 s
ALL CHECKS PASSED
```

The regen number is the exact prediction: 5 s delay, then 4/s for 5 s = 20 HP. Roughly
18 HP and 6 s per zombie 1v1, so a pack of three is genuinely dangerous against 100 HP.

Also verified: all four input actions register with the right events (a malformed
`project.godot` entry fails silently, so this was worth checking rather than assuming);
`docs-check` passes both `--audit` and the CI `--diff origin/main...HEAD` form.

## Doc stamps

The second commit bumps four `verified-against` stamps. This is DEPSTALE doing its job
rather than bookkeeping: the hero grew a combat surface and both neighbouring docs rest on
it. All four were re-read against `46564b4`. Only `scenes/map/` needed a correction — it
named `command_move_to()` as the thing that clamps a destination, which after this refactor
is every order rather than one of them.

`CLAUDE.md` changed only because `project.godot` did and the hook requires it. The edit is
a real one — it records that the layer-name and input-action registries live in that file
but are *owned* by `scenes/CLAUDE.md`, so the next person to add one knows where to write
it instead of duplicating it here. See #40 for why that gate is awkward as it stands.
