### PR TITLE
End boss and victory screen

### DIFF
--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -227,4 +227,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: ac81093 -->
+<!-- verified-against: c6b15fb -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -108,7 +108,14 @@ what winning *means* belongs here.
 - **Death is ignored once the boss is down.** `_run_over` is set on the boss's
   `died`, before the beat that precedes the screen, because the boss room still
   has zombies in it and the hero is standing in the middle of them. A respawn
-  starting behind the victory screen would take the win back.
+  starting behind the victory screen would take the win back. **It is tested on
+  both sides of the respawn wait**, and the second test is not the first one
+  repeated: a run can be won *during* that wait, and `create_timer` keeps
+  counting through the pause a win brings with it. That half is unreachable
+  today only because the hero is the only thing that can damage the boss and
+  cannot swing while dead — an invariant about who damages what which no folder
+  owns and nothing states. Cross-review of PR #50 asked for the line rather than
+  the invariant, and it was right to.
 - **The beat before the screen is load-bearing, not polish.** A corpse tween is
   bound to the corpse, so pausing on the frame the boss dies leaves it halfway
   through toppling over, underneath a banner saying it is dead.

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -21,9 +21,9 @@ Top-level game scenes and their scripts.
      (`bake_navigation_mesh(false)`) because the web export has threads
      disabled, so don't switch it to on-thread baking. On the open level this
      costs ~55 ms at startup, up from ~12 ms on the maze;
-  4. **then** it lays the checkpoint pads and spawns one zombie per `Z` cell of
-     the map. Enemies path on the navmesh, so they must not exist before the
-     bake.
+  4. **then** it lays the checkpoint pads, spawns one zombie per `Z` cell of
+     the map, and puts the boss on the `B` cell. Enemies path on the navmesh, so
+     they must not exist before the bake.
 - **Enemy spawning** sets `position` *before* `add_child`, because
   `Zombie._ready()` captures `global_position` as the home its roam area and
   leash are measured from. `Enemies` sits at the origin so local and global
@@ -42,6 +42,10 @@ hero's `health_changed`, `attack_move_armed_changed`, `died` and
 `select_clicked` to methods on the two `scenes/ui/` nodes, and connects
 `UnitSelection.selection_changed` to the `HUD`. It never touches a Label. Add UI
 there, not here, and keep it reachable by method rather than by node path.
+
+**One wire runs the other way**: `HUD.restart_requested` into `_restart_run()`.
+The victory screen asks, this script decides — a widget must not be the thing
+that knows what starting a run means.
 
 One ordering rule lives in `_ready()`: `selection_changed` is connected
 **before** `select_unit(_hero)` is called, because the info bar learns the
@@ -82,6 +86,40 @@ belongs to; deciding what a death costs is this folder's.
 - The camera is snapped after the teleport, for the same reason `_ready()` snaps
   after placing the hero, and the info bar is pointed back at him *before* the
   clear: it has no way to notice a unit that is removed rather than killed.
+
+## Winning, and starting again (issue #39)
+
+The boss is the only enemy whose `died` anything listens to, and `main.gd` is
+where the listening happens: this folder already owns what a death costs, so it
+owns what a kill is worth beside it. The screen itself belongs to `scenes/ui/`;
+what winning *means* belongs here.
+
+- **The boss is spawned like a zombie and restored like one.** It comes from
+  `LevelMap.boss_position()` / `boss_segment()` rather than the spawn list,
+  because it is one authored instance — but it is parented under `Enemies` with
+  the same segment metadata, so `_clear_from_segment()` sweeps it up and
+  `_spawn_boss()` puts it back on exactly the terms the zombies around it get.
+  That is what makes dying to the boss a retry: without it a respawn at the gate
+  would clear the boss away and leave a run that cannot be finished.
+- **Winning freezes the tree** (`get_tree().paused`), which is what makes the
+  run *over* rather than merely won — otherwise the hero can still be commanded
+  around, and still killed, behind a VICTORY banner. `scenes/ui/` keeps the
+  victory panel processing so its button still answers.
+- **Death is ignored once the boss is down.** `_run_over` is set on the boss's
+  `died`, before the beat that precedes the screen, because the boss room still
+  has zombies in it and the hero is standing in the middle of them. A respawn
+  starting behind the victory screen would take the win back.
+- **The beat before the screen is load-bearing, not polish.** A corpse tween is
+  bound to the corpse, so pausing on the frame the boss dies leaves it halfway
+  through toppling over, underneath a banner saying it is dead.
+- **Restarting reloads the scene, where a death deliberately does not.** The
+  asymmetry is the point: a death has to preserve everything cleared behind the
+  armed checkpoint, which is why issue #38 took the reload *out* of that path;
+  a restart has to discard exactly that. Rebuilding is the only version of
+  "discard all of it" that cannot forget a piece of run state — including the
+  ones not written yet, like issue #8's XP. The pause flag is the exception that
+  proves it: it lives on the `SceneTree` rather than the scene, so `_restart_run`
+  clears it by hand or the new run comes up frozen.
 
 ## Navmesh gotchas (learned the hard way)
 
@@ -157,9 +195,10 @@ describes. See `scenes/enemies/CLAUDE.md`.
 
 - Instances `scenes/map/level_map.tscn`, `scenes/hero/hero.tscn`,
   `scenes/ui/hud.tscn` and `scenes/ui/unit_selection.tscn` from the .tscn, and
-  `scenes/enemies/zombie.tscn` and `scenes/map/checkpoint.tscn` at runtime. Two
-  exports are wired here as `NodePath`s and both point at the hero: the camera's
-  `target` and `UnitSelection.hero`.
+  `scenes/enemies/zombie.tscn`, `scenes/enemies/boss.tscn` and
+  `scenes/map/checkpoint.tscn` at runtime. Two exports are wired here as
+  `NodePath`s and both point at the hero: the camera's `target` and
+  `UnitSelection.hero`.
 - **Input actions** are defined in `project.godot` and every one of them is
   consumed by `scenes/hero/`, not by anything in this folder. What each *means*
   is that folder's to document; this is only the inventory:
@@ -168,15 +207,18 @@ describes. See `scenes/enemies/CLAUDE.md`.
 - `LevelMap` emits `built`; nothing consumes it yet.
 - `main.gd` consumes `Checkpoint.reached` and calls `Checkpoint.set_armed()`
   back on every pad, so exactly one is lit. It calls `Hero.respawn_at()` and, on
-  the way, `HUD.show_death()` / `hide_death()` / `flash_checkpoint()`.
+  the way, `HUD.show_death()` / `hide_death()` / `flash_checkpoint()` —
+  plus `HUD.show_victory()` when the boss falls. It consumes
+  `HUD.restart_requested` in return.
 - `main.gd` consumes `Hero.died`, `Hero.health.health_changed`,
   `Hero.attack_move_armed_changed` and `Hero.select_clicked`, forwarding each to
   `scenes/ui/`. Unconsumed so far: `Hero.move_ordered` and `Hero.attack_ordered`
   — this doc used to earmark them "for the selection UI, issue #36", and that
   turned out to be wrong: selection is deliberately inert and reads nothing
-  about what the hero is doing. They now have no planned consumer. Also
-  unconsumed are both death signals, `Zombie.died` and the hero's attributed
-  `Hero.killed`, which are the XP hooks for issue #8.
+  about what the hero is doing. They now have no planned consumer. `Zombie.died`
+  is consumed **on the boss and nowhere else** (issue #39) — every trash zombie's
+  is still dropped, as is the hero's attributed `Hero.killed`, and both remain
+  the XP hooks for issue #8.
 
 ## Tooling note
 

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -234,4 +234,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: c6b15fb -->
+<!-- verified-against: a29d8c3 -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -4,14 +4,19 @@ depends-on: [scenes, scenes/hero, scenes/map, scenes/components, scenes/ui, asse
 
 # scenes/enemies/
 
-Hostile actors. Currently just the basic zombie (issue #7).
+Hostile actors: the basic zombie (issue #7) and the end boss (issue #39). They
+are **one script and two scenes**.
 
 - `zombie.tscn` — `CharacterBody3D`, collision layer 4 (enemies), mask 1|2|3.
   Placeholder green capsule + facing "nose" under a `Visual` node, a
   `CollisionShape3D`, a `NavigationAgent3D`, and a `Health` child (30 HP). In
   the `enemies` group — that is how the hero finds and targets it, so don't
   rename it: `scenes/hero/` looks enemies up by group, never by class.
-- `zombie.gd` (`class_name Zombie`) — roam / notice / chase / melee AI.
+- `boss.tscn` — the end boss. Structurally identical to the above, down to the
+  layer, the mask and the group: the same script, a capsule scaled ~1.75×, and
+  different export values. See "The boss" below.
+- `zombie.gd` (`class_name Zombie`) — roam / notice / chase / melee AI, and the
+  script on both scenes. Nothing in it knows which of the two it is running.
 
 ## The four radii
 
@@ -53,7 +58,13 @@ from where the map author placed them.
   when there are attack animations to hang it on.
 - **RETURN** — leashed or lost him. **Ignores the hero until home is reached**,
   so he cannot chain-pull a zombie across the map by re-entering its detection
-  radius at the edge of the leash.
+  radius at the edge of the leash. It exits on `from_home <= roam_radius` **or**
+  on the walk home finishing, and the second half is not belt-and-braces: the
+  nav agent stops within `target_desired_distance` (1.0) of its goal, so a guard
+  with `roam_radius = 0` never satisfies the first and would stand at its post
+  in RETURN for the rest of the run — the one state that cannot acquire a
+  target. Added with the boss, which is the first instance to have no patch at
+  all; for any wider radius the distance test still wins and nothing changed.
 - **DEAD** — goes inert (layer and mask both zeroed), emits `died(zombie)`, then
   a tween falls it over, lingers, sinks it and frees it. **`_physics_process`
   returns immediately for a dead body, above the gravity block**, and that
@@ -92,6 +103,62 @@ Together they mean the only way to undo damage is to actually break away. That
 is what closes the chip-and-retreat exploit `leash_radius` would otherwise hand
 the hero, now that he can deal damage at all (issue #11).
 
+## The boss (issue #39)
+
+`boss.tscn` is `zombie.gd` with different numbers, which is what this folder was
+built for — every stat has been a per-instance export since #7 precisely so the
+boss would not need a second AI. It did not: no new script, no new state, and no
+change in `scenes/ui/`, because a unit describes itself to the info bar through
+`unit_info()` and `display_name` and the boss simply reports bigger numbers.
+
+| Export | Zombie | Boss | Why the boss's value |
+|--------|--------|------|----------------------|
+| `max_health` (on `Health`) | 30 | 240 | 20 hero swings — a fight with a shape, not a slog |
+| `attack_damage` | 9 | 25 | four hits kill a full-health hero |
+| `attack_cooldown` | 1.3 | 2.0 | the damage is huge, so it has to be dodgeable |
+| `attack_range` | 2.0 | 3.0 | **longer than the hero's 2.2** — see below |
+| `chase_speed` | 3.4 | 2.2 | slow enough that kiting is a real option |
+| `roam_radius` | 6 | 0 | a guard, not a wanderer |
+| `detection_radius` | 12 | 18 | notices the hero ~4.5 cells into the room |
+| `aggro_radius` | 18 | 24 | above detection, so the hysteresis still exists |
+| `leash_radius` | 26 | 22 | under the 24 units from its post to the gate |
+| `alert_delay` | 0.5 | 1.0 | a longer, more readable wind-up |
+| `regen_delay` / `regen_per_second` | 6 / 3 | 8 / 12 | leaving the fight resets it |
+| `display_name` | `"Zombie"` | `"Zombie Warlord"` | what the info bar calls it |
+
+Three of those are the design rather than the tuning, and are the ones to argue
+with before touching the rest:
+
+- **The boss out-reaches the hero, where every zombie under-reaches him.** The
+  zombie's 2.0 against his 2.2 is what makes trading blows toe-to-toe *not* a
+  coin flip; inverting it means the boss cannot be out-traded at all and has to
+  be fought by moving. That is the whole encounter, and it is why `chase_speed`
+  is low enough for kiting to work.
+- **`roam_radius = 0` and a leash shorter than the way out make it a guard.**
+  Its post is 6 cells (24 units) from the boss-room gate and it turns back at
+  5.5, so it can never follow the hero out of the room, and there is no wander
+  that could carry it there either. The leash binds before `aggro_radius` does,
+  deliberately.
+- **Breaking off the fight resets it.** Regeneration is state-gated (see above),
+  so kiting inside the room never heals it — only a genuine disengage does, at
+  12 HP/s against the hero's 4. Retreating to heal is therefore a net loss and
+  the fight has to be won in one engagement. The 8 s delay is what keeps a
+  two-second reposition free.
+
+The stats are a first pass and are meant to be argued with: nothing in the game
+was balanced against an end boss before there was one.
+
+**It does not aggro on the frame the hero respawns**, and that is the same
+invariant `scenes/map/` states for spawns rather than a second rule: the boss
+sits 6 cells from the boss-room checkpoint, outside both its own
+`detection_radius` (4.5 cells) and the hero's `acquire_radius`. Moving the
+checkpoint closer, or raising either radius, breaks it.
+
+**Its selection ring is a crescent, not a ring** — issue #49. The ring in
+`scenes/ui/` is one fixed torus of outer radius 0.7, which is exactly the boss's
+body radius, so only the near arc clears the capsule. It still reads; anything
+wider than this will not.
+
 ## Gotchas
 
 - **Sensing is throttled** to one tick per `SENSE_INTERVAL` (0.2 s), and the
@@ -123,9 +190,9 @@ the hero, now that he can deal damage at all (issue #11).
   inside rock becomes the nearest reachable spot instead of a path request that
   resolves to nothing.
 - **The hit flash needs its own material, and `_ready()` duplicates one.** The
-  body material is a sub-resource of `zombie.tscn`, and Godot shares a scene's
-  sub-resources across every instance of it — tinting one zombie would tint the
-  whole horde. `_claim_own_material()` duplicates it per instance. Done in code
+  body material is a sub-resource of the scene — of either scene — and Godot
+  shares a scene's sub-resources across every instance of it, so tinting one
+  zombie would tint the whole horde. `_claim_own_material()` duplicates it per instance. Done in code
   rather than by ticking `resource_local_to_scene` on the resource: an editor
   round-trip can quietly clear a flag, and nothing would fail until someone
   noticed the entire map flashing at once. Anything else that animates a
@@ -157,9 +224,12 @@ the hero, now that he can deal damage at all (issue #11).
   the `enemies` group, without ever naming `Zombie`. So the pair of methods and
   the group name are a two-way contract; changing either signature breaks a
   folder that does not mention this one.
-- Emits `died(zombie)`. Nothing consumes it yet — it is the hook for XP
-  (issue #8). Note the hero emits its own `killed(victim)` from the swing that
-  lands the blow, which is the *attributed* version of the same moment.
+- Emits `died(zombie)`. **`scenes/main.gd` connects it on the boss and on
+  nothing else** (issue #39): one enemy in the level has a death that ends the
+  run, and every other one is still dropped. It remains the hook XP will hang
+  off (issue #8), and the hero still emits his own `killed(victim)` from the
+  swing that lands the blow, which is the *attributed* version of the same
+  moment.
 - **Describes itself to the unit info bar** through `unit_info()` and the
   `display_name` export (per-instance like every stat, so the boss-room guard
   the class docs describe can announce itself without a new scene). The travel
@@ -171,8 +241,11 @@ the hero, now that he can deal damage at all (issue #11).
 - Spawned by `scenes/main.gd` from `LevelMap.zombie_spawns()` — the `Z` cells of
   `scenes/map/level_map.gd`, each carrying the checkpoint segment it belongs to.
   The spawner sets `position` *before* `add_child`, because `_ready()` captures
-  `global_position` as home.
-- **It also removes them** (issue #38): on respawn, every zombie in the restored
+  `global_position` as home. **The boss is placed from `boss_position()` and
+  `boss_segment()` instead**, being one authored instance rather than a list
+  entry — but it lands under the same parent carrying the same segment metadata,
+  which is what lets everything below apply to it unchanged.
+- **It also removes them** (issue #38): on respawn, every enemy in the restored
   segment is freed and re-instanced, living, chasing or already a corpse. That
   is why "restored zombies are home in `ROAM`" needs no reset method here — a
   fresh instance is the reset. Two consequences worth knowing: a zombie can
@@ -180,7 +253,9 @@ the hero, now that he can deal damage at all (issue #11).
   reference to one must survive (`scenes/ui/` does, and says so); and the
   segment lives on the instance as node metadata rather than as anything this
   script knows about, so nothing in here needs to learn about checkpoints.
-- Still a placeholder capsule. The Quaternius zombie models in
-  `assets/characters/zombies/` are imported but unused, matching the hero.
+- Still placeholder capsules, both of them. The Quaternius zombie models in
+  `assets/characters/zombies/` are imported but unused, matching the hero — and
+  the boss has no model of its own at all, so whatever it eventually wears is a
+  separate question from what the horde does.
 
 <!-- verified-against: ac81093 -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -119,12 +119,22 @@ change in `scenes/ui/`, because a unit describes itself to the info bar through
 | `attack_range` | 2.0 | 3.0 | **longer than the hero's 2.2** — see below |
 | `chase_speed` | 3.4 | 2.2 | slow enough that kiting is a real option |
 | `roam_radius` | 6 | 0 | a guard, not a wanderer |
+| `roam_speed` | 1.3 | 1.0 | the walk *back to its post* — see below |
 | `detection_radius` | 12 | 18 | notices the hero ~4.5 cells into the room |
 | `aggro_radius` | 18 | 24 | above detection, so the hysteresis still exists |
 | `leash_radius` | 26 | 22 | under the 24 units from its post to the gate |
 | `alert_delay` | 0.5 | 1.0 | a longer, more readable wind-up |
 | `regen_delay` / `regen_per_second` | 6 / 3 | 8 / 12 | leaving the fight resets it |
 | `display_name` | `"Zombie"` | `"Zombie Warlord"` | what the info bar calls it |
+
+**`roam_speed` is the one that looks inert and is not**, which is worth stating
+because a reader who checks will reach for the wrong conclusion first: with no
+roam radius the boss never walks anywhere in `ROAM`, so the obvious reading is
+that the value is dead and the override pointless. But `RETURN` also travels at
+`roam_speed` — only `CHASE` uses `chase_speed` — so this is the speed the boss
+shambles back to its post at after a leash, which is the *only* time it walks
+without a target. Cross-review of PR #50 read it as unused; a headless run
+measured the boss covering ~1.0 units per second on the way home.
 
 Three of those are the design rather than the tuning, and are the ones to argue
 with before touching the rest:

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -258,4 +258,4 @@ wider than this will not.
   the boss has no model of its own at all, so whatever it eventually wears is a
   separate question from what the horde does.
 
-<!-- verified-against: ac81093 -->
+<!-- verified-against: c6b15fb -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -258,4 +258,4 @@ wider than this will not.
   the boss has no model of its own at all, so whatever it eventually wears is a
   separate question from what the horde does.
 
-<!-- verified-against: c6b15fb -->
+<!-- verified-against: a29d8c3 -->

--- a/scenes/enemies/boss.tscn
+++ b/scenes/enemies/boss.tscn
@@ -1,0 +1,63 @@
+[gd_scene load_steps=8 format=3]
+
+[ext_resource type="Script" path="res://scenes/enemies/zombie.gd" id="1_zombie"]
+[ext_resource type="Script" path="res://scenes/components/health.gd" id="2_health"]
+
+[sub_resource type="CapsuleMesh" id="CapsuleMesh_body"]
+radius = 0.7
+height = 3.0
+
+[sub_resource type="StandardMaterial3D" id="Material_body"]
+albedo_color = Color(0.36, 0.28, 0.44, 1)
+
+[sub_resource type="BoxMesh" id="BoxMesh_nose"]
+size = Vector3(0.35, 0.35, 0.85)
+
+[sub_resource type="StandardMaterial3D" id="Material_nose"]
+albedo_color = Color(0.85, 0.8, 0.6, 1)
+
+[sub_resource type="CapsuleShape3D" id="CapsuleShape_body"]
+radius = 0.7
+height = 3.0
+
+[node name="Boss" type="CharacterBody3D" groups=["enemies"]]
+collision_layer = 8
+collision_mask = 7
+script = ExtResource("1_zombie")
+display_name = "Zombie Warlord"
+roam_radius = 0.0
+roam_speed = 1.0
+detection_radius = 18.0
+aggro_radius = 24.0
+leash_radius = 22.0
+alert_delay = 1.0
+chase_speed = 2.2
+attack_range = 3.0
+attack_damage = 25.0
+attack_cooldown = 2.0
+regen_delay = 8.0
+regen_per_second = 12.0
+
+[node name="Visual" type="Node3D" parent="."]
+
+[node name="BodyMesh" type="MeshInstance3D" parent="Visual"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 0)
+mesh = SubResource("CapsuleMesh_body")
+surface_material_override/0 = SubResource("Material_body")
+
+[node name="NoseMesh" type="MeshInstance3D" parent="Visual"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.2, -0.85)
+mesh = SubResource("BoxMesh_nose")
+surface_material_override/0 = SubResource("Material_nose")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 0)
+shape = SubResource("CapsuleShape_body")
+
+[node name="NavigationAgent3D" type="NavigationAgent3D" parent="."]
+path_desired_distance = 1.0
+target_desired_distance = 1.0
+
+[node name="Health" type="Node" parent="."]
+script = ExtResource("2_health")
+max_health = 240.0

--- a/scenes/enemies/zombie.gd
+++ b/scenes/enemies/zombie.gd
@@ -20,7 +20,10 @@ extends CharacterBody3D
 ##                            the map author put them.
 ##
 ## All of them are per-instance exports: a corridor shambler and a boss-room
-## guard are the same scene with different numbers.
+## guard are the same scene with different numbers. [b]boss.tscn is that second
+## scene[/b] (issue #39) — this script, a bigger capsule, and stats that make it
+## a guard rather than a wanderer. Nothing in here knows which of the two it is
+## running, and keeping it that way is the point.
 
 ## Emitted once when this zombie's health hits zero, before the corpse fades.
 ## The hook issue #8 will use to award XP.
@@ -248,7 +251,15 @@ func _think() -> void:
 			# The hero is deliberately ignored until home is reached, so he
 			# cannot chain-pull a zombie across the map by re-entering its
 			# detection radius at the edge of the leash.
-			if from_home <= roam_radius:
+			#
+			# "Back inside the patch" cannot be the only way out of this state:
+			# the nav agent stops within target_desired_distance of its goal, so
+			# a guard with no patch at all (boss.tscn roams a radius of zero)
+			# would never satisfy it, and would stand at its post in RETURN
+			# forever — the one state that cannot acquire a target. Finishing the
+			# walk home is the same answer for any radius, and for a roam_radius
+			# wider than that stopping distance the distance test still wins.
+			if from_home <= roam_radius or _nav_agent.is_navigation_finished():
 				_enter_roam()
 
 

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -271,4 +271,4 @@ numbers.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: 35ada3a -->
+<!-- verified-against: c6b15fb -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -271,4 +271,4 @@ numbers.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: c6b15fb -->
+<!-- verified-against: a29d8c3 -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -115,6 +115,13 @@ one — see the contract in `scenes/ui/CLAUDE.md`.
 
 Measured 1v1 against one zombie: ~18 HP lost per kill, ~6 s of fighting.
 
+**The end boss inverts the reach advantage deliberately** (issue #39): its 3.0
+beats his 2.2, where every zombie's 2.0 loses to it. So the row above is a
+baseline meant to be broken by one encounter rather than a rule about all of
+them — standing and trading is a fair fight against a zombie and a lost one
+against the boss, which is the entire difference between the two.
+`scenes/enemies/` holds those numbers and the reasoning.
+
 **Out-of-combat regeneration** starts `regen_delay` after the last combat
 event, where *both* taking a hit and landing one count — a hero trading blows
 never regenerates mid-fight. It was written for issue #38, and #38 has now
@@ -180,8 +187,10 @@ numbers.
 - **`hero.gd` never names an enemy class.** Targets are found through the
   `enemies` group and used through `take_damage()` / `is_dead()`. There is no
   compile-time dependency on `scenes/enemies/`, so a second enemy type needs no
-  change here — but the group name and those two methods are a real runtime
-  contract, which is why `scenes/enemies` is declared in the frontmatter above.
+  change here — **issue #39's boss proved that rather than assumed it**: a whole
+  new scene, ten different stats, and not a line in this folder — but the group
+  name and those two methods are a real runtime contract, which is why
+  `scenes/enemies` is declared in the frontmatter above.
   A missing edge would be invisible; renaming the group would break the hero
   with nothing to catch it.
 - **Every range test measures horizontally, through `_horizontal_distance_to`.**
@@ -224,6 +233,12 @@ numbers.
   is a *delay*: dying mid-cooldown and keeping the value would make his first
   swing of the new life wait out the remainder of his last one. Clearing them
   stops that leak; it does not hold him back, it does the reverse.
+
+  **`died` is not a promise of a `respawn_at()`.** Since issue #39 a run can be
+  won, and `scenes/main.gd` ignores a death arriving after the boss has fallen —
+  the hero stays down where he lies while the victory screen comes up and the
+  tree freezes. Nothing in here needs to know that and nothing in here should:
+  this folder reports the death, and the scene decides what it costs.
 
   **What stops him swinging the instant he arrives is not in this folder.** It
   is `scenes/map/`'s rule that no spawn sits within 4 cells of a respawn cell —

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -170,7 +170,13 @@ func _on_hero_died() -> void:
 		return
 	_hud.show_death()
 	await get_tree().create_timer(RESPAWN_DELAY).timeout
-	if not is_inside_tree():
+	# Tested again on the way out, and the second test is not the first one
+	# repeated: the run can be won *during* this wait, and the timer keeps
+	# counting through the pause a win brings with it. It is unreachable today
+	# only because the hero is the only thing that can damage the boss and he
+	# cannot swing while dead — an invariant about who damages what, written
+	# down nowhere and owned by nobody. This line costs less than resting on it.
+	if not is_inside_tree() or _run_over:
 		return
 	_respawn()
 

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -1,5 +1,5 @@
 extends Node3D
-## Game entry scene (issues #5, #6, #7, #11, #36, #38).
+## Game entry scene (issues #5, #6, #7, #11, #36, #38, #39).
 ##
 ## Owns the order the level comes up in: the map builds itself in its own
 ## _ready() (children run first), then this script places the hero on the map's
@@ -17,16 +17,25 @@ extends Node3D
 ## which stretch of the run each spawn belongs to; deciding what a death costs is
 ## this script's, because it is the one thing here that knows both the armed
 ## checkpoint and what is currently standing in the level.
+##
+## [b]It owns where a run ends, too[/b] (issue #39). The boss is the one enemy
+## whose death anyone listens to, and this is where that listening happens: the
+## victory screen belongs to scenes/ui/, and what winning [i]means[/i] belongs
+## here, beside what dying means.
 
 ## Spawn units just above the floor surface and let gravity settle them, rather
 ## than guessing the exact tile height.
 const SPAWN_CLEARANCE := 0.3
 
 const ZOMBIE_SCENE := preload("res://scenes/enemies/zombie.tscn")
+const BOSS_SCENE := preload("res://scenes/enemies/boss.tscn")
 const CHECKPOINT_SCENE := preload("res://scenes/map/checkpoint.tscn")
 
 ## How long the death screen sits there before the hero comes back.
 const RESPAWN_DELAY := 2.5
+
+## How long the boss is left to fall over before the victory screen goes up.
+const VICTORY_DELAY := 1.2
 
 ## Which stretch of the run a spawned zombie came from, so a respawn can restore
 ## exactly the ones ahead of the armed checkpoint. Stored on the instance because
@@ -50,6 +59,11 @@ var _respawn_points := PackedVector3Array()
 var _checkpoint_nodes: Array[Checkpoint] = []
 var _armed_checkpoint := 0
 
+## Set the moment the boss dies, and never cleared — the only way out of a won
+## run is a fresh scene. It is what stops a death in the beat before the victory
+## screen appears starting a respawn behind it.
+var _run_over := false
+
 
 func _ready() -> void:
 	_hero.global_position = _level.start_position() + Vector3(0, SPAWN_CLEARANCE, 0)
@@ -57,6 +71,7 @@ func _ready() -> void:
 	_nav_region.bake_navigation_mesh(false)
 	_place_checkpoints()
 	_spawn_zombies(0)
+	_spawn_boss(0)
 
 	_hero.health.health_changed.connect(_hud.set_hero_health)
 	_hero.died.connect(_on_hero_died)
@@ -65,6 +80,9 @@ func _ready() -> void:
 	# belongs to, and hands on the clicks his attack command did not take.
 	_hero.select_clicked.connect(_selection.select_at)
 	_selection.selection_changed.connect(_hud.show_unit)
+	# The one wire that runs the other way, from the HUD back into the game: the
+	# victory screen asks, this script decides what starting a run means.
+	_hud.restart_requested.connect(_restart_run)
 
 	_hud.set_hero_health(_hero.health.current, _hero.health.max_health)
 	# Last, and after the connection above: the hero starts selected, and the
@@ -87,6 +105,29 @@ func _spawn_zombies(from_segment: int) -> void:
 		# Enemies sits at the origin, so local and global agree here.
 		zombie.position = spawn["position"] + Vector3(0, SPAWN_CLEARANCE, 0)
 		_enemies.add_child(zombie)
+
+
+## The boss, on the `B` cell the map already marked (issue #39).
+##
+## Separate from [method _spawn_zombies] because the boss is one authored
+## instance rather than an entry in the map's spawn list — but it is filed under
+## a segment by the same rule and stored in the same place, so the respawn path
+## clears it and puts it back without knowing it is special. That was the thing
+## worth checking about a boss and checkpoints, and it is why this takes a
+## [param from_segment] it will almost always pass.
+func _spawn_boss(from_segment: int) -> void:
+	var segment := _level.boss_segment()
+	if segment < from_segment:
+		return
+	var boss: Zombie = BOSS_SCENE.instantiate()
+	boss.set_meta(SEGMENT_META, segment)
+	# Position before add_child, for the reason _spawn_zombies() gives: _ready()
+	# captures where it stands as home, and for a guard that is its post.
+	boss.position = _level.boss_position() + Vector3(0, SPAWN_CLEARANCE, 0)
+	# The only `died` in the level anyone listens to. Every other one is dropped,
+	# and this one ends the run.
+	boss.died.connect(_on_boss_died)
+	_enemies.add_child(boss)
 
 
 ## Lay the checkpoint pads the map marked out.
@@ -121,11 +162,52 @@ func _on_checkpoint_reached(index: int) -> void:
 
 
 func _on_hero_died() -> void:
+	# The boss went down first, so the run is already won and the victory screen
+	# is on its way up. The boss room still has zombies in it and the hero is
+	# still standing in the middle of them, so this is reachable — and a respawn
+	# starting behind a VICTORY banner would take the win back.
+	if _run_over:
+		return
 	_hud.show_death()
 	await get_tree().create_timer(RESPAWN_DELAY).timeout
 	if not is_inside_tree():
 		return
 	_respawn()
+
+
+## The boss is dead: the run is won, and this is the only thing that ends one.
+##
+## [b]The delay is not decoration.[/b] A zombie's corpse tween is bound to the
+## zombie, so freezing the tree on the frame it dies leaves the boss halfway
+## through toppling over, under a banner announcing that it is dead. Letting the
+## fall finish first costs a beat and reads as the kill landing.
+func _on_boss_died(_boss: Zombie) -> void:
+	# Before the wait, not after — see the guard in _on_hero_died().
+	_run_over = true
+	await get_tree().create_timer(VICTORY_DELAY).timeout
+	if not is_inside_tree():
+		return
+	_hud.show_victory()
+	# Freezing the tree is what makes the run *over* rather than merely won: the
+	# hero stops taking orders, the zombies stop chewing on him, and the only
+	# thing left running is the victory panel, which asks for this on itself.
+	get_tree().paused = true
+
+
+## Start a fresh run, from the victory screen's button.
+##
+## [b]A scene reload, where a death deliberately is not one.[/b] The asymmetry is
+## the whole point: a death has to preserve everything cleared behind the armed
+## checkpoint, which is why issue #38 removed the reload from that path — and a
+## restart has to discard exactly that. Rebuilding the scene is the only version
+## of "discard all of it" that cannot forget a piece of run state, including the
+## ones nobody has added yet: issue #8's XP would otherwise have to remember to
+## reset itself here.
+func _restart_run() -> void:
+	# The pause flag lives on the SceneTree, not on the scene, so it would
+	# outlive the reload and leave the new run frozen on its first frame.
+	get_tree().paused = false
+	get_tree().reload_current_scene()
 
 
 ## Put the hero back at the armed checkpoint and restore the run ahead of it.
@@ -146,14 +228,18 @@ func _respawn() -> void:
 	# alongside a fresh copy of every one that died.
 	_clear_from_segment(_armed_checkpoint)
 	_spawn_zombies(_armed_checkpoint)
+	# The boss is restored on the same terms as the trash around it, which is
+	# what makes dying to it a retry rather than the end of the run.
+	_spawn_boss(_armed_checkpoint)
 	_hero.respawn_at(_respawn_points[_armed_checkpoint] + Vector3(0, SPAWN_CLEARANCE, 0))
 	# The hero has teleported, so the follow camera would otherwise sail across
 	# the level — the same reason _ready() snaps after placing him.
 	_camera.snap_to_target()
 
 
-## Remove every zombie from [param from_segment] onward, living, chasing or
-## already a corpse.
+## Remove every enemy from [param from_segment] onward, living, chasing or
+## already a corpse — the boss included, since it is filed under a segment and
+## parented here like anything else.
 ##
 ## remove_child before queue_free, so they leave the `enemies` group this frame
 ## rather than at the end of it: a freed-but-still-parented zombie is one the

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -282,4 +282,4 @@ contiguous run of open cells without changing what the player sees.
   `scenes/hero/`, which is why it is in the frontmatter above. `Checkpoint`
   never names `Hero` as a type.
 
-<!-- verified-against: ac81093 -->
+<!-- verified-against: c6b15fb -->

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -282,4 +282,4 @@ contiguous run of open cells without changing what the player sees.
   `scenes/hero/`, which is why it is in the frontmatter above. `Checkpoint`
   never names `Hero` as a type.
 
-<!-- verified-against: c6b15fb -->
+<!-- verified-against: a29d8c3 -->

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -4,8 +4,9 @@ depends-on: [scenes, scenes/hero, assets]
 
 # scenes/map/
 
-The playable map (issues #6, #37) and the checkpoints laid out on it (#38).
-Replaces the 40×40 test arena that `main.tscn` used to carry.
+The playable map (issues #6, #37), the checkpoints laid out on it (#38), and the
+segment the boss cell belongs to (#39). Replaces the 40×40 test arena that
+`main.tscn` used to carry.
 
 - `level_map.tscn` — a bare `Node3D` with `level_map.gd`. All geometry is
   generated at runtime, so the .tscn stays a single node.
@@ -53,6 +54,13 @@ that gap is the only reason he cannot swing on the frame he respawns — his own
 timers are cleared to *full readiness*, deliberately. Shrink the clearance here,
 and the invariant protecting the player is gone with nothing in that folder to
 notice. Issue #9 raising `acquire_radius` does the same from the other end.
+
+**`B` is an enemy placement as well now** (issue #39), so the same clearance
+binds it — and unlike a `Z` cell, nothing checks it:
+`_warn_about_split_segments()` reads `_zombie_cells` only. The boss sits 6 cells
+from its checkpoint, outside its own 4.5-cell detection radius as well as the
+hero's acquire radius, so a respawn at the gate does not start with a charge.
+Moving that checkpoint deeper into the room is the edit that would break it.
 
 Cells are `CELL_SIZE` = 4 units, matching the KayKit dungeon grid: `wall` is
 4×4×1 and `floor_tile_large` is 4×4.
@@ -126,6 +134,14 @@ Three rules make that work, and each is load-bearing:
 `S` is checkpoint 0 and gets no pad: the hero is standing on it before he can
 walk onto anything, and the map already paints it green.
 
+**`B` is filed under a segment too** (`boss_segment()`, issue #39), by the same
+rule and the same code path as a spawn — the boss is one authored instance
+rather than an entry in `zombie_spawns()`, so it is the one thing on the map
+that would otherwise have nowhere to read its segment from. Without it a death
+in the boss room would clear the boss away with the rest of its segment and have
+nothing to put one back, which is the difference between a retry and a run that
+cannot be finished. On the current layout it is segment 2, the boss-room gate.
+
 ### The authoring constraint, and the one place it bit
 
 **A dead-end spur must be shorter than the run from its neck to the next
@@ -166,8 +182,15 @@ rows on is the whole fix, and it costs nothing — no spawn sits between 45 and
   left that collides with neither pair. Its pads are the harder case of the two,
   because a marker is somewhere units *stand*: a selection ring is drawn on top
   of a checkpoint pad every time the pad matters.
-- Public API: `start_position()`, `boss_position()`, `zombie_spawns()`,
-  `checkpoints()`, and the `built` signal.
+
+  **The red marker stopped being the easy case when #39 stood the boss on it.**
+  That was the collision the cyan/orange choice was made against, and it holds:
+  an orange ring on the red plate is legible. What does not hold is the ring's
+  *size* — the boss is as wide as the ring, so what survives is a crescent at
+  its feet rather than a circle around it (issue #49). Colour was the constraint
+  anyone thought to check; scale was the one nobody had needed to.
+- Public API: `start_position()`, `boss_position()`, `boss_segment()`,
+  `zombie_spawns()`, `checkpoints()`, and the `built` signal.
 
 **The map never instances enemies, and it does not instance checkpoints
 either.** It only says where they go; `scenes/main.gd` reads `zombie_spawns()`
@@ -247,8 +270,9 @@ contiguous run of open cells without changing what the player sees.
   `checkpoint.gd` uses none — its pads are `BoxMesh`es, like the zone markers.
 - Instanced by `scenes/main.tscn` under `NavigationRegion3D`; `scenes/main.gd`
   reads `start_position()` to place the hero, bakes the navmesh, and then reads
-  `checkpoints()` and `zombie_spawns()` to lay the pads and populate the map with
-  `scenes/enemies/`. The ordering is load-bearing — `LevelMap._ready()` runs
+  `checkpoints()`, `zombie_spawns()` and the `boss_position()` / `boss_segment()`
+  pair to lay the pads and populate the map with `scenes/enemies/`. The ordering
+  is load-bearing — `LevelMap._ready()` runs
   before `Main._ready()` because Godot readies children first, so the geometry
   exists before the bake.
 - `Checkpoint` emits `reached(index)` and takes `set_armed(bool)` back;

--- a/scenes/map/level_map.gd
+++ b/scenes/map/level_map.gd
@@ -167,6 +167,17 @@ func boss_position() -> Vector3:
 	return _cell_to_world(_boss_cell)
 
 
+## The stretch of the run the boss cell belongs to (issue #39), on the same
+## rule as a spawn's: the last checkpoint at or before its own path distance.
+##
+## The boss is one authored instance rather than an entry in [method
+## zombie_spawns], so whoever places it has nowhere else to read this from —
+## and without it a respawn would clear the boss away with the rest of its
+## segment and have nothing telling it to put one back.
+func boss_segment() -> int:
+	return _segment_of(_boss_cell)
+
+
 ## Every `Z` cell as `{"position": Vector3, "segment": int}`, in layout order.
 ## Whoever instances the enemies decides what to put there; the map only says
 ## where, and which stretch of the run it belongs to.
@@ -477,12 +488,21 @@ func _group_checkpoints() -> void:
 ## File each spawn under the last checkpoint at or before its own path distance.
 func _assign_spawn_segments() -> void:
 	for cell in _zombie_cells:
-		var distance := _distance_of(cell)
-		var segment := 0
-		for index in _checkpoint_groups.size():
-			if distance >= _distance_of(_checkpoint_groups[index][0]):
-				segment = index
-		_spawn_segments.append(segment)
+		_spawn_segments.append(_segment_of(cell))
+
+
+## The last checkpoint at or before [param cell]'s own path distance.
+##
+## Cached for the spawns because they are asked for as a list, and computed on
+## demand for the boss cell — one rule either way, so the boss can never end up
+## filed by a different one than the zombies standing next to it.
+func _segment_of(cell: Vector2i) -> int:
+	var distance := _distance_of(cell)
+	var segment := 0
+	for index in _checkpoint_groups.size():
+		if distance >= _distance_of(_checkpoint_groups[index][0]):
+			segment = index
+	return segment
 
 
 ## Catch the authoring hazard the segment rule creates.

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -202,4 +202,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: c6b15fb -->
+<!-- verified-against: a29d8c3 -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -194,4 +194,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: ac81093 -->
+<!-- verified-against: c6b15fb -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -103,6 +103,14 @@ region of the screen the event never leaves. The game being paused makes it
 doubly true here, and neither fact should be relied on alone if a widget is ever
 added that is live during play.
 
+**It takes the screen when it comes up**, cancelling the checkpoint flash and
+hiding the death screen — and the two are not the same case. The flash is
+genuinely reachable: arming a checkpoint and winning seconds later is what a
+boss-room gate produces. The death screen is not, because `scenes/main.gd` stops
+answering a death once the run is won. It is hidden anyway so that *this panel
+owns the screen* is a rule of this folder, rather than something true only while
+a guard in another folder keeps it true.
+
 There is deliberately **no `hide_victory()`**: the only way off that screen is a
 fresh scene, so a path taking it back down would be one no caller could reach.
 The death screen's `hide_death()` is the counter-example that makes the

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -10,8 +10,8 @@ five elements and one of them non-trivial.
 
 - `hud.tscn` / `hud.gd` (`class_name HUD`) — the `CanvasLayer`. Holds the hero's
   health bar (bottom-left), the armed-attack indicator, the controls crib sheet
-  (top-left), the death screen, the checkpoint confirmation, and an instance of
-  the info bar.
+  (top-left), the death screen, the checkpoint confirmation, the victory panel
+  (issue #39), and an instance of the info bar.
 - `unit_info_bar.tscn` / `unit_info_bar.gd` (`class_name UnitInfoBar`) — the
   bottom-centre panel: name, live HP as `current / max`, and damage / attack
   speed / move speed.
@@ -74,6 +74,40 @@ while handling the very click that used it — so an armed click would land as
 both an attack and a selection, or as neither, depending on which node
 `_unhandled_input` reached first.
 
+## The victory panel (issue #39)
+
+The boss dies, `scenes/main.gd` calls `show_victory()`, and a "VICTORY" heading,
+a line of text and a **New run** button come up. Three things about it are worth
+knowing before touching it.
+
+**It is the only thing in this folder that sends something back into the game.**
+Everything else here is fed inward by method call; `restart_requested` is a
+signal going the other way, and it carries no argument and no opinion. What
+starting a run *means* is `scenes/main.gd`'s — this folder must not learn.
+
+**The whole tree is paused while it is up, and the panel alone keeps running.**
+Freezing is what makes the run over rather than merely won: the hero stops
+taking orders and the zombies stop chewing on him. But a paused `Control` is
+skipped by GUI input dispatch, so the button would be dead under the cursor.
+`hud.gd` sets `PROCESS_MODE_ALWAYS` on the panel in `_ready()` rather than in
+the scene file, so the reason travels with the line; its children inherit it.
+Anything else that has to work while the game is frozen goes inside that panel
+or gets the same treatment.
+
+**The button is this folder's first interactive `Control`, and it does not
+break the rule above about the left mouse button.** A `Control` consumes a click
+in GUI dispatch, which runs *before* `_unhandled_input`, so `scenes/hero/` never
+sees it and there is no second listener on `select_command` — the arrangement
+that section forbids. A `Button` is not another owner of the button; it is a
+region of the screen the event never leaves. The game being paused makes it
+doubly true here, and neither fact should be relied on alone if a widget is ever
+added that is live during play.
+
+There is deliberately **no `hide_victory()`**: the only way off that screen is a
+fresh scene, so a path taking it back down would be one no caller could reach.
+The death screen's `hide_death()` is the counter-example that makes the
+difference worth stating rather than assuming.
+
 ## Gotchas
 
 - **The ring is cyan and orange, not the RTS-classic green and red**, and that
@@ -81,8 +115,13 @@ both an attack and a selection, or as neither, depending on which node
   boss cell red as floor markers. A green ring is invisible on the green start
   marker — where the hero stands for the first seconds of every run, exactly
   when the player is working out that the ring means something — and a red ring
-  would vanish the same way once issue #39 puts something selectable on the boss
-  cell. If those markers are recoloured, re-check these.
+  would vanish the same way on the boss cell. If those markers are recoloured,
+  re-check these. **#39 has now put the boss on the red marker and the colour
+  choice held**; what did not is the ring's *size*, which nobody had reason to
+  question while every selectable unit was a 0.4-radius capsule. The torus has
+  an outer radius of 0.7, exactly the boss's body radius, so what a player sees
+  is a crescent at its feet rather than a circle around it — issue #49. It
+  reads; the next unit wider than this one will not.
 - **The ring's material is duplicated in `_ready()`**, for the reason
   `scenes/enemies/` records: a scene's sub-resources are shared between
   instances and this one is recoloured at runtime. One ring exists today; the
@@ -138,9 +177,14 @@ both an attack and a selection, or as neither, depending on which node
   `NodePath`, the way the camera's `target` is.
 - Consumes `Hero.select_clicked`, and `Health.health_changed` / `Health.died` on
   whatever is selected. `scenes/main.gd` also calls `set_hero_health()`,
-  `set_attack_move_armed()`, `show_death()` / `hide_death()` and
-  `flash_checkpoint()` — the last from `Checkpoint.reached`, the only HUD call
-  that does not originate with the hero.
+  `set_attack_move_armed()`, `show_death()` / `hide_death()`,
+  `flash_checkpoint()` and `show_victory()` — the last two from
+  `Checkpoint.reached` and the boss's `Zombie.died`, the only HUD calls that do
+  not originate with the hero.
+- Emits `HUD.restart_requested`, consumed by `scenes/main.gd`. It is the only
+  signal this folder sends into the game rather than draws from it, and it is
+  also what pairs with the pause: that script sets `get_tree().paused`, so it is
+  the one that has to clear it.
 - **`scenes/main.gd` re-selects the hero on every respawn**, before it clears
   the restored segment. That ordering is its concern, not this folder's, but it
   is the reason a freed selection is rare rather than routine — the

--- a/scenes/ui/hud.gd
+++ b/scenes/ui/hud.gd
@@ -94,6 +94,12 @@ func show_victory() -> void:
 	# Same reason show_death() does it: a "CHECKPOINT" still fading out under the
 	# end of the run is reading out the wrong moment.
 	_clear_checkpoint_flash()
+	# The death screen is a different case and worth being honest about: it
+	# cannot be up, because scenes/main.gd stops answering a death once the run
+	# is won. Taking it down anyway makes this panel's claim on the screen a rule
+	# of this folder, rather than something true only while a guard in another
+	# folder keeps it true.
+	hide_death()
 	_victory_panel.show()
 	# After show(), which is what makes the button focusable. Enter then works as
 	# well as a click, and by this point nothing else on screen takes input at all.

--- a/scenes/ui/hud.gd
+++ b/scenes/ui/hud.gd
@@ -14,6 +14,11 @@ extends CanvasLayer
 ## enemy's health, and a player who cannot see their own during a fight is worse
 ## off than one looking at a redundant bar.
 
+## Emitted when the player asks for a fresh run from the victory screen (issue
+## #39). Nothing here acts on it: scenes/main.gd owns what a run is, so what
+## "start another one" does is that script's decision and not a widget's.
+signal restart_requested
+
 ## How long the checkpoint confirmation holds before it starts fading, and how
 ## long the fade takes. Long enough to read mid-fight, short enough that it is
 ## gone before the fight the checkpoint was banked for.
@@ -27,8 +32,20 @@ const CHECKPOINT_FADE := 0.7
 @onready var _death_sub_label: Label = $DeathSubLabel
 @onready var _checkpoint_label: Label = $CheckpointLabel
 @onready var _unit_info_bar: UnitInfoBar = $UnitInfoBar
+@onready var _victory_panel: Control = $VictoryPanel
+@onready var _restart_button: Button = $VictoryPanel/RestartButton
 
 var _checkpoint_tween: Tween = null
+
+
+func _ready() -> void:
+	_restart_button.pressed.connect(restart_requested.emit)
+	# The whole tree is paused while the victory panel is up — that is what makes
+	# the run over rather than merely won — and a paused Control is skipped by GUI
+	# input dispatch, which would leave the button dead under the cursor. This is
+	# the one node in the HUD that has to keep running when nothing else does; its
+	# children inherit the mode from it.
+	_victory_panel.process_mode = Node.PROCESS_MODE_ALWAYS
 
 
 ## Always-visible player health, whatever is selected.
@@ -65,6 +82,22 @@ func show_death() -> void:
 func hide_death() -> void:
 	_death_label.hide()
 	_death_sub_label.hide()
+
+
+## The boss is dead and the run is won (issue #39).
+##
+## [b]There is deliberately no hide_victory().[/b] The only way off this screen is
+## a fresh scene, so a path that took it back down would be one no caller could
+## reach — and the death screen's [method hide_death] is the counter-example that
+## makes the distinction worth stating rather than assuming.
+func show_victory() -> void:
+	# Same reason show_death() does it: a "CHECKPOINT" still fading out under the
+	# end of the run is reading out the wrong moment.
+	_clear_checkpoint_flash()
+	_victory_panel.show()
+	# After show(), which is what makes the button focusable. Enter then works as
+	# well as a click, and by this point nothing else on screen takes input at all.
+	_restart_button.grab_focus()
 
 
 ## Confirm that a checkpoint is now armed.

--- a/scenes/ui/hud.tscn
+++ b/scenes/ui/hud.tscn
@@ -92,6 +92,62 @@ text = "Returning to the last checkpoint"
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="VictoryPanel" type="Control" parent="."]
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+
+[node name="Title" type="Label" parent="VictoryPanel"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -280.0
+offset_top = -104.0
+offset_right = 280.0
+offset_bottom = -24.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(1, 0.85, 0.4, 1)
+theme_override_font_sizes/font_size = 56
+text = "VICTORY"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Subtitle" type="Label" parent="VictoryPanel"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -280.0
+offset_top = -16.0
+offset_right = 280.0
+offset_bottom = 16.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(0.86, 0.88, 0.94, 1)
+theme_override_font_sizes/font_size = 20
+text = "The boss is dead. The map is yours."
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="RestartButton" type="Button" parent="VictoryPanel"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -110.0
+offset_top = 64.0
+offset_right = 110.0
+offset_bottom = 112.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 22
+text = "New run"
+
 [node name="CheckpointLabel" type="Label" parent="."]
 visible = false
 anchor_left = 0.5


### PR DESCRIPTION
Closes #39. This is step 5 of the winnable-loop batch and the last one — the run
can now be finished as well as survived.

## The boss is `zombie.gd` with different numbers

`scenes/enemies/boss.tscn` is the same script, a capsule scaled ~1.75×, and ten
changed export values. No new script, no new state, and **no change in
`scenes/ui/`** — a unit already describes itself to the info bar through
`unit_info()` and `display_name`, so the boss shows up there correctly on its
own. That was the plan recorded on the Flowdex `game-design/winnable-loop` page
and in `zombie.gd`'s own class docs since #7; it held.

Three of the values are design rather than tuning, and are the ones to argue
with before the rest:

- **It out-reaches the hero** (3.0 against his 2.2) where every zombie
  under-reaches him (2.0). Standing and trading is a fair fight against a zombie
  and a lost one against the boss — that inversion *is* the encounter, and it is
  why `chase_speed` is low enough (2.2) for kiting to be the answer.
- **`roam_radius = 0` and `leash_radius = 22` make it a guard.** Its post is 6
  cells (24 units) from the boss-room gate and it turns back at 5.5, so it can
  never follow the hero out, and there is no wander that could carry it there.
- **Disengaging resets the fight.** Regeneration is state-gated already, so
  kiting inside the room never heals it; only a real break does, at 12 HP/s
  against the hero's 4. The 8 s delay keeps a two-second reposition free.

240 HP is 20 hero swings and 25 damage is four hits on a full-health hero.
Deliberately a first pass — nothing in the game was balanced against an end boss
before there was one, which is why the wiki said not to tune enemy stats until
this landed.

## One line of shared AI changed

`RETURN` exited only on `from_home <= roam_radius`. The nav agent stops within
`target_desired_distance` (1.0) of its goal, so a guard with **no** patch would
never satisfy that and would stand at its post in `RETURN` for the rest of the
run — the one state that cannot acquire a target. It now also exits when the
walk home finishes, which is the same answer for any radius; for `roam_radius`
6 the distance test still wins first, so trash zombies are unchanged.

Verified in a headless run: leashed the boss, watched it walk back
(`from_home` 3.16 → 2.17 → 1.18), enter `ROAM` at 1.02, and re-acquire the hero
afterwards.

## Dying to the boss is a retry

`LevelMap.boss_segment()` files the `B` cell under a checkpoint segment by the
same code path a spawn uses (`_segment_of()`, factored out of
`_assign_spawn_segments()`). `main.gd` then spawns the boss with that segment as
node metadata, under `Enemies`, exactly like a zombie — so `_clear_from_segment()`
sweeps it up and `_spawn_boss()` puts it back.

This is the thing the wiki flagged as worth checking about a boss and
checkpoints, and it was a real hole: without it, a respawn at the gate clears the
boss away with the rest of its segment and leaves a run that cannot be finished.

## Winning

`HUD.show_victory()` raises a panel with a **New run** button and `main.gd`
freezes the tree. Points a reviewer should push on:

- **The freeze is what makes the run over rather than merely won.** Otherwise the
  hero can still be commanded around, and still killed, behind a VICTORY banner.
  The panel is the one node set to `PROCESS_MODE_ALWAYS`, because a paused
  `Control` is skipped by GUI input dispatch and the button would be dead.
- **A death after the boss falls is ignored** (`_run_over`). Reachable, not
  theoretical: the boss room holds three more zombies and the hero is standing
  among them.
- **The beat before the screen is load-bearing.** A corpse tween is bound to the
  corpse, so pausing on the frame the boss dies leaves it halfway through
  toppling over, under a banner saying it is dead.
- **Restart reloads the scene, which is the exact opposite of what #38 did to the
  death path** — and deliberately so. A death has to preserve everything cleared
  behind the armed checkpoint; a restart has to discard it. Rebuilding is the
  only version of "discard all of it" that cannot forget a piece of run state
  someone adds later, e.g. #8's XP. The pause flag lives on the `SceneTree` and
  is cleared by hand for that reason.
- **The button does not break "the hero owns the left mouse button".** GUI
  dispatch runs before `_unhandled_input`, so `scenes/hero/` never sees the
  click; there is no second listener on `select_command`.

## Verified

Headless and windowed runs of `main.tscn`, no errors or warnings:

- boss segment 2, 240 HP, "Zombie Warlord" in the info bar with no UI change;
- respawn at the boss checkpoint frees the boss and re-instances it (new object
  id, enemy count back to 20);
- killing it → panel visible, `paused = true`, button still processing;
- leash / return-to-post / re-acquire, as above;
- eyeballed both frames: the boss reads as clearly distinct against the trash
  zombies and the red floor marker, and the panel lays out correctly.

## Found and filed, not fixed here

The selection ring is one fixed torus with `outer_radius = 0.7`, which is exactly
the boss's body radius — so selecting it shows a crescent at its feet rather than
a circle. It reads; anything wider will not. Fixing it means sizing the ring per
unit, which is a change to the duck-typed unit contract across three folders, so
it is #49 rather than scope creep here. Recorded in `scenes/ui/CLAUDE.md` and
`scenes/map/CLAUDE.md` — the colour constraint those docs predicted for this
issue held, and it was the dimension nobody had thought to check that did not.

## Docs

Second commit re-stamps five folder docs, which the dependency check requires.
`scenes/hero/` is the interesting one: its folder did not change, but the boss
falsified two of its claims (the reach note read as a rule about all enemies,
and `died` is no longer a promise of a `respawn_at()`).
