### PR TITLE
Checkpoints and respawn: a death costs a segment, not the run

### DIFF
--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -7,11 +7,11 @@ depends-on: [scenes/map, scenes/hero, scenes/enemies, scenes/ui]
 Top-level game scenes and their scripts.
 
 - `main.tscn` — the game entry scene: a `NavigationRegion3D` wrapping the
-  level map (`scenes/map/`), the instanced hero, an `Enemies` holder, lighting,
-  the RTS camera, and two instances from `scenes/ui/` — the `HUD` and the
-  `UnitSelection` node that holds the selection ring. The 40×40 test arena that
-  lived here for issue #5 is gone; issue #6 replaced it with the real map, and
-  issue #37 replaced that maze with an open single-path level.
+  level map (`scenes/map/`), the instanced hero, `Enemies` and `Checkpoints`
+  holders, lighting, the RTS camera, and two instances from `scenes/ui/` — the
+  `HUD` and the `UnitSelection` node that holds the selection ring. The 40×40
+  test arena that lived here for issue #5 is gone; issue #6 replaced it with the
+  real map, and issue #37 replaced that maze with an open single-path level.
 - `main.gd` — attached to the root. Owns the startup order, which is
   load-bearing:
   1. the map builds itself in its own `_ready()` (Godot readies children
@@ -21,12 +21,15 @@ Top-level game scenes and their scripts.
      (`bake_navigation_mesh(false)`) because the web export has threads
      disabled, so don't switch it to on-thread baking. On the open level this
      costs ~55 ms at startup, up from ~12 ms on the maze;
-  4. **then** it spawns one zombie per `Z` cell of the map. Enemies path on
-     the navmesh, so they must not exist before the bake.
+  4. **then** it lays the checkpoint pads and spawns one zombie per `Z` cell of
+     the map. Enemies path on the navmesh, so they must not exist before the
+     bake.
 - **Enemy spawning** sets `position` *before* `add_child`, because
   `Zombie._ready()` captures `global_position` as the home its roam area and
   leash are measured from. `Enemies` sits at the origin so local and global
-  agree.
+  agree. `Checkpoint.setup()` has the same rule for the same reason: it builds
+  its pads and triggers in `_ready()` and has nothing to build them from until
+  it has been told its cells.
 
 ## HUD and selection
 
@@ -44,12 +47,41 @@ One ordering rule lives in `_ready()`: `selection_changed` is connected
 **before** `select_unit(_hero)` is called, because the info bar learns the
 initial selection from that signal and nothing re-sends it.
 
-## Death and restart
+## Death and respawn (issue #38)
 
-`main.gd` listens for `Hero.died`, shows the death label, waits
-`RESTART_DELAY` (2.5 s) and calls `get_tree().reload_current_scene()`. Crude on
-purpose — issue #7 explicitly allows it and a run carries no state worth
-preserving yet.
+`main.gd` listens for `Hero.died`, shows the death screen, waits
+`RESPAWN_DELAY` (2.5 s) and puts him back at the armed checkpoint. The scene
+reload issue #7 allowed is gone: a run now carries state worth preserving, which
+is the whole point of the feature.
+
+**This script owns the respawn rule**, because it is the only thing here that
+knows both the armed checkpoint and what is currently standing in the level.
+`scenes/map/` says where the checkpoints are and which segment each spawn
+belongs to; deciding what a death costs is this folder's.
+
+- **Only the segment ahead of the armed checkpoint is restored.** Everything
+  cleared behind it stays cleared, so a death costs the fight and not the run;
+  everything ahead comes back, so a hard fight cannot be whittled down by dying
+  at it repeatedly.
+- **Clear first, then spawn.** Restoring a segment means putting it back *as
+  authored*, which is not the same as topping up the survivors — a zombie left
+  mid-chase would otherwise stay standing where it ran the hero down, beside a
+  fresh copy of every one that died. Removing and re-instancing is also what
+  makes "restored zombies are home in ROAM" true for free, rather than needing a
+  reset method on the enemy.
+- **`remove_child` before `queue_free`**, so a cleared zombie leaves the
+  `enemies` group this frame rather than at the end of it. The hero can acquire
+  and walk toward a queued-but-still-parented target on the tick between.
+- **Each zombie carries its segment as node metadata** (`SEGMENT_META`). A list
+  kept here would be a second record of a set the scene tree already holds, and
+  zombies remove themselves from it when a corpse finishes fading.
+- **The most recently armed checkpoint wins, not the furthest reached.** Walking
+  back through an earlier pad really does hand back the ground in between — the
+  lit pad is always the promise being made, which is the version a player can
+  read off the screen.
+- The camera is snapped after the teleport, for the same reason `_ready()` snaps
+  after placing the hero, and the info bar is pointed back at him *before* the
+  clear: it has no way to notice a unit that is removed rather than killed.
 
 ## Navmesh gotchas (learned the hard way)
 
@@ -93,7 +125,7 @@ inspector reads properly.
 |-------|----------|--------------|--------------|
 | 1     | Ground/floor (ground-click rays collide with this only) | floor tiles | hero, zombies |
 | 2     | Walls & static obstacles (also tested by both line-of-sight rays, by the hero's attack-targeting click, and by the selection click, so none of them sees through rock) | wall pieces | hero, zombies |
-| 3     | Hero (also what the selection ray tests) | hero | zombies |
+| 3     | Hero (also what the selection ray tests, and what the checkpoint pads' `Area3D`s detect) | hero | zombies |
 | 4     | Enemies (also what the hero's attack-targeting ray and the selection ray test) | zombies | *nobody* |
 
 **"Who masks it" is about bodies, not queries.** A `collision_mask` decides what
@@ -108,6 +140,13 @@ attack-targeting ray against layer 4 while this row still read as though nothing
 touched it. Issue #36 added the third such consumer — `scenes/ui/`'s selection
 ray, which is the first thing of any kind to query layer 3.
 
+**An `Area3D`'s mask is a third kind of consumer**, and it goes in the same
+column for the same reason. Issue #38's checkpoint pads mask layer 3, but an
+area is not blocked by what it masks and does not block it either — it only
+*notices*. So the hero is not stopped by a pad, and nothing about his own mask
+changed. Three questions now, one column each: what stops a body, what a ray
+finds, what an area notices.
+
 The asymmetry in the last two rows is intentional: zombies are blocked by the
 hero, the hero is not blocked by zombies, and zombies do not collide with each
 other. Mutually-colliding zombies jam solid in a one-cell corridor, and a hero
@@ -118,15 +157,18 @@ describes. See `scenes/enemies/CLAUDE.md`.
 
 - Instances `scenes/map/level_map.tscn`, `scenes/hero/hero.tscn`,
   `scenes/ui/hud.tscn` and `scenes/ui/unit_selection.tscn` from the .tscn, and
-  `scenes/enemies/zombie.tscn` at runtime. Two exports are wired here as
-  `NodePath`s and both point at the hero: the camera's `target` and
-  `UnitSelection.hero`.
+  `scenes/enemies/zombie.tscn` and `scenes/map/checkpoint.tscn` at runtime. Two
+  exports are wired here as `NodePath`s and both point at the hero: the camera's
+  `target` and `UnitSelection.hero`.
 - **Input actions** are defined in `project.godot` and every one of them is
   consumed by `scenes/hero/`, not by anything in this folder. What each *means*
   is that folder's to document; this is only the inventory:
   `move_command` (right mouse), `select_command` (left mouse),
   `attack_move` (`A`), `cancel_command` (`Escape`).
 - `LevelMap` emits `built`; nothing consumes it yet.
+- `main.gd` consumes `Checkpoint.reached` and calls `Checkpoint.set_armed()`
+  back on every pad, so exactly one is lit. It calls `Hero.respawn_at()` and, on
+  the way, `HUD.show_death()` / `hide_death()` / `flash_checkpoint()`.
 - `main.gd` consumes `Hero.died`, `Hero.health.health_changed`,
   `Hero.attack_move_armed_changed` and `Hero.select_clicked`, forwarding each to
   `scenes/ui/`. Unconsumed so far: `Hero.move_ordered` and `Hero.attack_ordered`

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -185,4 +185,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: a5a431e -->
+<!-- verified-against: 35ada3a -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -185,4 +185,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 35ada3a -->
+<!-- verified-against: ac81093 -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -185,4 +185,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: f0a582f -->
+<!-- verified-against: a5a431e -->

--- a/scenes/components/CLAUDE.md
+++ b/scenes/components/CLAUDE.md
@@ -10,13 +10,20 @@ inherited or copy-pasted. Nothing in here knows about a specific actor.
 - `health.gd` (`class_name Health`) — hit points. Added as a `Node` child of
   `hero.tscn` (100 HP) and `zombie.tscn` (30 HP).
   - `@export var max_health`; `current` is set from it in `_ready()`.
-  - `take_damage(amount)` / `heal(amount)` / `is_dead()`.
+  - `take_damage(amount)` / `heal(amount)` / `revive()` / `is_dead()`.
   - Signals: `health_changed(current, maximum)` — emitted on damage *and*
     healing, carrying both numbers so a HUD never has to reach back into the
-    node — and `died`, emitted exactly once when health first reaches zero.
+    node — and `died`, emitted when health reaches zero.
   - Damage and healing on a dead component are ignored. Healing a corpse would
     silently revive it; resurrection should be an explicit decision, not a side
     effect of a heal.
+  - **`revive()` is that explicit decision** (issue #38's checkpoint respawn):
+    full health, whatever the current value. Because it exists, `died` is
+    once-per-*life* rather than once ever — repeated damage on a corpse still
+    cannot re-fire it, but a revived owner killed again will. It deliberately
+    emits nothing of its own beyond `health_changed`: whoever revives an owner
+    is also moving it and clearing its death state, so a signal here would
+    announce a half-finished resurrection.
 
 ## Convention
 

--- a/scenes/components/health.gd
+++ b/scenes/components/health.gd
@@ -13,8 +13,9 @@ extends Node
 ## draw a bar without reaching back into this node.
 signal health_changed(current: float, maximum: float)
 
-## Emitted once, when health first reaches zero. Never re-emitted: further
-## damage on a corpse is ignored.
+## Emitted when health reaches zero. Once per life: further damage on a corpse is
+## ignored, so it cannot fire twice — but a component put back on its feet by
+## [method revive] can emit it again the next time it is killed.
 signal died
 
 @export var max_health := 100.0
@@ -45,4 +46,15 @@ func heal(amount: float) -> void:
 	if is_dead() or amount <= 0.0:
 		return
 	current = minf(current + amount, max_health)
+	health_changed.emit(current, max_health)
+
+
+## Put a dead owner back on its feet at full health (issue #38's checkpoint
+## respawn). The explicit decision [method heal] refuses to make for you.
+##
+## Deliberately does not emit anything of its own. Whoever revives an owner is
+## the one moving it, healing it and clearing its death state, so a signal here
+## would announce a half-finished resurrection.
+func revive() -> void:
+	current = max_health
 	health_changed.emit(current, max_health)

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -147,6 +147,11 @@ the hero, now that he can deal damage at all (issue #11).
 - Finds the hero via `get_tree().get_first_node_in_group("hero")` — no scene
   path, so a zombie works in any scene that has a hero and a baked navmesh.
 - Calls `Hero.take_damage()`; reads `Hero.is_dead()` to stop hitting a corpse.
+  **Since issue #38 a corpse can stop being one** — the hero respawns rather
+  than reloading the scene — and nothing here needed changing for it, because
+  every state reads `is_dead()` fresh on its own sense tick rather than latching
+  a death. A zombie left in `ATTACK` when he died finds him alive again but far
+  away on the next tick, so it leashes home the ordinary way.
 - **Is damaged by the hero through the same two methods, in reverse.**
   `scenes/hero/` calls `take_damage()` and reads `is_dead()` on whatever is in
   the `enemies` group, without ever naming `Zombie`. So the pair of methods and
@@ -163,9 +168,18 @@ the hero, now that he can deal damage at all (issue #11).
   nothing to it — `scenes/ui/` never issues an order. That folder also watches
   the `Health` child's `died` so the bar drops a corpse, which is why it is in
   the frontmatter above.
-- Spawned by `scenes/main.gd` at the `Z` cells of `scenes/map/level_map.gd`; the
-  spawner sets `position` *before* `add_child`, because `_ready()` captures
+- Spawned by `scenes/main.gd` from `LevelMap.zombie_spawns()` — the `Z` cells of
+  `scenes/map/level_map.gd`, each carrying the checkpoint segment it belongs to.
+  The spawner sets `position` *before* `add_child`, because `_ready()` captures
   `global_position` as home.
+- **It also removes them** (issue #38): on respawn, every zombie in the restored
+  segment is freed and re-instanced, living, chasing or already a corpse. That
+  is why "restored zombies are home in `ROAM`" needs no reset method here — a
+  fresh instance is the reset. Two consequences worth knowing: a zombie can
+  leave the tree without `died` ever firing, which is what anything holding a
+  reference to one must survive (`scenes/ui/` does, and says so); and the
+  segment lives on the instance as node metadata rather than as anything this
+  script knows about, so nothing in here needs to learn about checkpoints.
 - Still a placeholder capsule. The Quaternius zombie models in
   `assets/characters/zombies/` are imported but unused, matching the hero.
 

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -183,4 +183,4 @@ the hero, now that he can deal damage at all (issue #11).
 - Still a placeholder capsule. The Quaternius zombie models in
   `assets/characters/zombies/` are imported but unused, matching the hero.
 
-<!-- verified-against: a5a431e -->
+<!-- verified-against: 35ada3a -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -183,4 +183,4 @@ the hero, now that he can deal damage at all (issue #11).
 - Still a placeholder capsule. The Quaternius zombie models in
   `assets/characters/zombies/` are imported but unused, matching the hero.
 
-<!-- verified-against: f0a582f -->
+<!-- verified-against: a5a431e -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -183,4 +183,4 @@ the hero, now that he can deal damage at all (issue #11).
 - Still a placeholder capsule. The Quaternius zombie models in
   `assets/characters/zombies/` are imported but unused, matching the hero.
 
-<!-- verified-against: 35ada3a -->
+<!-- verified-against: ac81093 -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -57,6 +57,9 @@ poking the `NavigationAgent3D`: `command_move_to(point)`,
 Each cancels the previous order outright: the agent repaths and horizontal
 velocity is zeroed so the hero can't coast a frame along the abandoned heading.
 
+`respawn_at(point)` is the one method outside that set that moves him, and it is
+not an order — see below.
+
 ## Which orders acquire targets
 
 Four orders (`IDLE`, `MOVE`, `ATTACK_TARGET`, `ATTACK_MOVE`), and the only
@@ -114,9 +117,10 @@ Measured 1v1 against one zombie: ~18 HP lost per kill, ~6 s of fighting.
 
 **Out-of-combat regeneration** starts `regen_delay` after the last combat
 event, where *both* taking a hit and landing one count — a hero trading blows
-never regenerates mid-fight. It exists for issue #38: without it, clearing a
-fight at low health makes the next one unwinnable and the only remaining move
-is to die on purpose, which is a miserable way to use a checkpoint.
+never regenerates mid-fight. It was written for issue #38, and #38 has now
+landed: without it, clearing a fight at low health makes the next one unwinnable
+and the only remaining move is to die on purpose, which is a miserable way to
+use a checkpoint. It is what stops the respawn below being the healing mechanic.
 
 **The gate is time only, where the zombie's is time *and* state.** That
 asymmetry is deliberate, not an oversight — cross-review raised it. A chasing
@@ -203,6 +207,18 @@ numbers.
   `_dead`, drops every order, and emits `died`; while dead he ignores input and
   holds position (gravity still runs). `is_dead()` is public so a zombie stops
   swinging at a corpse.
+- **Death is no longer terminal (issue #38).** `respawn_at(point)` revives him
+  in place rather than reloading the scene, because the run around him survives:
+  everything cleared behind the armed checkpoint stays cleared. So `died` now
+  fires once per *death*, not once per run, and every piece of state a death
+  leaves behind has to be undone in one place — the death flag, the orders, the
+  armed attack command, the carried velocity, and the three timers. Two of those
+  are easy to miss and were: **the attack cooldown**, which would otherwise let
+  him swing the instant he lands, and **the nav agent's target**, which nothing
+  else clears — leave it and the first order of the new life is judged finished
+  or not against a destination from the previous one. `Health.revive()` is
+  called last, so `health_changed` reaches the HUD with the hero already alive
+  and standing where he belongs.
 
 ## Dependencies
 
@@ -221,8 +237,9 @@ numbers.
   fired from the swing that lands the killing blow so attribution is exact
   rather than "something died". Emits `attack_move_armed_changed(armed)`, which
   `scenes/main.gd` consumes to show the armed-attack indicator, and `died`,
-  which `scenes/main.gd` consumes to restart the run. Consumes `Health.died`
-  from its own child.
+  which `scenes/main.gd` answers with `respawn_at()` at the armed checkpoint.
+  Consumes `Health.died` from its own child, and calls `Health.revive()` on the
+  way back.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -243,4 +243,4 @@ numbers.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: a5a431e -->
+<!-- verified-against: 35ada3a -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -5,7 +5,7 @@ depends-on: [scenes, scenes/components, scenes/enemies, scenes/ui, assets]
 # scenes/hero/
 
 The player-controlled hero (issue #5: movement; issue #7: taking damage and
-dying; issue #11: his own attack).
+dying; issue #11: his own attack; issue #38: coming back from a death).
 
 - `hero.tscn` — `CharacterBody3D` (collision layer 3, mask 1|2 — see the
   layer table in `scenes/CLAUDE.md`) with a placeholder capsule + a small
@@ -243,4 +243,4 @@ numbers.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: f0a582f -->
+<!-- verified-against: a5a431e -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -212,13 +212,26 @@ numbers.
   everything cleared behind the armed checkpoint stays cleared. So `died` now
   fires once per *death*, not once per run, and every piece of state a death
   leaves behind has to be undone in one place — the death flag, the orders, the
-  armed attack command, the carried velocity, and the three timers. Two of those
-  are easy to miss and were: **the attack cooldown**, which would otherwise let
-  him swing the instant he lands, and **the nav agent's target**, which nothing
+  armed attack command, the carried velocity, and the three timers.
+  `Health.revive()` is called last, so `health_changed` reaches the HUD with the
+  hero already alive and standing where he belongs.
+
+  Two pieces of that are easy to miss. **The nav agent's target**, which nothing
   else clears — leave it and the first order of the new life is judged finished
-  or not against a destination from the previous one. `Health.revive()` is
-  called last, so `health_changed` reaches the HUD with the hero already alive
-  and standing where he belongs.
+  or not against a destination from the previous one. And **the timers**, which
+  are frozen rather than running while he is dead, because `_physics_process`
+  returns above the line that decrements them. They count *down*, so a residual
+  is a *delay*: dying mid-cooldown and keeping the value would make his first
+  swing of the new life wait out the remainder of his last one. Clearing them
+  stops that leak; it does not hold him back, it does the reverse.
+
+  **What stops him swinging the instant he arrives is not in this folder.** It
+  is `scenes/map/`'s rule that no spawn sits within 4 cells of a respawn cell —
+  well outside `acquire_radius` (9) — so there is nothing to acquire on the
+  frame he comes back. That is the invariant to re-check if a checkpoint is ever
+  placed with less clearance, or if issue #9 grows these radii. Cross-review
+  caught this stated backwards: the code was right and the reason attached to it
+  was inverted, which is the same failure the doc lesson on #36 records.
 
 ## Dependencies
 

--- a/scenes/hero/hero.gd
+++ b/scenes/hero/hero.gd
@@ -58,7 +58,9 @@ signal attack_move_armed_changed(armed: bool)
 ## first would depend on the order _unhandled_input walks the tree.
 signal select_clicked(screen_point: Vector2)
 
-## Emitted once when the hero's health hits zero. scenes/main.gd listens.
+## Emitted when the hero's health hits zero. scenes/main.gd listens, and answers
+## it with [method respawn_at] rather than a scene reload (issue #38), so this
+## fires once per death and not once per run.
 signal died
 
 ## What the hero is currently under orders to do.
@@ -193,6 +195,32 @@ func unit_info() -> Dictionary:
 		"attack_cooldown": attack_cooldown,
 		"move_speed": move_speed,
 	}
+
+
+## Come back at [param point] with full health, ready to take orders (issue #38).
+##
+## The hero is revived in place rather than rebuilt, because the run around him
+## survives his death: everything cleared behind the armed checkpoint stays
+## cleared, so there is no scene to reload. Every piece of state a death leaves
+## behind is reset here — the death flag, the orders, the armed attack command,
+## the carried velocity, and the three timers, one of which would otherwise let
+## him swing the instant he lands.
+func respawn_at(point: Vector3) -> void:
+	_dead = false
+	_clear_orders()
+	_set_attack_move_armed(false)
+	velocity = Vector3.ZERO
+	global_position = point
+	# The agent is still holding the path he was walking when he died, and
+	# nothing else clears it: leave it and the first order after the respawn is
+	# judged finished or not against a destination from the previous life.
+	_nav_agent.target_position = point
+	_attack_timer = 0.0
+	_retarget_timer = 0.0
+	_regen_timer = 0.0
+	# Last, so health_changed reaches the HUD with the hero already alive and
+	# standing where he belongs.
+	health.revive()
 
 
 ## What the hero is currently doing, for the HUD and for tests.

--- a/scenes/hero/hero.gd
+++ b/scenes/hero/hero.gd
@@ -203,8 +203,21 @@ func unit_info() -> Dictionary:
 ## survives his death: everything cleared behind the armed checkpoint stays
 ## cleared, so there is no scene to reload. Every piece of state a death leaves
 ## behind is reset here — the death flag, the orders, the armed attack command,
-## the carried velocity, and the three timers, one of which would otherwise let
-## him swing the instant he lands.
+## the carried velocity, and the three timers.
+##
+## [b]The timers are cleared to stop state leaking across a death, not to hold
+## him back.[/b] They count *down*, and _physics_process returns above the line
+## that decrements them while [member _dead] is set, so they are frozen at
+## whatever they read when he fell — dying mid-cooldown would otherwise make his
+## first swing of the new life wait out the remainder of the last one. Zeroing
+## them means the opposite of a delay: he lands fully ready.
+##
+## What actually stops him swinging the moment he arrives is not here at all.
+## It is the map's rule that no spawn sits within 4 cells of a respawn cell (see
+## scenes/map/CLAUDE.md), which is well outside [member acquire_radius], so there
+## is nothing to acquire on the frame he comes back. That is the invariant to
+## re-check if a checkpoint is ever placed with less clearance, or if issue #9
+## grows the radii — not this reset.
 func respawn_at(point: Vector3) -> void:
 	_dead = false
 	_clear_orders()

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -1,5 +1,5 @@
 extends Node3D
-## Game entry scene (issues #5, #6, #7, #11, #36).
+## Game entry scene (issues #5, #6, #7, #11, #36, #38).
 ##
 ## Owns the order the level comes up in: the map builds itself in its own
 ## _ready() (children run first), then this script places the hero on the map's
@@ -12,30 +12,51 @@ extends Node3D
 ## It also wires the HUD and unit selection (scenes/ui/) to the hero, and that
 ## is all it does with them: this script calls HUD methods and never touches a
 ## Label, so the layout is free to change without a gameplay script changing too.
+##
+## [b]It owns the respawn rule.[/b] The map says where the checkpoints are and
+## which stretch of the run each spawn belongs to; deciding what a death costs is
+## this script's, because it is the one thing here that knows both the armed
+## checkpoint and what is currently standing in the level.
 
 ## Spawn units just above the floor surface and let gravity settle them, rather
 ## than guessing the exact tile height.
 const SPAWN_CLEARANCE := 0.3
 
 const ZOMBIE_SCENE := preload("res://scenes/enemies/zombie.tscn")
+const CHECKPOINT_SCENE := preload("res://scenes/map/checkpoint.tscn")
 
-## How long the death screen sits there before the run restarts.
-const RESTART_DELAY := 2.5
+## How long the death screen sits there before the hero comes back.
+const RESPAWN_DELAY := 2.5
+
+## Which stretch of the run a spawned zombie came from, so a respawn can restore
+## exactly the ones ahead of the armed checkpoint. Stored on the instance because
+## the alternative — a list kept here — would be a second record of a set the
+## scene tree already holds, and zombies remove themselves from it when a corpse
+## finishes fading.
+const SEGMENT_META := &"checkpoint_segment"
 
 @onready var _nav_region: NavigationRegion3D = $NavigationRegion3D
 @onready var _level: LevelMap = $NavigationRegion3D/LevelMap
 @onready var _hero: Hero = $Hero
 @onready var _camera: RTSCamera = $RTSCamera
 @onready var _enemies: Node3D = $Enemies
+@onready var _checkpoints_root: Node3D = $Checkpoints
 @onready var _hud: HUD = $HUD
 @onready var _selection: UnitSelection = $UnitSelection
+
+## Where the hero comes back, one entry per checkpoint. Entry 0 is the start
+## cell, so this is never empty and a death before the first pad still respawns.
+var _respawn_points := PackedVector3Array()
+var _checkpoint_nodes: Array[Checkpoint] = []
+var _armed_checkpoint := 0
 
 
 func _ready() -> void:
 	_hero.global_position = _level.start_position() + Vector3(0, SPAWN_CLEARANCE, 0)
 	_camera.snap_to_target()
 	_nav_region.bake_navigation_mesh(false)
-	_spawn_zombies()
+	_place_checkpoints()
+	_spawn_zombies(0)
 
 	_hero.health.health_changed.connect(_hud.set_hero_health)
 	_hero.died.connect(_on_hero_died)
@@ -51,22 +72,95 @@ func _ready() -> void:
 	_selection.select_unit(_hero)
 
 
-## One zombie per `Z` cell in the level layout. The map says where an encounter
-## is; deciding what stands there is this scene's job, so the map stays pure
-## geometry and never has to know the enemy scenes exist.
-func _spawn_zombies() -> void:
-	for spawn in _level.zombie_spawn_positions():
+## One zombie per `Z` cell from [param from_segment] onward. The map says where
+## an encounter is; deciding what stands there is this scene's job, so the map
+## stays pure geometry and never has to know the enemy scenes exist.
+func _spawn_zombies(from_segment: int) -> void:
+	for spawn in _level.zombie_spawns():
+		var segment: int = spawn["segment"]
+		if segment < from_segment:
+			continue
 		var zombie: Zombie = ZOMBIE_SCENE.instantiate()
+		zombie.set_meta(SEGMENT_META, segment)
 		# Position before add_child: Zombie._ready() captures where it stands as
 		# "home" — the centre of the patch it roams and the anchor of its leash.
 		# Enemies sits at the origin, so local and global agree here.
-		zombie.position = spawn + Vector3(0, SPAWN_CLEARANCE, 0)
+		zombie.position = spawn["position"] + Vector3(0, SPAWN_CLEARANCE, 0)
 		_enemies.add_child(zombie)
+
+
+## Lay the checkpoint pads the map marked out.
+func _place_checkpoints() -> void:
+	var groups := _level.checkpoints()
+	for index in groups.size():
+		# The nearest cell of a checkpoint is where the hero comes back — see
+		# LevelMap.checkpoints() for why it is a cell and not an average.
+		_respawn_points.append(groups[index][0])
+		# Checkpoint 0 is the start cell. It gets no pad: the map already paints
+		# it green, and it is the one checkpoint that arms itself, since the hero
+		# is standing on it before he can walk anywhere.
+		if index == 0:
+			continue
+		var checkpoint: Checkpoint = CHECKPOINT_SCENE.instantiate()
+		checkpoint.setup(index, groups[index])
+		checkpoint.reached.connect(_on_checkpoint_reached)
+		_checkpoint_nodes.append(checkpoint)
+		_checkpoints_root.add_child(checkpoint)
+
+
+## The hero stepped on a pad. The most recently armed checkpoint is the one he
+## comes back to, so walking back through an earlier one really does hand back
+## the ground in between — the lit pad is always the promise being made.
+func _on_checkpoint_reached(index: int) -> void:
+	if index == _armed_checkpoint:
+		return
+	_armed_checkpoint = index
+	for checkpoint in _checkpoint_nodes:
+		checkpoint.set_armed(checkpoint.index == index)
+	_hud.flash_checkpoint()
 
 
 func _on_hero_died() -> void:
 	_hud.show_death()
-	# Crude restart, which is all issue #7 asks for: a run carries no state
-	# worth preserving yet.
-	await get_tree().create_timer(RESTART_DELAY).timeout
-	get_tree().reload_current_scene()
+	await get_tree().create_timer(RESPAWN_DELAY).timeout
+	if not is_inside_tree():
+		return
+	_respawn()
+
+
+## Put the hero back at the armed checkpoint and restore the run ahead of it.
+##
+## [b]Only what is ahead.[/b] Everything cleared behind the checkpoint stays
+## cleared, so a death costs the segment being fought and not the run; and
+## everything ahead is restored, so a hard fight cannot be whittled down by
+## dying at it over and over.
+func _respawn() -> void:
+	_hud.hide_death()
+	# Before the clear below, not after: the info bar may be pointed at a zombie
+	# that is about to be freed, and it has no way to notice one that is removed
+	# rather than killed.
+	_selection.select_unit(_hero)
+	# Clear first, then spawn. Restoring a segment means putting it back as it
+	# was authored, which is not the same as topping up the survivors — a zombie
+	# left mid-chase would otherwise stay standing wherever it ran the hero down,
+	# alongside a fresh copy of every one that died.
+	_clear_from_segment(_armed_checkpoint)
+	_spawn_zombies(_armed_checkpoint)
+	_hero.respawn_at(_respawn_points[_armed_checkpoint] + Vector3(0, SPAWN_CLEARANCE, 0))
+	# The hero has teleported, so the follow camera would otherwise sail across
+	# the level — the same reason _ready() snaps after placing him.
+	_camera.snap_to_target()
+
+
+## Remove every zombie from [param from_segment] onward, living, chasing or
+## already a corpse.
+##
+## remove_child before queue_free, so they leave the `enemies` group this frame
+## rather than at the end of it: a freed-but-still-parented zombie is one the
+## hero can acquire and walk toward on the tick between the two.
+func _clear_from_segment(from_segment: int) -> void:
+	for zombie in _enemies.get_children():
+		if int(zombie.get_meta(SEGMENT_META, 0)) < from_segment:
+			continue
+		_enemies.remove_child(zombie)
+		zombie.queue_free()

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -40,6 +40,8 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.1, 0)
 
 [node name="Enemies" type="Node3D" parent="."]
 
+[node name="Checkpoints" type="Node3D" parent="."]
+
 [node name="UnitSelection" parent="." node_paths=PackedStringArray("hero") instance=ExtResource("6_selection")]
 hero = NodePath("../Hero")
 

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -47,6 +47,13 @@ current map were moved to earn that clearance, and the boss-room guard was moved
 four cells deeper into its room for the same reason. Nothing is now within 4
 cells of a respawn cell; the nearest to `S` is 7.
 
+**`scenes/hero/` leans on that number**, so it is a contract and not just good
+practice. 4 cells is 16 units, comfortably outside his `acquire_radius` of 9, and
+that gap is the only reason he cannot swing on the frame he respawns — his own
+timers are cleared to *full readiness*, deliberately. Shrink the clearance here,
+and the invariant protecting the player is gone with nothing in that folder to
+notice. Issue #9 raising `acquire_radius` does the same from the other end.
+
 Cells are `CELL_SIZE` = 4 units, matching the KayKit dungeon grid: `wall` is
 4×4×1 and `floor_tile_large` is 4×4.
 
@@ -251,4 +258,4 @@ contiguous run of open cells without changing what the player sees.
   `scenes/hero/`, which is why it is in the frontmatter above. `Checkpoint`
   never names `Hero` as a type.
 
-<!-- verified-against: a5a431e -->
+<!-- verified-against: ac81093 -->

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -1,15 +1,18 @@
 ---
-depends-on: [scenes, assets]
+depends-on: [scenes, scenes/hero, assets]
 ---
 
 # scenes/map/
 
-The playable map (issues #6, #37). Replaces the 40×40 test arena that
-`main.tscn` used to carry.
+The playable map (issues #6, #37) and the checkpoints laid out on it (#38).
+Replaces the 40×40 test arena that `main.tscn` used to carry.
 
 - `level_map.tscn` — a bare `Node3D` with `level_map.gd`. All geometry is
   generated at runtime, so the .tscn stays a single node.
 - `level_map.gd` (`class_name LevelMap`) — builds the map from ASCII.
+- `checkpoint.tscn` / `checkpoint.gd` (`class_name Checkpoint`) — one respawn
+  pad, built the same way: a bare `Node3D` that generates its plates and
+  triggers at runtime. Instanced by `scenes/main.gd`, not by the builder.
 
 Issue #37 renamed both away from `maze`: the layout is deliberately not a maze
 any more, and a class called `Maze` that builds a non-maze is the kind of thing
@@ -26,14 +29,23 @@ The map is the `layout` export: one character per cell, north is row 0.
 | `S`  | start cell (hero spawns here) — exactly one |
 | `B`  | boss room centre — exactly one |
 | `Z`  | ordinary floor that also marks a zombie spawn — any number |
+| `C`  | ordinary floor that also marks a respawn checkpoint — any number |
 
 Rows must all be the same length. `build()` refuses to build a malformed
 layout and `push_error`s instead of half-building one.
 
 Encounters are authored the same way the map is: placing an enemy is editing
-one character. Keep `Z` cells well clear of `S` — a zombie within its own
-detection radius (12 units = 3 cells) of the start charges the hero before the
-player has taken a step. The nearest one on the current map is 7 cells away.
+one character.
+
+**Keep `Z` cells well clear of every cell the hero can start on** — a zombie
+within its own detection radius (12 units = 3 cells) charges him before the
+player has taken a step. That used to mean `S` alone; since #38 it means every
+`C` cell too, and it binds harder there: respawning restores the zombies ahead
+of the checkpoint *to their spawns*, so a spawn too close arrives with the hero,
+every time, on a player who has just lost a fight. Both checkpoints on the
+current map were moved to earn that clearance, and the boss-room guard was moved
+four cells deeper into its room for the same reason. Nothing is now within 4
+cells of a respawn cell; the nearest to `S` is 7.
 
 Cells are `CELL_SIZE` = 4 units, matching the KayKit dungeon grid: `wall` is
 4×4×1 and `floor_tile_large` is 4×4.
@@ -52,6 +64,10 @@ start to boss passes through both chokepoints, and there is no loop.
 - **Two dead-end spurs** — a chamber north of the first clearing (21 cells) and
   a vault south of the second (24 cells), each holding two zombies. Both hang
   off a two-cell neck, so neither shows up as a single-cell cut.
+- **Two checkpoints** past the implicit one on `S`: three cells filling the
+  tunnel (24 from the start) and a six-cell gate across the boss-room threshold
+  (46). Between them the run splits 7 / 9 / 3 zombies. See below for why those
+  two and not the obvious third.
 
 **Openness costs nothing in the builder.** Walls are only raised on the
 rock/floor boundary, so a 13-wide clearing and a one-cell corridor run the same
@@ -76,6 +92,53 @@ that needs units to pass now has somewhere to do it. The 0.2 of slack is why
 avoidance stays a plausible remedy rather than a hopeless one, and why this
 paragraph has to be re-checked if it is ever enabled.
 
+## Checkpoints and segments (issue #38)
+
+`checkpoints()` returns one entry per checkpoint, ordered by path distance from
+the start; `zombie_spawns()` returns each spawn with the `segment` it belongs
+to. Respawning at checkpoint *k* restores exactly the spawns with `segment >= k`
+— `scenes/main.gd` does the restoring, this folder only says which is which.
+
+Three rules make that work, and each is load-bearing:
+
+- **A run of adjacent `C` cells is one checkpoint.** Six pads across a six-cell
+  door are one thing to arm, so a gate can span a doorway wide enough to walk
+  round. A checkpoint the player can miss costs them far more progress than the
+  one they believed they had banked.
+- **Segments are cut by BFS distance from `S`, not by authored order.** Sort the
+  checkpoints by distance, and a spawn belongs to the last checkpoint at or
+  before its own. Nothing is numbered by hand, so moving a `C` re-files every
+  spawn behind it automatically.
+- **`checkpoints()[k][0]` is the nearest cell of checkpoint *k*, and that is the
+  respawn point.** A cell, never an average of the group — the centre of an
+  L-shaped gate can land in solid rock.
+
+`S` is checkpoint 0 and gets no pad: the hero is standing on it before he can
+walk onto anything, and the map already paints it green.
+
+### The authoring constraint, and the one place it bit
+
+**A dead-end spur must be shorter than the run from its neck to the next
+checkpoint.** Segments are cut by distance, but "behind the checkpoint" is
+really a question about *routes*, and the two only agree while nothing hangs off
+the route deeper than the next checkpoint is far. The far end of a long spur
+scores a distance past the checkpoint, so a spawn cleared before the checkpoint
+is filed ahead of it and comes back on every respawn there — in a place the
+player has already left, for no reason they can see.
+
+`_warn_about_split_segments()` checks this at build time and `push_warning`s the
+offending cell, so it is a fact about the layout rather than a rule to remember.
+It checks *spawns* only: an empty cell filed on the wrong side changes nothing
+observable, and the current level has eleven of them in the deep corners of the
+south vault. Warning about those would train everyone to ignore it.
+
+This is why the second checkpoint is the boss-room threshold and **not** the
+two-cell door one row below it, which is the spot that looks right. The south
+vault runs to distance 47; the door is at 44, the threshold at 46. At the door,
+the vault's far zombie files into the wrong segment. Moving the checkpoint two
+rows on is the whole fix, and it costs nothing — no spawn sits between 45 and
+47, so the split is identical either way.
+
 ## What gets built
 
 - **Floor** — `floor_tile_large` per open cell, `floor_dirt_large` for the
@@ -85,18 +148,24 @@ paragraph has to be re-checked if it is ever enabled.
   between two open cells never gets one and no edge is ever built twice.
 - **Rock caps** — see the gotcha below.
 - **Zone markers** — flat emissive plates (green start, red boss). Plain
-  `MeshInstance3D`, no collision. **Those two colours are now a constraint on
+  `MeshInstance3D`, no collision. **Those two colours are a constraint on
   everything else drawn on the floor:** `scenes/ui/` picks its selection ring
   colours (cyan and orange) specifically to stay legible on top of them, since
   the hero spawns standing on the green one. Recolouring a marker means
-  re-checking that folder.
-- Public API: `start_position()`, `boss_position()`,
-  `zombie_spawn_positions()`, and the `built` signal.
+  re-checking that folder — and now `checkpoint.gd`, whose violet is the one hue
+  left that collides with neither pair. Its pads are the harder case of the two,
+  because a marker is somewhere units *stand*: a selection ring is drawn on top
+  of a checkpoint pad every time the pad matters.
+- Public API: `start_position()`, `boss_position()`, `zombie_spawns()`,
+  `checkpoints()`, and the `built` signal.
 
-**The map never instances enemies.** It only says where an encounter is;
-`scenes/main.gd` reads `zombie_spawn_positions()` and decides what stands
-there. That keeps the map pure geometry and lets enemy scenes change without
-touching it.
+**The map never instances enemies, and it does not instance checkpoints
+either.** It only says where they go; `scenes/main.gd` reads `zombie_spawns()`
+and `checkpoints()` and decides what stands there. That keeps the map pure
+geometry and lets those scenes change without touching it. The pad is the one
+piece of level furniture that is *not* built by the builder, and that is the
+reason: it has behaviour, and behaviour belongs on the other side of this seam
+even when the art does not.
 
 Everything with collision is a `StaticBody3D` whose `BoxShape3D` is derived
 from the piece's own mesh AABB, so swapping a piece's art keeps its collider
@@ -145,10 +214,18 @@ contiguous run of open cells without changing what the player sees.
   metres from spawn. Widening it keeps waypoints down the corridor centreline.
   Keep it a multiple of the navmesh `cell_size` (0.25) or Godot warns that the
   value is ceiled to voxel units.
-- **`_boss_is_reachable()` proves the layout connects, not that the level is
-  walkable.** It flood-fills the *grid* after every build and `push_error`s if
-  the boss is walled off, so a bad map edit fails loudly instead of being
-  discovered by walking there. But it knows nothing about the navmesh, and a
+- **A checkpoint's trigger is an `Area3D`, and that is what keeps it out of the
+  navmesh.** The bake parses static colliders only, so an `Area3D` is invisible
+  to it — where a `StaticBody3D` would bake a hole in the walkable surface at
+  every checkpoint. This is the mirror of the rock-cap trap above: there,
+  collision had to be withheld from something visible; here, a trigger has to
+  sense without being solid. Both come out of the same rule.
+- **The distance flood-fill proves the layout connects, not that the level is
+  walkable.** It runs on the *grid* after every build and `push_error`s if the
+  boss is walled off (or a checkpoint is), so a bad map edit fails loudly
+  instead of being discovered by walking there. It is also what segments are cut
+  by, so one BFS answers both questions and they cannot disagree. But it knows
+  nothing about the navmesh, and a
   one-cell chokepoint is exactly where erosion could sever the baked surface
   while the grid still connects. After editing chokepoints, order the hero to
   `boss_position()` and confirm he arrives — that is the only check that covers
@@ -157,10 +234,18 @@ contiguous run of open cells without changing what the player sees.
 ## Dependencies
 
 - Art: `assets/dungeon/` (`wall`, `floor_tile_large`, `floor_dirt_large`).
+  `checkpoint.gd` uses none — its pads are `BoxMesh`es, like the zone markers.
 - Instanced by `scenes/main.tscn` under `NavigationRegion3D`; `scenes/main.gd`
   reads `start_position()` to place the hero, bakes the navmesh, and then reads
-  `zombie_spawn_positions()` to populate the map with `scenes/enemies/`. The
-  ordering is load-bearing — `LevelMap._ready()` runs before `Main._ready()`
-  because Godot readies children first, so the geometry exists before the bake.
+  `checkpoints()` and `zombie_spawns()` to lay the pads and populate the map with
+  `scenes/enemies/`. The ordering is load-bearing — `LevelMap._ready()` runs
+  before `Main._ready()` because Godot readies children first, so the geometry
+  exists before the bake.
+- `Checkpoint` emits `reached(index)` and takes `set_armed(bool)` back;
+  `scenes/main.gd` owns which one is armed, because only one can be and a node
+  deciding that for itself would have to hear about every other one. The pad
+  masks physics layer 3 and tests the `hero` group — a runtime contract on
+  `scenes/hero/`, which is why it is in the frontmatter above. `Checkpoint`
+  never names `Hero` as a type.
 
 <!-- verified-against: f0a582f -->

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -58,14 +58,17 @@ start to boss passes through both chokepoints, and there is no loop.
 
 - **Two clearings** 10–13 cells across, joined by a passage 3 cells thick.
 - **Two one-cell chokepoints** — a throat out of the start clearing, and a
-  tunnel between the clearings that is one cell *tall* and five long.
+  tunnel between the clearings that is one cell *tall* and three long. (This
+  said five until #38 counted it: the cells at either mouth are single-cell
+  *cuts*, so every route still crosses all five, but they have open floor above
+  and below them and are not part of the enclosed tunnel.)
 - **A two-cell door** into the boss arena. Narrow enough to read as a gate,
   wide enough that two units are not forced to queue.
 - **Two dead-end spurs** — a chamber north of the first clearing (21 cells) and
   a vault south of the second (24 cells), each holding two zombies. Both hang
   off a two-cell neck, so neither shows up as a single-cell cut.
-- **Two checkpoints** past the implicit one on `S`: three cells filling the
-  tunnel (24 from the start) and a six-cell gate across the boss-room threshold
+- **Two checkpoints** past the implicit one on `S`: the three enclosed tunnel
+  cells (24 from the start) and a six-cell gate across the boss-room threshold
   (46). Between them the run splits 7 / 9 / 3 zombies. See below for why those
   two and not the obvious third.
 

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -248,4 +248,4 @@ contiguous run of open cells without changing what the player sees.
   `scenes/hero/`, which is why it is in the frontmatter above. `Checkpoint`
   never names `Hero` as a type.
 
-<!-- verified-against: f0a582f -->
+<!-- verified-against: a5a431e -->

--- a/scenes/map/checkpoint.gd
+++ b/scenes/map/checkpoint.gd
@@ -1,0 +1,122 @@
+class_name Checkpoint
+extends Node3D
+## A respawn pad, laid on the `C` cells of the level layout (issue #38).
+##
+## One node is one checkpoint, which may cover several cells: LevelMap groups a
+## run of adjacent `C` cells so a gate can span a door the hero could otherwise
+## walk round. The pads are built per cell here for the same reason — a single
+## plate stretched across six cells would be one flat slab where the level is
+## made of tiles.
+##
+## [b]This node only reports being stepped on.[/b] Which checkpoint is armed is
+## scenes/main.gd's to know, because only one can be, and a node that decided
+## that for itself would need to hear about every other one. So arming arrives
+## from outside through [method set_armed] and this script owns nothing but its
+## own appearance.
+
+## Emitted when the hero walks onto any of this checkpoint's cells. Re-emitted on
+## every entry, including walking back onto one already armed.
+signal reached(index: int)
+
+## The hero is physics layer 3 — see the table in scenes/CLAUDE.md. This is the
+## first area of any kind to watch that layer; the selection ray was the first
+## query to.
+const HERO_MASK := 4
+
+const HERO_GROUP := "hero"
+
+## Matches the zone markers LevelMap draws on the start and boss cells: a thin
+## plate sitting just above the floor tile, covering most of its cell.
+const PAD_SIZE := LevelMap.CELL_SIZE * 0.8
+const PAD_THICKNESS := 0.02
+const PAD_CLEARANCE := 0.07
+
+## Tall enough that the trigger is crossed by a 1.8-unit capsule however the
+## floor settles under it, and short enough not to reach anything on top of a
+## wall.
+const TRIGGER_HEIGHT := 2.4
+
+## Violet, and the choice is forced from two directions. LevelMap paints the
+## start cell green and the boss cell red, and scenes/ui/ rings the hero in cyan
+## and enemies in orange — and unlike those two markers, a checkpoint pad is
+## somewhere units *stand*, so a ring is drawn on top of it every time it
+## matters. Violet is the one hue that collides with neither set.
+const COLOUR_ARMED := Color(0.7, 0.42, 1.0)
+const COLOUR_IDLE := Color(0.32, 0.24, 0.46)
+const EMISSION_ARMED := 0.9
+const EMISSION_IDLE := 0.15
+
+## Position along the run, matching the index LevelMap.checkpoints() returned
+## this checkpoint's cells at. 0 is the start cell, which never gets a pad.
+var index := 0
+
+var _cells := PackedVector3Array()
+var _materials: Array[StandardMaterial3D] = []
+
+
+## Place this checkpoint on its cells. Call it [b]before[/b] add_child, the way
+## scenes/main.gd sets a zombie's position first: the pads and triggers are built
+## in _ready(), and there is nothing to build them from until this has run.
+func setup(checkpoint_index: int, cells: PackedVector3Array) -> void:
+	index = checkpoint_index
+	_cells = cells
+
+
+func _ready() -> void:
+	for centre in _cells:
+		_build_pad(centre)
+		_build_trigger(centre)
+	set_armed(false)
+
+
+## Light the pad, or put it out. Called by whoever tracks the armed checkpoint —
+## including on the ones being disarmed, so exactly one is ever lit.
+func set_armed(armed: bool) -> void:
+	for material in _materials:
+		material.albedo_color = COLOUR_ARMED if armed else COLOUR_IDLE
+		material.emission = COLOUR_ARMED if armed else COLOUR_IDLE
+		material.emission_energy_multiplier = EMISSION_ARMED if armed else EMISSION_IDLE
+
+
+func _build_pad(centre: Vector3) -> void:
+	var mesh := BoxMesh.new()
+	mesh.size = Vector3(PAD_SIZE, PAD_THICKNESS, PAD_SIZE)
+	var material := StandardMaterial3D.new()
+	material.emission_enabled = true
+	var pad := MeshInstance3D.new()
+	pad.mesh = mesh
+	pad.material_override = material
+	pad.position = centre + Vector3(0, PAD_CLEARANCE, 0)
+	add_child(pad)
+	_materials.append(material)
+
+
+## An Area3D rather than a distance check in _process: this has to fire for one
+## cell of a six-cell gate whichever way the hero crosses it, and the physics
+## server already answers exactly that.
+##
+## It carries no collision layer, because nothing needs to detect the trigger
+## itself, and being an Area3D it is invisible to the navmesh bake — which parses
+## static colliders only (see CLAUDE.md). A StaticBody3D here would bake a hole
+## in the walkable surface at every checkpoint.
+func _build_trigger(centre: Vector3) -> void:
+	var shape := BoxShape3D.new()
+	shape.size = Vector3(LevelMap.CELL_SIZE, TRIGGER_HEIGHT, LevelMap.CELL_SIZE)
+	var collider := CollisionShape3D.new()
+	collider.shape = shape
+
+	var area := Area3D.new()
+	area.collision_layer = 0
+	area.collision_mask = HERO_MASK
+	area.position = centre + Vector3(0, TRIGGER_HEIGHT * 0.5, 0)
+	area.add_child(collider)
+	area.body_entered.connect(_on_body_entered)
+	add_child(area)
+
+
+## The mask already limits this to the hero's layer; the group test is what keeps
+## it true if anything else is ever put on that layer.
+func _on_body_entered(body: Node3D) -> void:
+	if not body.is_in_group(HERO_GROUP):
+		return
+	reached.emit(index)

--- a/scenes/map/checkpoint.gd.uid
+++ b/scenes/map/checkpoint.gd.uid
@@ -1,0 +1,1 @@
+uid://dcm22vgqtwoxs

--- a/scenes/map/checkpoint.tscn
+++ b/scenes/map/checkpoint.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scenes/map/checkpoint.gd" id="1_checkpoint"]
+
+[node name="Checkpoint" type="Node3D"]
+script = ExtResource("1_checkpoint")

--- a/scenes/map/level_map.gd
+++ b/scenes/map/level_map.gd
@@ -1,6 +1,6 @@
 class_name LevelMap
 extends Node3D
-## Grid-driven level builder (issues #6, #37).
+## Grid-driven level builder (issues #6, #37, #38).
 ##
 ## The map is authored as ASCII in [member layout] — one character per 4×4
 ## cell — and turned into KayKit dungeon geometry at runtime. Authoring a map
@@ -35,8 +35,14 @@ const CELL_BOSS := "B"
 ## An ordinary floor cell that also marks where a zombie spawns (issue #7).
 ## Encounters are authored in the layout for the same reason the map is: placing
 ## an enemy is editing one character. The map itself never instances enemies —
-## scenes/main.gd reads [method zombie_spawn_positions] and does that.
+## scenes/main.gd reads [method zombie_spawns] and does that.
 const CELL_ZOMBIE := "Z"
+## Ordinary floor cell that also marks a respawn checkpoint (issue #38). A run of
+## orthogonally adjacent `C` cells is *one* checkpoint, so a map author can lay a
+## gate across a door the hero could otherwise walk round: the pads are per cell,
+## the checkpoint is per run. The map only says where — scenes/main.gd instances
+## checkpoint.tscn on the cells, exactly as it does zombies on the `Z` cells.
+const CELL_CHECKPOINT := "C"
 
 ## Physics layers, per the table in scenes/CLAUDE.md.
 const LAYER_GROUND := 1
@@ -77,6 +83,21 @@ const EDGES := [
 ## its own detection radius (12 units = 3 cells) of `S` would charge the hero
 ## the moment the run begins, before the player has taken a single step. The
 ## nearest one here is 7 cells away.
+##
+## [b]That rule binds every `C` cell the hero can respawn on too[/b], and it is
+## sharper there, because the zombies ahead of a checkpoint are restored to their
+## spawns by the very respawn that puts him on it — so the two arrive together,
+## every time, on a player who has just lost a fight. Both checkpoints here were
+## moved to earn it: this one back into the tunnel (it sat at the mouth, one cell
+## from a spawn) and the boss-room guard four cells deeper into its room (it
+## stood in the doorway the gate covers). Nothing is now within 4 cells of a
+## respawn cell.
+##
+## The two checkpoints sit on the only places every route passes through that are
+## *also* late enough to be worth reaching: inside the one-cell tunnel (24 from
+## the start) and on the six-cell threshold of the boss room (46). `S` is
+## checkpoint 0. The remaining cut — the throat out of the start clearing — is
+## four cells from `S` and would bank nothing.
 @export var layout: PackedStringArray = PackedStringArray([
 	"############################################",
 	"############################################",
@@ -86,11 +107,11 @@ const EDGES := [
 	"#####################...Z.................##",
 	"####################..........B...........##",
 	"####################..................Z...##",
-	"#####################.....................##",
+	"#####################.........Z...........##",
 	"#####################....................###",
-	"######################........Z.........####",
+	"######################..................####",
 	"########################..............######",
-	"############################......##########",
+	"############################CCCCCC##########",
 	"#############################....###########",
 	"#####.....####################..############",
 	"####.Z...Z.#################..Z..###########",
@@ -103,7 +124,7 @@ const EDGES := [
 	"##...Z.........#########.................###",
 	"##..........Z..#########..Z..............###",
 	"##...................###..................##",
-	"##...............Z.......Z................##",
+	"##...............Z...CCC.Z................##",
 	"##..Z................###.............Z....##",
 	"###..........###########........Z........###",
 	"####...Z...##############...............####",
@@ -121,6 +142,14 @@ const EDGES := [
 var _start_cell := Vector2i(-1, -1)
 var _boss_cell := Vector2i(-1, -1)
 var _zombie_cells: Array[Vector2i] = []
+var _checkpoint_cells: Array[Vector2i] = []
+## Path distance in cells from the start, per open cell. Keys are Vector2i.
+var _distances := {}
+## Checkpoint groups, ordered by distance from the start, each an Array[Vector2i]
+## whose own cells are ordered the same way. Group 0 is always the start cell.
+var _checkpoint_groups: Array = []
+## Segment index per entry of [member _zombie_cells].
+var _spawn_segments: Array[int] = []
 var _rock_material_cache: StandardMaterial3D = null
 
 
@@ -138,13 +167,41 @@ func boss_position() -> Vector3:
 	return _cell_to_world(_boss_cell)
 
 
-## Floor-level world positions of every `Z` cell, in layout order. Whoever
-## instances the enemies decides what to put there; the map only says where.
-func zombie_spawn_positions() -> Array[Vector3]:
-	var positions: Array[Vector3] = []
-	for cell in _zombie_cells:
-		positions.append(_cell_to_world(cell))
-	return positions
+## Every `Z` cell as `{"position": Vector3, "segment": int}`, in layout order.
+## Whoever instances the enemies decides what to put there; the map only says
+## where, and which stretch of the run it belongs to.
+##
+## The two are returned together rather than as parallel arrays because nothing
+## downstream can tell a mismatched pair apart from a correct one.
+##
+## `segment` is the index of the last checkpoint at or before the spawn's own
+## path distance, so respawning at checkpoint *k* restores exactly the spawns
+## with `segment >= k` — see [method checkpoints].
+func zombie_spawns() -> Array[Dictionary]:
+	var spawns: Array[Dictionary] = []
+	for index in _zombie_cells.size():
+		spawns.append({
+			"position": _cell_to_world(_zombie_cells[index]),
+			"segment": _spawn_segments[index],
+		})
+	return spawns
+
+
+## Every checkpoint, ordered by path distance from the start (issue #38).
+##
+## Entry 0 is the start cell, which is checkpoint 0 by definition — a run always
+## has somewhere to come back to, even before the hero has walked onto a pad.
+## Later entries are the runs of adjacent `C` cells, each entry holding all of
+## that checkpoint's cells with the *nearest* one first, so `[0]` is where the
+## hero respawns and the whole array is where the pads go.
+func checkpoints() -> Array[PackedVector3Array]:
+	var groups: Array[PackedVector3Array] = []
+	for group in _checkpoint_groups:
+		var positions := PackedVector3Array()
+		for cell in group:
+			positions.append(_cell_to_world(cell))
+		groups.append(positions)
+	return groups
 
 
 ## Rebuild the level from [member layout]. Safe to call again after editing it.
@@ -155,6 +212,10 @@ func build() -> void:
 	_start_cell = Vector2i(-1, -1)
 	_boss_cell = Vector2i(-1, -1)
 	_zombie_cells.clear()
+	_checkpoint_cells.clear()
+	_checkpoint_groups.clear()
+	_spawn_segments.clear()
+	_distances.clear()
 
 	if not _validate_layout():
 		return
@@ -172,13 +233,19 @@ func build() -> void:
 				_boss_cell = cell
 			elif kind == CELL_ZOMBIE:
 				_zombie_cells.append(cell)
+			elif kind == CELL_CHECKPOINT:
+				_checkpoint_cells.append(cell)
 			_build_open_cell(cell, kind)
 
-	if not _boss_is_reachable():
+	_distances = _flood_distances({})
+	if not _distances.has(_boss_cell):
 		push_error(
 			"LevelMap: the boss cell is walled off from the start cell. " +
 			"Fix `layout` — the map is unplayable as authored."
 		)
+	_group_checkpoints()
+	_assign_spawn_segments()
+	_warn_about_split_segments()
 	built.emit()
 
 
@@ -338,21 +405,120 @@ func _cell_to_world(cell: Vector2i) -> Vector3:
 	)
 
 
-## Flood-fill the open cells from the start. Catches a map edit that seals the
-## boss room off before anyone has to discover it by walking there.
-func _boss_is_reachable() -> bool:
-	if _start_cell.x < 0 or _boss_cell.x < 0:
-		return false
-	var seen := {_start_cell: true}
+## Path distance in cells from the start to every open cell it can reach,
+## treating each cell of [param blocked] as if it were rock.
+##
+## With nothing blocked this doubles as the reachability check: a boss cell
+## missing from the result is walled off, which catches a map edit that seals the
+## goal away before anyone has to discover it by walking there. With a
+## checkpoint's cells blocked it answers the other question — what lies *behind*
+## that checkpoint — which is what [method _warn_about_split_segments] needs.
+func _flood_distances(blocked: Dictionary) -> Dictionary:
+	var distances := {}
+	if _start_cell.x < 0:
+		return distances
+	distances[_start_cell] = 0
 	var queue: Array[Vector2i] = [_start_cell]
 	while not queue.is_empty():
 		var cell: Vector2i = queue.pop_front()
-		if cell == _boss_cell:
-			return true
+		var distance: int = distances[cell]
 		for edge in EDGES:
 			var next: Vector2i = cell + edge["cell"]
-			if seen.has(next) or _cell_kind(next) == CELL_WALL:
+			if distances.has(next) or blocked.has(next):
 				continue
-			seen[next] = true
+			if _cell_kind(next) == CELL_WALL:
+				continue
+			distances[next] = distance + 1
 			queue.append(next)
-	return false
+	return distances
+
+
+## Collect the `C` cells into checkpoints and order them along the run.
+##
+## Adjacent `C` cells are one checkpoint, which is what lets a gate span a door
+## wide enough to walk round; a checkpoint the player can miss costs them far
+## more progress than the one they thought they had banked. Within a group the
+## nearest cell comes first, so callers have an unambiguous respawn point without
+## averaging positions — an average can land in rock, a cell never does.
+func _group_checkpoints() -> void:
+	var start_group: Array[Vector2i] = [_start_cell]
+	_checkpoint_groups = [start_group]
+	var seen := {}
+	for cell in _checkpoint_cells:
+		if seen.has(cell):
+			continue
+		var group: Array[Vector2i] = []
+		var queue: Array[Vector2i] = [cell]
+		seen[cell] = true
+		while not queue.is_empty():
+			var current: Vector2i = queue.pop_front()
+			group.append(current)
+			for edge in EDGES:
+				var next: Vector2i = current + edge["cell"]
+				if seen.has(next) or _cell_kind(next) != CELL_CHECKPOINT:
+					continue
+				seen[next] = true
+				queue.append(next)
+		if _distance_of(group[0]) < 0:
+			push_error(
+				"LevelMap: the checkpoint at %s is walled off from the start " % group[0] +
+				"cell, so it can never be armed. Fix `layout`."
+			)
+			continue
+		group.sort_custom(func(a: Vector2i, b: Vector2i) -> bool:
+			return _distance_of(a) < _distance_of(b)
+		)
+		_checkpoint_groups.append(group)
+	_checkpoint_groups.sort_custom(func(a: Array, b: Array) -> bool:
+		return _distance_of(a[0]) < _distance_of(b[0])
+	)
+
+
+## File each spawn under the last checkpoint at or before its own path distance.
+func _assign_spawn_segments() -> void:
+	for cell in _zombie_cells:
+		var distance := _distance_of(cell)
+		var segment := 0
+		for index in _checkpoint_groups.size():
+			if distance >= _distance_of(_checkpoint_groups[index][0]):
+				segment = index
+		_spawn_segments.append(segment)
+
+
+## Catch the authoring hazard the segment rule creates.
+##
+## Segments are cut by path distance, but "behind the checkpoint" is really a
+## question about routes, and the two only agree while nothing hangs off the
+## route deeper than the next checkpoint is far. A dead-end spur longer than the
+## run to the next checkpoint breaks that: its far end scores a distance past the
+## checkpoint, so a spawn the player cleared *before* the checkpoint is filed
+## ahead of it and comes back on every respawn — for no reason the player can
+## see, in a place they have already left.
+##
+## Only spawns are checked, not cells. An empty cell filed on the wrong side of a
+## checkpoint changes nothing that anyone can observe, and the current level has
+## eleven of them in the deep corners of the south vault; warning about those
+## would train everyone to ignore this.
+func _warn_about_split_segments() -> void:
+	for index in range(1, _checkpoint_groups.size()):
+		var blocked := {}
+		for cell in _checkpoint_groups[index]:
+			blocked[cell] = true
+		var behind := _flood_distances(blocked)
+		for spawn in _zombie_cells.size():
+			if _spawn_segments[spawn] < index or not behind.has(_zombie_cells[spawn]):
+				continue
+			push_warning(
+				"LevelMap: the spawn at %s is reachable without passing " % _zombie_cells[spawn] +
+				"checkpoint %d, but sits in segment %d, so it will be " % [
+					index, _spawn_segments[spawn],
+				] +
+				"restored on every respawn there. Shorten the spur it is on, " +
+				"or move the checkpoint past it."
+			)
+
+
+func _distance_of(cell: Vector2i) -> int:
+	if not _distances.has(cell):
+		return -1
+	return int(_distances[cell])

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -109,10 +109,21 @@ both an attack and a selection, or as neither, depending on which node
   else here survived being permanent.
 - **A unit can now leave the level without dying**, and that broke an assumption
   this folder had held since #36. `scenes/main.gd` *removes* the zombies ahead
-  of a checkpoint on respawn, so `UnitSelection` can be watching a `Health` that
-  is freed rather than merely dead — a reference that is non-null and unusable
-  at once. `_stop_watching()` therefore tests `is_instance_valid`, not `!= null`.
-  Anything else here that holds a unit between frames has the same problem.
+  of a checkpoint on respawn, so a `Health` this folder is watching can be freed
+  rather than merely dead — a reference that is non-null and unusable at once.
+  **Both** `UnitSelection._stop_watching()` and `UnitInfoBar._unsubscribe()`
+  therefore test `is_instance_valid`, not `!= null`. Only the first is reachable
+  today; the panel is spared by `scenes/main.gd` redirecting it before it clears
+  anything. That protection lives in another folder, which is exactly why the
+  two are not allowed to differ here — a reader finding one guarded and one not
+  would reasonably conclude the difference meant something.
+- **The checkpoint flash is cancelled when the death screen goes up.** Arming a
+  checkpoint and dying seconds later is not a corner case — a zombie chasing the
+  hero across a threshold produces it — and a "CHECKPOINT" still fading behind
+  "YOU DIED" reads as congratulating the player on the death. Killing the tween
+  is the load-bearing half: it drives `modulate:a`, so hiding the label without
+  it leaves the fade running and re-hiding it a second later, over whatever came
+  next.
 - **`flash_checkpoint()` is the second half of the checkpoint feedback, not the
   whole of it.** The lit pad in the world is the lasting signal and this is the
   transient one, for a player watching the fight rather than the floor they just

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -139,4 +139,4 @@ both an attack and a selection, or as neither, depending on which node
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: f0a582f -->
+<!-- verified-against: a5a431e -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -150,4 +150,4 @@ both an attack and a selection, or as neither, depending on which node
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: a5a431e -->
+<!-- verified-against: ac81093 -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -10,7 +10,8 @@ five elements and one of them non-trivial.
 
 - `hud.tscn` / `hud.gd` (`class_name HUD`) — the `CanvasLayer`. Holds the hero's
   health bar (bottom-left), the armed-attack indicator, the controls crib sheet
-  (top-left), the death label, and an instance of the info bar.
+  (top-left), the death screen, the checkpoint confirmation, and an instance of
+  the info bar.
 - `unit_info_bar.tscn` / `unit_info_bar.gd` (`class_name UnitInfoBar`) — the
   bottom-centre panel: name, live HP as `current / max`, and damage / attack
   speed / move speed.
@@ -34,6 +35,11 @@ The hero is selected at startup and selection falls back to him from everything
 else: a click on ground, sky, a wall or a corpse, and the death of whatever was
 selected. There is deliberately no "nothing selected" state — an empty panel is
 dead screen space.
+
+The hero's *own* death is the exception, and it stays that way: the panel holds
+on him, reads 0 through the death screen, and fills again when `scenes/main.gd`
+revives him. It used to be an exception because there was nothing to fall back
+to and the run was about to reload; it is now also the right answer.
 
 ## The unit contract
 
@@ -98,6 +104,20 @@ both an attack and a selection, or as neither, depending on which node
   while an enemy is selected the panel shows the *enemy's* health, and a player
   who cannot see their own mid-fight is worse off than one looking at a
   redundant bar.
+- **The death screen has to come back off** now that a death is a respawn rather
+  than a scene reload (issue #38), which is what `hide_death()` is for. Nothing
+  else here survived being permanent.
+- **A unit can now leave the level without dying**, and that broke an assumption
+  this folder had held since #36. `scenes/main.gd` *removes* the zombies ahead
+  of a checkpoint on respawn, so `UnitSelection` can be watching a `Health` that
+  is freed rather than merely dead — a reference that is non-null and unusable
+  at once. `_stop_watching()` therefore tests `is_instance_valid`, not `!= null`.
+  Anything else here that holds a unit between frames has the same problem.
+- **`flash_checkpoint()` is the second half of the checkpoint feedback, not the
+  whole of it.** The lit pad in the world is the lasting signal and this is the
+  transient one, for a player watching the fight rather than the floor they just
+  crossed. Both exist because either alone is missable: pads sit at the edge of
+  a one-cell tunnel where the camera barely sees them.
 - `%g` does not exist in GDScript format strings, hence the by-hand trim of a
   trailing `.0` in the stat numbers.
 
@@ -107,7 +127,13 @@ both an attack and a selection, or as neither, depending on which node
   `NodePath`, the way the camera's `target` is.
 - Consumes `Hero.select_clicked`, and `Health.health_changed` / `Health.died` on
   whatever is selected. `scenes/main.gd` also calls `set_hero_health()`,
-  `set_attack_move_armed()` and `show_death()` from the hero's own signals.
+  `set_attack_move_armed()`, `show_death()` / `hide_death()` and
+  `flash_checkpoint()` — the last from `Checkpoint.reached`, the only HUD call
+  that does not originate with the hero.
+- **`scenes/main.gd` re-selects the hero on every respawn**, before it clears
+  the restored segment. That ordering is its concern, not this folder's, but it
+  is the reason a freed selection is rare rather than routine — the
+  `is_instance_valid` guard above is what makes it merely rare and not fatal.
 - Emits `UnitSelection.selection_changed(unit)`, consumed by `HUD` only.
 - **Order matters at startup:** `scenes/main.gd` connects `selection_changed`
   *before* calling `select_unit(hero)`, because the info bar learns the initial

--- a/scenes/ui/hud.gd
+++ b/scenes/ui/hud.gd
@@ -14,11 +14,21 @@ extends CanvasLayer
 ## enemy's health, and a player who cannot see their own during a fight is worse
 ## off than one looking at a redundant bar.
 
+## How long the checkpoint confirmation holds before it starts fading, and how
+## long the fade takes. Long enough to read mid-fight, short enough that it is
+## gone before the fight the checkpoint was banked for.
+const CHECKPOINT_HOLD := 1.1
+const CHECKPOINT_FADE := 0.7
+
 @onready var _hero_health_bar: ProgressBar = $HeroHealthBar
 @onready var _hero_health_value: Label = $HeroHealthBar/Value
 @onready var _attack_move_label: Label = $AttackMoveLabel
 @onready var _death_label: Label = $DeathLabel
+@onready var _death_sub_label: Label = $DeathSubLabel
+@onready var _checkpoint_label: Label = $CheckpointLabel
 @onready var _unit_info_bar: UnitInfoBar = $UnitInfoBar
+
+var _checkpoint_tween: Tween = null
 
 
 ## Always-visible player health, whatever is selected.
@@ -42,3 +52,26 @@ func set_attack_move_armed(armed: bool) -> void:
 
 func show_death() -> void:
 	_death_label.show()
+	_death_sub_label.show()
+
+
+## Death is no longer the end of the run (issue #38), so the screen has to come
+## back off again.
+func hide_death() -> void:
+	_death_label.hide()
+	_death_sub_label.hide()
+
+
+## Confirm that a checkpoint is now armed.
+##
+## The lit pad in the world is the lasting signal; this is the one that reaches a
+## player who is watching the fight rather than the floor they just crossed.
+func flash_checkpoint() -> void:
+	if _checkpoint_tween != null and _checkpoint_tween.is_valid():
+		_checkpoint_tween.kill()
+	_checkpoint_label.modulate.a = 1.0
+	_checkpoint_label.show()
+	_checkpoint_tween = create_tween()
+	_checkpoint_tween.tween_interval(CHECKPOINT_HOLD)
+	_checkpoint_tween.tween_property(_checkpoint_label, "modulate:a", 0.0, CHECKPOINT_FADE)
+	_checkpoint_tween.tween_callback(_checkpoint_label.hide)

--- a/scenes/ui/hud.gd
+++ b/scenes/ui/hud.gd
@@ -51,6 +51,11 @@ func set_attack_move_armed(armed: bool) -> void:
 
 
 func show_death() -> void:
+	# Cancel any checkpoint flash still fading. Arming a checkpoint and dying
+	# seconds later is not a corner case — a zombie chasing the hero across a
+	# threshold produces exactly that — and "CHECKPOINT" fading out behind "YOU
+	# DIED" reads as congratulating the player on the death.
+	_clear_checkpoint_flash()
 	_death_label.show()
 	_death_sub_label.show()
 
@@ -67,11 +72,19 @@ func hide_death() -> void:
 ## The lit pad in the world is the lasting signal; this is the one that reaches a
 ## player who is watching the fight rather than the floor they just crossed.
 func flash_checkpoint() -> void:
-	if _checkpoint_tween != null and _checkpoint_tween.is_valid():
-		_checkpoint_tween.kill()
+	_clear_checkpoint_flash()
 	_checkpoint_label.modulate.a = 1.0
 	_checkpoint_label.show()
 	_checkpoint_tween = create_tween()
 	_checkpoint_tween.tween_interval(CHECKPOINT_HOLD)
 	_checkpoint_tween.tween_property(_checkpoint_label, "modulate:a", 0.0, CHECKPOINT_FADE)
 	_checkpoint_tween.tween_callback(_checkpoint_label.hide)
+
+
+## Kill a running fade and take the label down. Both callers need the tween
+## stopped first: it drives `modulate:a`, so it would keep animating a hidden
+## label and then re-hide it a second later, over whatever came next.
+func _clear_checkpoint_flash() -> void:
+	if _checkpoint_tween != null and _checkpoint_tween.is_valid():
+		_checkpoint_tween.kill()
+	_checkpoint_label.hide()

--- a/scenes/ui/hud.tscn
+++ b/scenes/ui/hud.tscn
@@ -73,3 +73,39 @@ theme_override_font_sizes/font_size = 48
 text = "YOU DIED"
 horizontal_alignment = 1
 vertical_alignment = 1
+
+[node name="DeathSubLabel" type="Label" parent="."]
+visible = false
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -240.0
+offset_top = 48.0
+offset_right = 240.0
+offset_bottom = 80.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(0.78, 0.66, 1, 1)
+theme_override_font_sizes/font_size = 20
+text = "Returning to the last checkpoint"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="CheckpointLabel" type="Label" parent="."]
+visible = false
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -240.0
+offset_top = -160.0
+offset_right = 240.0
+offset_bottom = -120.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(0.78, 0.66, 1, 1)
+theme_override_font_sizes/font_size = 28
+text = "CHECKPOINT"
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/scenes/ui/unit_info_bar.gd
+++ b/scenes/ui/unit_info_bar.gd
@@ -55,8 +55,14 @@ func show_unit(unit: Node3D) -> void:
 	show()
 
 
+## is_instance_valid, not a null check, for the reason UnitSelection records: a
+## unit can leave the level without dying, so this can be holding a freed Health
+## — a reference that is non-null and unusable at once. Ordering in
+## scenes/main.gd happens to redirect the panel before anything is freed, but
+## that protection lives in another folder, and the sibling class does not lean
+## on it.
 func _unsubscribe() -> void:
-	if _health != null and _health.health_changed.is_connected(_on_health_changed):
+	if is_instance_valid(_health) and _health.health_changed.is_connected(_on_health_changed):
 		_health.health_changed.disconnect(_on_health_changed)
 	_health = null
 	_hp_bar.show()

--- a/scenes/ui/unit_selection.gd
+++ b/scenes/ui/unit_selection.gd
@@ -122,15 +122,20 @@ func _start_watching() -> void:
 		_health.died.connect(_on_selected_died)
 
 
+## is_instance_valid, not a null check: a unit can now leave the level without
+## dying — scenes/main.gd removes the ones ahead of a checkpoint on respawn — and
+## a freed Health is a reference that is non-null and unusable at the same time.
 func _stop_watching() -> void:
-	if _health != null and _health.died.is_connected(_on_selected_died):
+	if is_instance_valid(_health) and _health.died.is_connected(_on_selected_died):
 		_health.died.disconnect(_on_selected_died)
 	_health = null
 
 
 ## The selected unit died, so the bar would be showing a corpse. Fall back to
 ## the hero — except when it *is* the hero, where there is nothing to fall back
-## to and scenes/main.gd is already restarting the run.
+## to. Staying on him is also the right answer now that a death is a respawn
+## rather than a reload (issue #38): the panel reads 0 through the death screen
+## and fills again when scenes/main.gd revives him, with no reselection needed.
 func _on_selected_died() -> void:
 	if _selected == hero:
 		return


### PR DESCRIPTION
Fixes #38. Step 4 of the winnable-loop batch ([[game-design/winnable-loop]] in
Flowdex); only the boss and victory screen (#39) are left after this.

Dying no longer reloads the scene. The hero comes back at the last checkpoint he
armed, at full health, with the run around him intact.

## The reset rule

Decided in the issue, implemented here: **only zombies past the checkpoint come
back.** Everything cleared behind it stays cleared, so a death costs the fight
you lost; everything ahead is restored *as authored*, so a hard fight cannot be
whittled down by dying at it repeatedly.

"Past the checkpoint" is computed rather than authored. One BFS from `S` gives
every open cell a distance; checkpoints sort by it; a spawn belongs to the last
checkpoint at or before its own. Nothing is numbered by hand, so moving a
checkpoint re-files every spawn behind it. That same flood-fill is now also the
boss-reachability check, so the two cannot disagree.

## Authoring

A new `C` layout character marks a checkpoint, and **a run of adjacent `C` cells
is one checkpoint** — that is what lets a gate span a door wide enough to walk
round. A checkpoint the player can miss costs them far more than the one they
believed they had banked. `S` is checkpoint 0 and gets no pad.

Two go on this map: three cells filling the tunnel between the clearings
(distance 24), and a six-cell gate across the boss-room threshold (46). The run
splits **7 / 9 / 3** zombies. The third one-cell cut — the throat out of the
start clearing — is four cells from `S` and would bank nothing.

## Three things the implementation forced

Each is documented in the folder that owns it; flagging them here because they
are the parts worth arguing with.

**1. The two-cell boss door is the obvious second checkpoint and the wrong one.**
The south vault runs to distance 47 while the door sits at 44, so a spawn the
player cleared *before* the door files into the segment *after* it and returns on
every respawn — in a place they have already left, for no reason they can see.
That is exactly the authoring constraint the issue predicted, hit on its first
use. It now fails loudly rather than being a rule to remember:
`_warn_about_split_segments()` re-floods with each checkpoint's cells blocked and
warns about any spawn reachable *around* it. Moving the checkpoint two rows on to
the threshold (46) costs nothing — no spawn sits between 45 and 47, so the split
is identical either way. The check deliberately looks at spawns, not cells: the
level has eleven empty cells on the wrong side and warning about those would
train everyone to ignore it.

**2. "Keep spawns clear of the start" binds every respawn cell, and harder.** A
respawn restores the zombies ahead of the checkpoint *to their spawns*, so one
too close arrives with the hero — every time, on a player who has just lost a
fight. The first placement had the hero respawning one cell from a spawn and
losing 9 HP before he could take a step. Both checkpoints moved to earn the
clearance and the boss-room guard moved four cells deeper into its room; nothing
is now within 4 cells of a respawn cell.

**3. A unit can now leave the level without dying.** `scenes/main.gd` removes the
zombies ahead of the checkpoint, so `UnitSelection` could be holding a `Health`
that is *freed* rather than merely dead — non-null and unusable at once. That was
unreachable before this PR (a corpse always announced itself first).
`_stop_watching()` now tests `is_instance_valid`, and main re-selects the hero
before it clears.

## Design calls worth a second opinion

- **Most recently armed wins, not furthest reached** — the issue's wording, kept
  literally. Walking back through an earlier pad really does hand back the ground
  in between. Defensible because the lit pad is the promise being made and a
  player can read it off the screen; say so if you would rather it ratcheted.
- **Clear then re-spawn, rather than a reset method on `Zombie`.** Freeing and
  re-instancing makes "restored zombies are home in ROAM, not chasing" true for
  free, and keeps `scenes/enemies/` from learning that checkpoints exist.
- **Pads are violet.** Forced from both sides: the map paints the start green and
  the boss red, and `scenes/ui/` rings units cyan and orange. A pad is somewhere
  units *stand*, so a ring is drawn on top of it every time it matters.
- **`zombie_spawn_positions()` became `zombie_spawns()`**, returning position and
  segment together. Parallel arrays would have been the smaller diff, but nothing
  downstream can tell a mismatched pair from a correct one.

## Verification

Driven headlessly against the running game with a throwaway `SceneTree` probe
(not committed), three scenarios:

| | result |
|---|---|
| Segments | 7 / 9 / 3, checkpoint 2 grouped from 6 cells |
| Kill everything, arm checkpoint 1, die | segment 0 stays dead; 12 restored, all at their spawn homes in `ROAM`, full HP; hero at the pad, 100/100; no corpses left over |
| Die with a zombie mid-chase (`ATTACK`, 6 HP) | back as a fresh instance, `ROAM`, at home, 30 HP |
| Die before touching any pad | falls back to checkpoint 0; all 19 restored |

`_warn_about_split_segments()` is silent on the committed layout, and screenshots
were taken of both pads armed and disarmed to check the violet reads against the
floor and under a selection ring.

## Not done here

- The camera still has no level bounds (#43) — respawning snaps it, same as
  startup, so this does not make it worse.
- No death-screen input handling: the 2.5 s wait is fixed, not skippable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
