### PR TITLE
Re-stamp the four docs after #44 was squash-merged

### DIFF
--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -139,4 +139,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 8ce7816 -->
+<!-- verified-against: fe31cbd -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -161,4 +161,4 @@ the hero, now that he can deal damage at all (issue #11).
 - Still a placeholder capsule. The Quaternius zombie models in
   `assets/characters/zombies/` are imported but unused, matching the hero.
 
-<!-- verified-against: 8ce7816 -->
+<!-- verified-against: fe31cbd -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -207,4 +207,4 @@ numbers.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: 8ce7816 -->
+<!-- verified-against: fe31cbd -->

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -159,4 +159,4 @@ contiguous run of open cells without changing what the player sees.
   ordering is load-bearing — `LevelMap._ready()` runs before `Main._ready()`
   because Godot readies children first, so the geometry exists before the bake.
 
-<!-- verified-against: a93bd80 -->
+<!-- verified-against: fe31cbd -->


### PR DESCRIPTION
Repairs the `docs-audit` failure on `main` introduced by merging [#44](https://github.com/hipsen-systems/mg-zombies/pull/44).

## What broke

I squash-merged #44. Every previous PR in this repo landed as a merge commit, and **the `verified-against` convention depends on that**: the four docs in #44 were stamped at `a93bd80` and `8ce7816`, the squash replaced both with a single new commit `fe31cbd`, and the branch shas stopped existing. `--audit` on `main` then failed:

```
BADSTAMP    scenes/enemies/CLAUDE.md
            verified-against: 8ce7816 is not a commit in this repository
```

Three `BADSTAMP`s, exit 2. `main` has been red since the merge.

## The fix

Point the four stamps at `fe31cbd`. **Nothing about the docs was wrong** — they were read against exactly the tree that commit carries; only the sha they named became unreachable. This is a repair of the reference, not a re-verification, and it is not an unearned bump: the claim ("someone read this doc against the code at this commit") is the same claim, now naming a commit that exists.

`--audit` and `--diff origin/main..HEAD` both pass.

## Worth knowing, because it will happen again

**A squash merge silently invalidates every stamp written on the branch, and no check on the PR can catch it.** The branch's own `docs-check` passes — correctly — because at that moment the stamps *are* valid and the squash commit does not exist yet. The failure only materialises on `main`, after the merge, in the `docs-audit` job. So the PR gate is structurally blind to this one.

That makes it a third entry in the pattern the root doc and `.claude/hooks/CLAUDE.md` already collect: **a check that verifies the right thing at the wrong moment**. It is also the exact inverse of the #44 finding (a check that passed while measuring the wrong property) — here the check measures the right property and cannot run at the point where it would fail.

Two ways to close it properly, neither in this PR since it should stay a repair:

1. **Use merge commits** — the existing convention, and what makes the stamps meaningful. Cheapest fix: it needs a note in the docs, not code.
2. **Have the audit accept an unreachable sha whose tree matches**, or resolve stamps through the reflog/PR metadata. More robust, more work, and arguably the wrong trade for a two-person team.

I have written up the workflow consequence in Flowdex, and I'd suggest filing (1) as a documented rule in `CLAUDE.md` — happy to do it in a follow-up rather than widening this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
