### PR TITLE
Clamp the RTS camera to the level bounds (issue #43)

### DIFF
--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -16,7 +16,9 @@ Top-level game scenes and their scripts.
   load-bearing:
   1. the map builds itself in its own `_ready()` (Godot readies children
      first);
-  2. this script places the hero on the map's start cell and snaps the camera;
+  2. this script places the hero on the map's start cell, hands the camera the
+     map's bounds, and snaps it — in that order, because the snap is the frame
+     the player opens on and an unbounded one opens on void (issue #43);
   3. it bakes the navmesh over the geometry that now exists — synchronous
      (`bake_navigation_mesh(false)`) because the web export has threads
      disabled, so don't switch it to on-thread baking. On the open level this
@@ -270,4 +272,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: a29d8c3 -->
+<!-- verified-against: 711281c -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -152,14 +152,50 @@ what winning *means* belongs here.
   to its exported `target` (the hero); the script captures that offset in
   `_ready()`, aims once with `look_at()`, and afterwards only translates with
   exponential smoothing. It never rotates at runtime.
-- `snap_to_target()` moves **and re-aims**. `main.gd` teleports the hero to the
-  map's start cell after the camera's `_ready()` has already run, so without the
-  re-aim the camera keeps pointing at wherever the hero sat in the .tscn.
+- `snap_to_target()` moves and **restores the authored angle** from a basis
+  captured in `_ready()`. It used to re-aim with `look_at(target)`, which was
+  the same thing while the camera sat at exactly `target + offset` — the
+  direction is `-offset` either way. Bounds (below) break that identity on
+  purpose, and aiming at the target from a held-back camera would tilt the
+  fixed perspective by however much it is being held.
 - The offset is `(0, 22.1, 14)` → a ~57° pitch. The old `(0, 16, 24)` (~33°)
   was authored for the small arena; on the 60×72 maze that shallow angle showed
   the map from the outside rather than the hero's surroundings. The level is now
-  176×152, which does not change the offset but does make issue #43 (the camera
-  has no level bounds, so the view runs off the edge at spawn) more visible.
+  176×152, which does not change the offset.
+
+### Level bounds (issue #43)
+
+`main.gd` hands the camera `LevelMap.bounds()` **before the first snap**, and
+the camera then stops following once its view would run off the level. Passed
+in rather than read off the map, so the camera never learns what a level is —
+the same seam that keeps the map from knowing what stands on its spawn markers.
+
+Two things about it are worth knowing before touching it.
+
+- **It measures the frame rather than assuming one.** The ground the camera
+  covers is found by casting the four screen corners and intersecting them with
+  the plane the target stands on, so the clamp is right at any window size. A
+  hand-tuned margin would have reproduced the original bug, which got worse as
+  the window got wider.
+- **The clamp yields to the hero, and this is the part that is easy to get
+  wrong.** Fitting the frame inside the level *exactly* is what the issue
+  proposed, and on this map it is unusable: the level is 176 across against a
+  ~140-wide frame, so squaring the view with the west edge slides the camera
+  far enough sideways to carry the hero off the screen — measured at 158 px
+  past the left edge at 1152×648. So a correction is capped at
+  `MAX_TARGET_DRIFT` (0.15) of the frame, priced in pixels, per axis
+  independently — the level has depth to spare and no width to spare, and a
+  shared budget would let the west edge, which cannot be fixed, throttle the
+  south edge, which costs about a metre.
+
+What that buys, at 1152×648: the void band under the start clearing is gone,
+the boss room frames without one, and what is left at spawn is a small dark
+wedge in the far corner. **It does not promise the void is never on screen** —
+near a corner the map cannot fill the frame and the camera will not pay the
+hero's visibility for it. If that ever needs to be true, the fix is a wider
+rock margin in the layout, not a bigger drift budget: past ~0.25 the camera
+buys blank rock with the hero pinned to the edge, which looks worse than the
+wedge.
 
 ## Physics layers (project convention, established here)
 

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -268,4 +268,4 @@ wider than this will not.
   the boss has no model of its own at all, so whatever it eventually wears is a
   separate question from what the horde does.
 
-<!-- verified-against: a29d8c3 -->
+<!-- verified-against: 711281c -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -271,4 +271,4 @@ numbers.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: a29d8c3 -->
+<!-- verified-against: 711281c -->

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -67,6 +67,9 @@ var _run_over := false
 
 func _ready() -> void:
 	_hero.global_position = _level.start_position() + Vector3(0, SPAWN_CLEARANCE, 0)
+	# Before the snap, not after: the snap decides the frame the player opens on,
+	# and an unbounded one opens on the void past the south edge (issue #43).
+	_camera.set_bounds(_level.bounds())
 	_camera.snap_to_target()
 	_nav_region.bake_navigation_mesh(false)
 	_place_checkpoints()

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -189,8 +189,18 @@ rows on is the whole fix, and it costs nothing — no spawn sits between 45 and
   *size* — the boss is as wide as the ring, so what survives is a crescent at
   its feet rather than a circle around it (issue #49). Colour was the constraint
   anyone thought to check; scale was the one nobody had needed to.
-- Public API: `start_position()`, `boss_position()`, `boss_segment()`,
-  `zombie_spawns()`, `checkpoints()`, and the `built` signal.
+- Public API: `bounds()`, `start_position()`, `boss_position()`,
+  `boss_segment()`, `zombie_spawns()`, `checkpoints()`, and the `built` signal.
+
+**`bounds()` covers every cell, rock included, and the rock caps are the reason
+it can.** It is the rectangle `scenes/`'s camera keeps its view inside (issue
+#43), so it has to be the region with *something drawn in it* rather than the
+region you can walk on — and because every rock cell is capped rather than left
+as a hole, those two are the whole grid and the open floor respectively. The
+walkable shape would be the wrong answer twice over: it is full of concavities
+no camera can track, and honouring it would push the level's own walls off
+screen. It reads `layout` alone, so unlike the rest of the API it is valid
+before `build()` has run.
 
 **The map never instances enemies, and it does not instance checkpoints
 either.** It only says where they go; `scenes/main.gd` reads `zombie_spawns()`

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -292,4 +292,4 @@ contiguous run of open cells without changing what the player sees.
   `scenes/hero/`, which is why it is in the frontmatter above. `Checkpoint`
   never names `Hero` as a type.
 
-<!-- verified-against: a29d8c3 -->
+<!-- verified-against: 711281c -->

--- a/scenes/map/level_map.gd
+++ b/scenes/map/level_map.gd
@@ -157,6 +157,25 @@ func _ready() -> void:
 	build()
 
 
+## The level's whole footprint on the ground plane: world X on the returned
+## rect's x axis, world Z on its y.
+##
+## It covers every cell, rock included, because every cell is *drawn* — rock is
+## capped at wall height (see [method _add_rock_cap]) rather than left as a
+## hole. So this rectangle is exactly the region that has something in it, and
+## anything outside it is empty void, which is what makes it the shape
+## scenes/'s camera clamps its view into (issue #43). The walkable floor is a
+## smaller and wrong answer to that question: rock frames the level, and a
+## camera that refused to show it would push the walls off screen.
+##
+## Reads [member layout] only, so it is valid before [method build] has run.
+func bounds() -> Rect2:
+	if layout.is_empty():
+		return Rect2()
+	var size := Vector2(float(layout[0].length()), float(layout.size())) * CELL_SIZE
+	return Rect2(-size * 0.5, size)
+
+
 ## World position of the cell the hero starts in.
 func start_position() -> Vector3:
 	return _cell_to_world(_start_cell)

--- a/scenes/rts_camera.gd
+++ b/scenes/rts_camera.gd
@@ -1,21 +1,67 @@
 class_name RTSCamera
 extends Camera3D
-## Fixed-angle RTS-style follow camera (issue #5).
+## Fixed-angle RTS-style follow camera (issues #5, #43).
 ##
 ## The angle is defined entirely by where the camera node is placed in the
 ## scene relative to its target: _ready() captures that offset and aims at the
 ## target once, then only translates — never rotates — so the view keeps the
 ## classic StarCraft/Warcraft fixed perspective.
+##
+## Given the level's bounds it also stops following once the frame would run
+## off the edge of the map, the way an RTS camera does. Without that the hero
+## can stand near an edge with the void filling a large part of the screen —
+## which is what he does at spawn, since the start cell sits near the south
+## edge and the camera stands further south still (issue #43).
 
 @export var target: Node3D
 @export var follow_speed := 8.0
 
+## How far the bounds may push the target off centre, as a fraction of the
+## frame. **The clamp yields to this, not the other way round**, and that is
+## the whole reason this constant exists rather than the camera simply fitting
+## its view inside the level. On a map only a little wider than the view — this
+## one is 176 across against a ~140-wide frame — fitting the frame exactly means
+## sliding the camera far enough sideways to carry the hero off the screen
+## entirely. Measured, not predicted: the first version of this did exactly
+## that at spawn, putting him 158 px past the left edge of a 1152 px window.
+##
+## So void at the edge of the world is treated as the cosmetic problem it is,
+## and losing sight of the unit you control as the real one.
+##
+## 0.15 was picked off screenshots at the two corners the level actually has.
+## Higher is not better: at 0.25 the spawn frame loses its void but spends it
+## on a screenful of blank rock with the hero pinned to the left edge, which is
+## a worse picture than the small dark wedge 0.15 leaves in the far corner.
+const MAX_TARGET_DRIFT := 0.15
+
 var _offset := Vector3.ZERO
+## The authored viewing angle, captured once and reasserted rather than
+## recomputed — see snap_to_target() for why it can no longer be re-derived
+## from where the target is standing.
+var _aim := Basis.IDENTITY
+## World XZ rectangle the view is kept inside; empty until set_bounds().
+var _bounds := Rect2()
+var _bounded := false
 
 
 func _ready() -> void:
 	_offset = global_position - target.global_position
 	look_at(target.global_position)
+	_aim = global_basis
+
+
+## Keep the view inside [param level_bounds] — world X on the rect's x axis,
+## world Z on its y, which is what LevelMap.bounds() returns.
+##
+## Handed in rather than read off the map, so this stays a camera and not
+## something that knows what a level is; main.gd owns that seam, the same way
+## it decides what stands on the map's spawn markers.
+##
+## Call it before the first snap_to_target(), or the opening frame is the one
+## unclamped frame of the run — and that frame is the whole of issue #43.
+func set_bounds(level_bounds: Rect2) -> void:
+	_bounds = level_bounds
+	_bounded = level_bounds.has_area()
 
 
 ## Jump straight to the target instead of gliding to it. Call this after
@@ -23,15 +69,123 @@ func _ready() -> void:
 ## main.gd, which happens after this _ready(), and without a snap the camera
 ## would visibly sail across the map on the first frames.
 ##
-## Re-aims as well as moves: _ready() aimed at wherever the target was sitting
-## in the .tscn, which is the wrong point once it has been teleported. The
-## offset is unchanged, so the fixed viewing angle is preserved.
+## Restores the authored angle rather than re-aiming at the target. Aiming used
+## to be equivalent: the camera sat at exactly `target + _offset`, so looking at
+## the target always reproduced the angle _ready() captured. Bounds break that
+## identity — a clamped camera is deliberately somewhere else — and look_at()
+## would then tilt the view by however much the clamp is holding it back,
+## turning a fixed-perspective camera into one that pitches near a map edge.
 func snap_to_target() -> void:
-	global_position = target.global_position + _offset
-	look_at(target.global_position)
+	global_position = _clamped(target.global_position + _offset)
+	global_basis = _aim
 
 
 func _physics_process(delta: float) -> void:
-	var desired := target.global_position + _offset
+	var desired := _clamped(target.global_position + _offset)
 	# Exponential smoothing that is stable regardless of frame rate.
 	global_position = global_position.lerp(desired, 1.0 - exp(-follow_speed * delta))
+
+
+## Where the camera should actually sit, given it would rather be at
+## [param desired] and the level ends where it does.
+##
+## Clamping the *destination* and then smoothing toward it is what makes the
+## camera glide to a halt against an edge; clamping the smoothed result instead
+## would let it keep pressing into the boundary and stop dead there.
+func _clamped(desired: Vector3) -> Vector3:
+	if not _bounded:
+		return desired
+	var correction := _bounds_correction(desired)
+	# Priced one axis at a time, because the two cost wildly different amounts
+	# here and a shared budget would spend them together: this level has depth
+	# to spare and almost no width to spare, so the south edge — which costs
+	# about a metre of drift to fix — would be throttled by the west edge, which
+	# cannot be fixed at all. Separately, the cheap one is simply free.
+	for axis in 2:
+		if correction[axis] == 0.0:
+			continue
+		var alone := Vector2.ZERO
+		alone[axis] = correction[axis]
+		correction[axis] *= _affordable(desired, alone)
+	return desired + Vector3(correction.x, 0.0, correction.y)
+
+
+## How far the camera would have to move from [param from] for its view to stop
+## running off the level, as a world XZ offset. Zero when it already fits.
+func _bounds_correction(from: Vector3) -> Vector2:
+	var view := _ground_view(from)
+	var correction := Vector2.ZERO
+	for axis in 2:
+		if view.size[axis] >= _bounds.size[axis]:
+			# The frame is larger than the level on this axis, so no position
+			# hides the void — centre the level instead and split what is left
+			# between the two edges rather than banking it all against one.
+			correction[axis] = _bounds.get_center()[axis] - view.get_center()[axis]
+		elif view.position[axis] < _bounds.position[axis]:
+			correction[axis] = _bounds.position[axis] - view.position[axis]
+		elif view.end[axis] > _bounds.end[axis]:
+			correction[axis] = _bounds.end[axis] - view.end[axis]
+	return correction
+
+
+## The fraction of [param correction] that can be applied before the target
+## drifts further off centre than MAX_TARGET_DRIFT allows. 1.0 whenever the
+## correction is cheap, which on this map is everywhere except the edges.
+##
+## Measured in pixels rather than world units on purpose: a world-space budget
+## would have to be expressed against the view, and the view is a trapezoid —
+## a metre near the bottom of the screen costs several times the pixels a metre
+## at the top does, which is exactly the difference between a hero pushed
+## slightly off centre and a hero pushed out of frame.
+##
+## The measurement leans on the fixed angle: moving the camera by c projects the
+## target exactly where moving the *target* by -c would, so two unprojections
+## price a correction the camera has not made yet. Scaling the answer back
+## linearly is an approximation — perspective is not linear in the shift, and
+## it overshoots the budget by about 15% at the spawn corner. Left as is
+## deliberately: this is a comfort threshold read off screenshots, not a
+## boundary anything depends on, so iterating it would buy precision about a
+## number that was never precise.
+func _affordable(from: Vector3, correction: Vector2) -> float:
+	# Where the target sits now, expressed as a point in front of *this* camera.
+	var here := target.global_position - (from - global_position)
+	var moved := here - Vector3(correction.x, 0.0, correction.y)
+	var drift := (unproject_position(moved) - unproject_position(here)).abs()
+	var budget := get_viewport().get_visible_rect().size * MAX_TARGET_DRIFT
+	var affordable := 1.0
+	for axis in 2:
+		if drift[axis] > budget[axis]:
+			affordable = minf(affordable, budget[axis] / drift[axis])
+	return affordable
+
+
+## The patch of ground this camera would show from [param from], as a world XZ
+## rectangle. The ground plane is the one the target stands on.
+##
+## Measured by casting the four screen corners rather than derived from fov and
+## aspect, so it stays correct whatever the window is doing — the void in issue
+## #43 grew with the window, and a hand-tuned margin would have had that same
+## bug. A pitched camera sees a trapezoid; its bounding box is what gets
+## clamped, which errs toward showing less void rather than more.
+##
+## Only the ray *directions* are taken from the current transform, and those
+## come from the basis alone — which never changes. That is what makes this
+## valid for a position the camera has not moved to yet.
+func _ground_view(from: Vector3) -> Rect2:
+	var screen := get_viewport().get_visible_rect().size
+	var height := from.y - target.global_position.y
+	var low := Vector2.INF
+	var high := -Vector2.INF
+	for corner in [Vector2.ZERO, Vector2(screen.x, 0.0), Vector2(0.0, screen.y), screen]:
+		var direction := project_ray_normal(corner)
+		if direction.y >= -0.001:
+			# That corner is on or above the horizon, so it has no ground under
+			# it and there is no frame to fit inside the level. Fall back to
+			# keeping the camera itself over the map. Only reachable if the
+			# authored pitch or the fov is changed enough to put sky on screen.
+			return Rect2(Vector2(from.x, from.z), Vector2.ZERO)
+		var ground := direction * (height / -direction.y)
+		var point := Vector2(from.x + ground.x, from.z + ground.z)
+		low = low.min(point)
+		high = high.max(point)
+	return Rect2(low, high - low)

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -202,4 +202,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: a29d8c3 -->
+<!-- verified-against: 711281c -->


### PR DESCRIPTION
Fixes #43.

The camera stands 14 units behind the hero and the start cell sits near the south
edge of the layout, so the opening frame was largely void — the first thing anyone
sees on the playable link.

## What it does

- **`LevelMap.bounds()`** — the level's whole footprint as a `Rect2` in world XZ.
  It covers *every* cell, rock included, because every rock cell is capped
  (`_add_rock_cap`) and therefore drawn. The walkable floor would be the wrong
  answer: full of concavities, and honouring it would push the level's own walls
  off screen. Reads `layout` alone, so it is valid before `build()`.
- **`main.gd`** hands that to the camera *before* the first `snap_to_target()` —
  the snap decides the frame the player opens on.
- **`RTSCamera`** stops following once its view would leave the level.

## The part that is not what the issue proposed

The issue's option 2 was "fit the frame inside the level bounds". Built exactly
that way it is **unusable**, and the screenshots are unambiguous: the level is 176
across against a ~140-wide frame, so squaring the view with the west edge slides
the camera far enough sideways that the hero leaves the screen — measured at 158 px
past the left edge of a 1152 px window, with the frame filled by blank rock.

So the clamp yields to the hero. A correction is capped at `MAX_TARGET_DRIFT`
(0.15) of the frame, and two details of that are load-bearing:

- **Priced in pixels, not world units.** The view is a trapezoid, so a metre near
  the bottom of the screen costs several times the pixels a metre at the top does
  — which is exactly the difference between a hero slightly off centre and a hero
  out of frame. The measurement leans on the fixed angle: moving the camera by `c`
  projects the target where moving the *target* by `-c` would, so two
  unprojections price a correction the camera has not made yet.
- **Per axis independently.** This level has depth to spare and almost no width to
  spare. Under a shared budget the west edge — which cannot be fixed at all —
  would throttle the south edge, which costs about a metre of drift to fix.

Consequence worth reviewing on its merits: **this does not promise the void is
never on screen.** At spawn a small dark wedge remains in the far corner. The
alternative was paying for it with the hero's visibility. If it ever has to be
zero, the fix is a wider rock margin in the layout, not a bigger drift budget —
past ~0.25 the camera buys blank rock with the hero pinned to the edge, which
looks worse.

## Also in here

`snap_to_target()` restores the angle captured in `_ready()` instead of re-aiming
with `look_at(target)`. Those were the same thing only while the camera sat at
exactly `target + _offset` (the direction is `-_offset` either way, so the re-aim
was already a no-op). Bounds break that identity deliberately, and aiming at the
hero from a held-back camera would tilt the fixed perspective — the one thing
`RTSCamera` exists to keep steady.

## Verification

Ran the scene and measured at 1152×648, plus screenshots at both corners the
level has.

| | before | after |
|---|---|---|
| view past the south edge, at spawn | 1.9 u | 0 — flush |
| view past the west edge, at spawn | 43.8 u | 32.8 u |
| view past the north edge, boss room | 20.4 u | 10.3 u (and hidden by the rock ring, which stands 4 u proud of the ground plane) |
| hero's screen x at spawn (centre 576) | 576 | 396 |

The void band under the start clearing is gone and the boss room frames without
one. No script errors or warnings on a clean run.

## Docs

`scenes/CLAUDE.md` gets the bounds section and the new startup step;
`scenes/map/CLAUDE.md` gets `bounds()` and why it is the grid and not the floor.
The `depends-on` graph then flagged `enemies/`, `hero/` and `ui/` for `scenes/`
code moving — second commit records what re-reading them found (nothing untrue;
the hero's "a click past the level edge still produces an order" matters more
now, not less) and re-stamps.

Knowledge base: [[engine/main-scene]] and [[engine/level-map]] updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
