### PR TITLE
Make three root-doc claims about merging and the code map true

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ describes it. This is the one inventory the root keeps, and it is checked
 against the repo: a new folder holding any of those three fails CI until it is
 listed here.
 
-Those three extensions are the bound, not "any code". `.claude/hooks/` holds
+Those three extensions are the boundary, not "any code". `.claude/hooks/` holds
 shell scripts and has its own `CLAUDE.md`, and is deliberately absent below: the
 check guarding this table does not read `.sh`, so a row for it would be the one
 entry here that nothing verifies — a claim of exactly the kind the stamp section

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,17 @@ Engine configuration (from `project.godot`):
 
 ### Code map
 
-Every folder holding code, and the doc that describes it. This is the one
-inventory the root keeps, and it is checked against the repo — a new code folder
-fails CI until it is listed here.
+Every folder holding game code — `.gd`, `.gdshader`, `.tscn` — and the doc that
+describes it. This is the one inventory the root keeps, and it is checked
+against the repo: a new folder holding any of those three fails CI until it is
+listed here.
+
+Those three extensions are the bound, not "any code". `.claude/hooks/` holds
+shell scripts and has its own `CLAUDE.md`, and is deliberately absent below: the
+check guarding this table does not read `.sh`, so a row for it would be the one
+entry here that nothing verifies — a claim of exactly the kind the stamp section
+below exists to prevent. Issue #31 read the old wording as a gap in the map; it
+was a gap in this sentence.
 
 | Folder | What lives there |
 |--------|------------------|
@@ -104,6 +112,22 @@ You rarely need to touch it. A commit that changes both a folder's files and its
 doc satisfies the check on its own, so ordinary well-formed work never moves the
 stamp. Bump it when you have *audited* a doc: read it end to end against the
 code and corrected what drifted.
+
+**Land PRs as merge commits — the merge method is load-bearing for the stamp.**
+A stamp names a specific commit, so any history rewrite that discards the
+commits a branch was stamped against breaks it: squashing, rebasing, amending,
+force-pushing. The post-merge `docs-audit` job then fails with `BADSTAMP` on
+`main`, and **nothing on the PR can warn you first** — at check time the stamps
+are valid and the rewritten commit does not exist yet, so the gate is
+structurally blind to it. Not hypothetical: PR #44 was squashed, `main` stayed
+red until #45 repointed four stamps, and none of those docs were wrong — only
+the reference they carried.
+
+Squash and rebase merging are disabled on the repository, so the ordinary route
+can no longer hit this; the rule is written down for what settings cannot cover,
+such as amending or force-pushing a branch after its docs were stamped. If it
+does happen anyway, the repair is to repoint the stamps at the resulting commit.
+Do not re-audit the docs — nothing about them became untrue.
 
 ### What is enforced, and what is not
 
@@ -231,7 +255,7 @@ GitHub Issues is the project backlog. Claude sessions should actively use it:
 
 - **Web build / playable link:** every merge to `main` exports the Web preset and deploys it to GitHub Pages: https://hipsen-systems.github.io/mg-zombies/ — the always-current playable state of the game.
 - **Releases:** pushing a tag like `v0.1.0` builds the Windows exe and attaches it to an auto-created GitHub Release. Tag from an up-to-date `main` only.
-- **PR build check:** every PR must export successfully (`build-check` workflow) before it can merge.
+- **PR build check:** every PR must export successfully (`build-check` workflow) before it can merge. The required status checks on `main` are exactly `docs-check`, `claude-review` and `build-check`. That last one was advisory until issue #30 found this line claiming otherwise; the claim was made true rather than deleted, because with zero required approvals a failed export could otherwise reach the always-current playable link.
 - Export presets live in `export_presets.cfg` (Web has thread support disabled on purpose — required for GitHub Pages; Windows embeds the pck into a single exe). `build/` output is gitignored.
 
 ## GitHub API access


### PR DESCRIPTION
Three claims in the root `CLAUDE.md` that were checked against the live repo and
found false. One topic: statements the root doc makes about how this repository
actually behaves.

Two of the three fixes are repository settings, already applied — the doc change
records them. The third is purely a wording correction.

## What was wrong, and how each was verified

**#46 — the merge method is load-bearing for `verified-against`, and the doc never said so.**
A stamp names a specific commit, so squashing (or any history rewrite) discards
the commits a branch was stamped against and the post-merge `docs-audit` job
fails with `BADSTAMP` on `main`. That already happened: PR #44 was squashed and
`main` stayed red until #45 repointed four stamps.

No check on a PR can catch it — at check time the stamps are valid and the
rewritten commit does not exist yet — so the convention was the only defence,
and it was unwritten.

Verified: `allow_squash_merge` and `allow_rebase_merge` were both still `true`,
i.e. the trap was still armed.

*Applied:* squash and rebase merging are now **disabled** on the repository, so
the ordinary route cannot hit this. The doc text covers what settings cannot —
amending or force-pushing a branch after its docs were stamped.

**#30 — "every PR must export successfully before it can merge" was false.**
Verified against `branches/main/protection`: required contexts were `docs-check`
and `claude-review` only. `build-check` ran on every PR but was advisory, so a
PR that failed to export could merge.

This is the fork #30 raises, and I took "make the claim true" rather than "make
the doc true": with zero required approvals the alternative is a failed export
reaching the always-current playable link, and the check already runs on every
PR so requiring it costs nothing.

*Applied:* required contexts are now `docs-check`, `claude-review`,
`build-check`. The doc records the full set.

**#31 — the code map claimed to list "every folder holding code".**
It does not list `.claude/hooks/`, which holds three shell scripts and has its
own `CLAUDE.md`. Reading `check-folder-docs.sh` shows why, and it is not an
oversight: `CODE_RE` is `\.(gd|gdshader|tscn)$`, so the check guarding this table
never considers `.sh` to be code.

So the false thing was the sentence, not the table. Adding a row would have put
one entry in the map that nothing verifies — the exact shape the stamp section
warns against. Narrowed the sentence to what is actually enforced instead.

## One thing worth a reviewer's eye

The new stamp text describes the merge method **in prose and never names the
command**. That is deliberate. The root doc is injected into every session's
context, and `check-flowdex.sh` decides a session merged a PR by grepping its
transcript for that command literal — so writing it here would make every
session that merely loads this file get accused of merging a pull request.

This is the trap already recorded in `.claude/hooks/CLAUDE.md` ("keep the joined
forms out of the root `CLAUDE.md` too"), which has caught this repo three times.
Please keep it in mind if you reword that paragraph.

## Checks run locally

- `check-folder-docs.sh --diff origin/main...HEAD` → exit 0
- `check-folder-docs.sh --audit` → exit 0
- Confirmed the diff introduces no joined form of the grepped merge command.

No folder doc changed, and none needed to: this touches only the root doc, which
carries no stamp of its own.

Closes #46. Closes #31. Closes #30.
