### PR TITLE
Harden the doc checks (#27, #34, #35) and correct the respawn-clearance rule (#54)

### DIFF
--- a/.claude/hooks/CLAUDE.md
+++ b/.claude/hooks/CLAUDE.md
@@ -26,22 +26,37 @@ one failing does not prevent the other from running.
   against two `scenes/map/maze.gd` commits.
 
   **The frontmatter parser is the third thing here to hit the self-reference
-  trap.** `depends-on:` is read from line 2 to the first closing `---`, never
-  with a `/^---$/,/^---$/` range: sed restarts a range at every later match, so
-  a markdown horizontal rule further down a doc reopens it, and any prose line
-  starting `depends-on:` is then read as a real edge. A doc explaining this
-  convention would be misparsed by the parser it explains — the same shape as
-  the stamp parser taking the *last* match, and as the Flowdex hook reading its
-  own source. Assume any parser added here will hit it too.
+  trap, and it hit it twice.** `depends-on:` is read from line 2 to the first
+  closing `---`, never with a `/^---$/,/^---$/` range: sed restarts a range at
+  every later match, so a markdown horizontal rule further down a doc reopens
+  it, and any prose line starting `depends-on:` is then read as a real edge. A
+  doc explaining this convention would be misparsed by the parser it explains —
+  the same shape as the stamp parser taking the *last* match, and as the Flowdex
+  hook reading its own source. Assume any parser added here will hit it too.
+
+  The second half of that was issue #34: `2,/^---$/` has no terminator if the
+  closing `---` is missing, so it reads to end of file and the same prose line
+  is parsed as an edge by a different route. **The close is now required rather
+  than assumed** — `frontmatter_closed` answers whether there is a block at all
+  and `frontmatter` prints nothing when there is not, so callers have to report
+  the absence instead of receiving an empty parse. Anything reading frontmatter
+  should go through those two, not re-derive a range.
 
   **The bracket form is required, and the reason is not cosmetic.** An
-  unbracketed `depends-on: scenes` satisfies a bare key test while the parser
-  extracts nothing from it, so the doc reads as having no dependencies —
-  indistinguishable from a deliberate `[]`, with no `BADDEP` or `DEPSTALE` able
-  to fire for it ever again. That is this check's own failure mode reproduced
-  inside its parser, which is why the gate tests for `[...]` rather than for the
-  key alone. The general lesson: every gate here should ask whether a
-  *malformed* input is silently read as an *empty* one.
+  unbracketed `depends-on: scenes` — or a list wrapped over several lines —
+  satisfies a bare key test while the parser extracts nothing from it, so the
+  doc reads as having no dependencies, indistinguishable from a deliberate `[]`,
+  with no `BADDEP` or `DEPSTALE` able to fire for it ever again. That is this
+  check's own failure mode reproduced inside its parser, which is why the gate
+  tests for `[...]` rather than for the key alone. The general lesson: every
+  gate here should ask whether a *malformed* input is silently read as an
+  *empty* one.
+
+  **`NOFRONT` says which of the three it is**, and that is worth keeping. The
+  single message it used to print — "no `depends-on: [...]` key in a
+  frontmatter block on line 1" — sent anyone with a wrapped list looking for a
+  key that was plainly there (issue #34). No block, a block without the key, and
+  a key in an unparseable form now read differently.
 
   **Both graph and stamp checks must exclude nested subfolders.** A git pathspec
   of `scenes` also matches `scenes/map/` and `scenes/hero/`, so the first version
@@ -52,6 +67,23 @@ one failing does not prevent the other from running.
 
   `--audit` runs the history checks alone against any checkout, and is the
   one-command answer to "are these docs still trustworthy?".
+
+  **A stamp can name a real commit and still be impossible, and the
+  verification check cannot see it** (issue #35). It asks whether the folder
+  changed since the stamp without the doc changing; a stamp from *before the
+  folder existed* passes that trivially, because there are no such commits.
+  Two guards run first and fail closed: `PREDATES` (the folder does not exist
+  at that commit) and `UNREACHABLE` (the commit is not an ancestor of `HEAD`,
+  so it is a sha copied from elsewhere in the history rather than one this
+  branch was read at). The second is deliberately stricter locally than in CI,
+  where the PR job checks out the merge with `main` and so has more ancestors —
+  starting every branch fresh from `origin/main` is what keeps the two agreeing.
+  Both repair by repointing the stamp, never by re-auditing: like a rewritten
+  history, nothing about the doc became untrue.
+
+  It found live debt on its first run, exactly as the graph check did:
+  `tests/CLAUDE.md` was stamped at `200ccec`, one merge before `tests/` was
+  created.
 
   Note the ceiling: all four verify a doc was *edited*, never that it is
   *true*. The stamp does not change that — it makes the human judgement
@@ -69,6 +101,18 @@ one failing does not prevent the other from running.
 - `check-flowdex.sh` — enforces the Flowdex write-back rule (see "Knowledge
   base" in the root `CLAUDE.md`). No-ops for a developer who has not connected
   the Flowdex MCP server.
+
+  **What separates a call from a mention is a shape, not a key name** (issue
+  #27). The write-back probe requires the tool name under a key spelled exactly
+  `name`, which is how a call is recorded; the three other ways a name reaches a
+  transcript each miss for their own reason — a different key on a tool-search
+  reference entry, no key at all in a bare listing, and backslash-escaped quotes
+  in a schema quoted as text. So the thing that would kill enforcement silently
+  is a transcript format storing a tool *listing* in the structured shape a call
+  uses, by any route. The comment above that grep used to name only the key
+  rename, which is one of the three and would send a maintainer to re-test the
+  wrong thing. Re-test by opening a real transcript from a session that *loaded*
+  these tools without calling them and confirming the pattern finds nothing.
 - `test-check-flowdex.sh` — test harness for the above. Run it after any change
   to `check-flowdex.sh`:
 

--- a/.claude/hooks/CLAUDE.md
+++ b/.claude/hooks/CLAUDE.md
@@ -12,7 +12,8 @@ one failing does not prevent the other from running.
   `CLAUDE.md`, in four layers: **same-change** (code changed in a folder =>
   that folder's doc changed too), **code map** (every code folder is linked from
   the root's map, and every entry resolves), **verification** (every folder
-  doc carries a `verified-against: <sha>` stamp, and its folder has not changed
+  doc carries a `verified-against: <sha>` stamp, the stamp names a commit the
+  claim could have been made at, and its folder has not changed
   since without the doc being touched), and **dependency graph** (every folder
   doc *declares* `depends-on: [...]` — `[]` if it has none — each entry
   resolves, and no doc is left unread after code it depends on moved). Runs

--- a/.claude/hooks/check-flowdex.sh
+++ b/.claude/hooks/check-flowdex.sh
@@ -87,15 +87,30 @@ fi
 # pattern is satisfied by merely having Flowdex connected — which is what the
 # availability probe above deliberately uses it for.
 #
-# The distinction rests on the JSON key, so be careful changing it. A real call
-# is recorded as "name":"<tool>"; every other appearance of a tool name in a
-# transcript uses a different key or no key at all — a ToolSearch result stores
-# it as "tool_name":"<tool>" and as bare comma-separated names. Requiring a
-# quote immediately before `name` is what separates the two. Verified against
-# 15 real session transcripts: this pattern's hit count equalled the number of
-# genuine calls in every one, including a session where these tools' full
-# schemas were loaded via ToolSearch. If Claude Code ever renames that key to
-# `name`, enforcement dies silently — that is the thing to re-test.
+# What separates the two is the *shape* a name is stored in, not the spelling of
+# any one key — and the shape is the thing to re-test (issue #27). A call is
+# recorded as an object carrying the name under a key spelled exactly `name`, so
+# demanding a quote immediately before it is what makes the other three ways a
+# name reaches a transcript miss. Each misses for its own reason, which is why
+# no single one of them is the invariant:
+#
+#   a ToolSearch reference entry   files it under "tool_name":"<tool>"
+#   a tool listing or a query      bare comma-separated names, no key at all
+#   a schema quoted as text        JSON-escaped, so its quotes are backslashed
+#                                  and the bare `"` here cannot match them
+#
+# Enforcement therefore dies silently the day a transcript format stores a tool
+# *listing* in the same structured shape a real call uses — whether by renaming
+# that key, by inlining schemas as JSON objects instead of as escaped text, or
+# by some third route to the same place. Re-testing only "has the key been
+# renamed?" would miss two of the three, which is what this comment used to send
+# a maintainer off to do. The check that covers all of them: open a current
+# transcript from a session that *loaded* these tools without calling them, and
+# confirm this pattern still finds nothing in it.
+#
+# Measured 2026-08-04 across 30 real transcripts: 214 occurrences of the matched
+# form, all 214 inside a tool_use entry, against 38 filed under `tool_name` and
+# 3 sitting in escaped text. No false positive in any of them.
 if grep -qE "\"name\"[[:space:]]*:[[:space:]]*\"${mcp_prefix}${writeback_tools}\"" "$transcript" 2>/dev/null; then
   exit 0
 fi

--- a/.claude/hooks/check-folder-docs.sh
+++ b/.claude/hooks/check-folder-docs.sh
@@ -13,6 +13,7 @@
 #                    the root doc's only volatile claim, made checkable.
 #
 #   C. verification  Every folder doc carries a `verified-against: <sha>` stamp,
+#                    the stamp names a commit the claim could have been made at,
 #                    and no commit since that sha touched the folder without
 #                    also touching the doc. Catches everything that bypasses A:
 #                    history predating these hooks, merge-conflict resolutions,
@@ -163,6 +164,25 @@ check_verification() {
       echo "            verified-against: $stamp is not a commit in this repository"
       continue
     fi
+    # Two ways a stamp names a real commit and is still impossible on its face,
+    # and the check below cannot see either: it asks "did this folder change
+    # since the stamp without the doc changing?", which a stamp from before the
+    # folder existed passes trivially — there are no such commits, because there
+    # was no such folder (issue #35, found on `scenes/components/` in review of
+    # #20). A stamp is the only human claim in this repo, so one that could not
+    # have been earned is worse than one that is merely old.
+    if ! git cat-file -e "${stamp}:${d}" 2>/dev/null; then
+      echo "PREDATES    $doc"
+      echo "            verified-against: $stamp — $d/ does not exist at that"
+      echo "            commit, so nothing can have been read against it there"
+      continue
+    fi
+    if ! git merge-base --is-ancestor "$stamp" HEAD 2>/dev/null; then
+      echo "UNREACHABLE $doc"
+      echo "            verified-against: $stamp is not an ancestor of HEAD — it"
+      echo "            is not a state this branch was ever checked against"
+      continue
+    fi
 
     offenders=$(unaccompanied_commits "$d" "$stamp")
     [ -n "$offenders" ] || continue
@@ -183,14 +203,34 @@ check_verification() {
 # anything it depends on did. That is the drift nothing else catches: change the
 # navmesh settings in scenes/ and scenes/map/CLAUDE.md can silently stop being
 # true, because its own folder never moved.
-# Frontmatter body only: line 2 through the first closing `---`. NOT a
-# /^---$/,/^---$/ range — sed restarts a range at every later match, so a
-# markdown horizontal rule further down the file reopens it and any prose line
-# beginning `depends-on:` is read as a real edge. That is the self-reference
-# trap again, in a third form: a doc explaining this convention would be
-# misparsed by the parser it explains. Callers check line 1 is `---` first.
+# Frontmatter body only: line 2 through the first closing `---`. Two sed idioms
+# are deliberately not used, and they are the same self-reference trap in two
+# guises — a doc explaining this convention misparsed by the parser it explains:
+#
+#   /^---$/,/^---$/   a range restarts at every later match, so a markdown
+#                     horizontal rule reopens the block and any prose line
+#                     beginning `depends-on:` is read as a real edge.
+#   2,/^---$/         with no closing `---` at all this reads to end of file,
+#                     which is the same failure by another route (issue #34).
+#
+# So the close is required rather than assumed: frontmatter_closed answers
+# whether there is a block, frontmatter prints the body only when there is one.
+# Callers must report its absence — treating the empty output as "declares no
+# dependencies" would be this check's own failure mode inside its parser, which
+# is the same reason the bracket form is demanded below.
+frontmatter_closed() {
+  awk 'NR == 1 { if ($0 != "---") exit 1; next }
+       $0 == "---" { closed = 1; exit }
+       END { exit (closed ? 0 : 1) }' "$1"
+}
+
+frontmatter() {
+  frontmatter_closed "$1" || return 0
+  awk 'NR == 1 { next } $0 == "---" { exit } { print }' "$1"
+}
+
 declared_deps() {
-  sed -n '2,/^---$/p' "$1" \
+  frontmatter "$1" \
     | sed -n 's/^depends-on:[[:space:]]*\[\(.*\)\].*/\1/p' \
     | tr ',' '\n' \
     | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
@@ -221,15 +261,29 @@ check_graph() {
 
     # Three ways this goes wrong, and every one of them has to be loud. A
     # missing block is obvious, and a block omitting the key nearly so. The
-    # third is not: an unbracketed `depends-on: scenes` satisfies a bare key
-    # test, while declared_deps extracts nothing from it -- so the doc reads as
-    # having no dependencies, indistinguishable from a deliberate `[]`, and no
-    # BADDEP or DEPSTALE can ever fire for it. That is this check's own failure
-    # mode reproduced inside its parser, so the gate demands the bracket form.
-    if ! sed -n '1p' "$doc" | grep -qx -- '---' \
-       || ! sed -n '2,/^---$/p' "$doc" | grep -q '^depends-on:[[:space:]]*\[.*\]'; then
+    # third is not: an unbracketed `depends-on: scenes`, or a list wrapped over
+    # several lines, satisfies a bare key test while declared_deps extracts
+    # nothing from it -- so the doc reads as having no dependencies,
+    # indistinguishable from a deliberate `[]`, and no BADDEP or DEPSTALE can
+    # ever fire for it. That is this check's own failure mode reproduced inside
+    # its parser, so the gate demands the single-line bracket form. Each case
+    # gets its own words: a message naming the wrong fault sends the reader to
+    # look for a key that is plainly there (issue #34).
+    if ! frontmatter_closed "$doc"; then
       echo "NOFRONT     $doc"
-      echo "            no 'depends-on: [...]' key in a frontmatter block on line 1"
+      echo "            no frontmatter block — line 1 must be '---' and a later"
+      echo "            line must close it"
+      continue
+    fi
+    front=$(frontmatter "$doc")
+    if ! printf '%s\n' "$front" | grep -q '^depends-on:[[:space:]]*\[.*\]'; then
+      echo "NOFRONT     $doc"
+      if printf '%s\n' "$front" | grep -q '^depends-on:'; then
+        echo "            depends-on: is present but is not a single-line"
+        echo "            '[a, b]' list; no other form is parsed"
+      else
+        echo "            no 'depends-on: [...]' key in the frontmatter block"
+      fi
       continue
     fi
 
@@ -286,6 +340,8 @@ problems=$(
   echo "            doc's claims rest on:  ---\\ndepends-on: [scenes, assets]\\n---"
   echo "            Declaring none is 'depends-on: []' — an explicit claim, not"
   echo "            an omitted key, which nothing could tell from forgetting."
+  echo "            The list must sit on one line: a wrapped array parses as"
+  echo "            no dependencies at all, which is why it is refused here."
   echo "SELFDEP     drop the self-reference; a folder does not depend on itself."
   echo "BADDEP      the named folder has no CLAUDE.md — fix the name or add the doc."
   echo "DEPSTALE    a folder this doc depends on changed. Re-read this doc against"
@@ -293,6 +349,12 @@ problems=$(
   echo "            no longer holds, then bump this doc's stamp. This is the check"
   echo "            that catches drift arriving from outside the folder."
   echo "NOSTAMP     append to the doc:  <!-- verified-against: \$(git rev-parse --short HEAD) -->"
+  echo "BADSTAMP    the sha does not resolve — history was rewritten under it"
+  echo "PREDATES    (squash, rebase, amend, force-push). Repoint the stamp at the"
+  echo "UNREACHABLE resulting commit; do not re-audit, nothing became untrue."
+  echo "            PREDATES and UNREACHABLE also catch a sha copied from"
+  echo "            elsewhere in the history rather than earned: stamp at the"
+  echo "            HEAD you actually read the doc against, and nowhere else."
   echo "UNVERIFIED  read the listed commits against the doc, correct whatever no"
   echo "            longer holds, then bump the stamp to the current HEAD. Bump it"
   echo "            only once the doc is actually true — the stamp is a claim that"

--- a/.claude/hooks/test-check-flowdex.sh
+++ b/.claude/hooks/test-check-flowdex.sh
@@ -50,6 +50,13 @@ read_only="{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_us
 merged="{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"tool_use\",\"name\":\"Bash\",\"input\":{\"command\":\"${merge_cmd} 23 --squash\"}}]}}"
 # A tool-listing / schema mention: the tool name appears, but never as a call.
 mention="{\"type\":\"tool_result\",\"content\":[{\"type\":\"tool_reference\",\"tool_name\":\"${write_tool}\"}]}"
+# The same thing in the other shape a listing arrives in: a schema quoted as
+# *text*, so its quotes are JSON-escaped and the call pattern cannot reach them.
+# The hook's comment names three ways a name reaches a transcript without being
+# a call; this pins the one that is not a key at all. It is only safe to write
+# out because the escaped form is not the matched form — read_the_tests below
+# is what proves that, by feeding this file to the hook and demanding a 0.
+schema_text="{\"type\":\"user\",\"message\":{\"content\":[{\"type\":\"tool_result\",\"content\":\"<function>{\\\"name\\\": \\\"${write_tool}\\\"}</function>\"}]}}"
 
 mk() { local name=$1; shift; printf '%s\n' "$@" > "$TMP/$name.jsonl"; }
 
@@ -62,6 +69,7 @@ mk read_only         "$avail" "$read_only"
 mk scratchpad_only   "$avail" "$edit_scratch"
 mk licenses_only     "$avail" "$edit_lic"
 mk mention_not_call  "$avail" "$edit_gd" "$mention"
+mk schema_as_text    "$avail" "$edit_gd" "$schema_text"
 
 # The regression that shipped: a session holding this hook's own text must not
 # be read as having merged a PR or written anything back. Grep is line-based,
@@ -96,6 +104,7 @@ check no_writeback      2 "code edited, nothing written back"
 check merged_no_write   2 "PR merged, nothing written back"
 check licenses_only     2 "only LICENSES.md edited"
 check mention_not_call  2 "tool named but never called"
+check schema_as_text    2 "schema quoted as escaped text, never called"
 echo
 echo "stays out of the way when it should:"
 check wrote_back        0 "code edited and written back"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,8 @@ Rules:
   ---
   ```
 
+  **The list must sit on one line, and the brackets are required.** A wrapped array is valid YAML and is still refused here (issue #34): the parser reads a single-line `[a, b]` and nothing else, so any other form would be read as *no dependencies at all* — indistinguishable from a deliberate `[]`, with no further check able to fire for that doc again. Declaring none is `depends-on: []`, which is a claim; an unparseable list is not.
+
   Only this direction is stored. "What do I affect?" is its exact inverse, and keeping both would create two records that can disagree — see the `depends-on` graph below for what the edges are actually used for.
 - Keep them short and current — a stale doc is worse than none. Delete statements that no longer hold rather than appending corrections.
 - These folder docs are also what PR reviewers use to judge a change, so an out-of-date doc is a valid review finding.
@@ -130,6 +132,16 @@ such as amending or force-pushing a branch after its docs were stamped. If it
 does happen anyway, the repair is to repoint the stamps at the resulting commit.
 Do not re-audit the docs — nothing about them became untrue.
 
+**Stamp at the `HEAD` you actually read the doc against, never at a sha found
+somewhere in the history.** Two guards refuse a stamp that could not have been
+earned (issue #35): the folder must exist at that commit, and the commit must be
+an ancestor of `HEAD`. Neither is caught by the check above — "did this folder
+change since the stamp?" is trivially satisfied by a stamp from before the
+folder existed, because there are no such commits. That is the extreme form of
+converting "unknown" into "verified", and it reached a PR with four checks
+green. Both faults repair the same way a rewritten history does: repoint, do not
+re-audit.
+
 ### What is enforced, and what is not
 
 `.claude/hooks/check-folder-docs.sh` runs as a Stop hook locally and in CI on
@@ -139,7 +151,7 @@ every PR (`docs-check` workflow). It runs four checks:
 |-------|---------|
 | same-change | Code changed in a folder without its doc changing; `project.godot` changed without the root doc changing |
 | code map | A code folder missing from the root's code map, or a map entry pointing at a doc that does not exist |
-| verification | A folder whose files changed since its `verified-against` stamp without the doc being touched — including history that predates these hooks, merge-conflict resolutions, and commits from anyone running without hooks |
+| verification | A folder whose files changed since its `verified-against` stamp without the doc being touched — including history that predates these hooks, merge-conflict resolutions, and commits from anyone running without hooks — plus a stamp that cannot be true at all: one naming a commit where the folder does not exist, or one that is not an ancestor of `HEAD` |
 | dependency graph | A `depends-on` entry naming a folder with no doc, or naming itself — and the one this check exists for: a doc left unread after code it *depends on* changed |
 
 ### The `depends-on` graph

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -272,4 +272,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 711281c -->
+<!-- verified-against: 6958cf7 -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -268,4 +268,4 @@ wider than this will not.
   the boss has no model of its own at all, so whatever it eventually wears is a
   separate question from what the horde does.
 
-<!-- verified-against: 711281c -->
+<!-- verified-against: 6958cf7 -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -241,12 +241,23 @@ numbers.
   this folder reports the death, and the scene decides what it costs.
 
   **What stops him swinging the instant he arrives is not in this folder.** It
-  is `scenes/map/`'s rule that no spawn sits within 4 cells of a respawn cell —
-  well outside `acquire_radius` (9) — so there is nothing to acquire on the
-  frame he comes back. That is the invariant to re-check if a checkpoint is ever
-  placed with less clearance, or if issue #9 grows these radii. Cross-review
-  caught this stated backwards: the code was right and the reason attached to it
-  was inverted, which is the same failure the doc lesson on #36 records.
+  is `scenes/map/`'s rule that nothing a respawn *restores* stands within 4 cells
+  of the cell it puts him on — 16 units, well outside `acquire_radius` (9) — so
+  there is nothing to acquire on the frame he comes back. That is the invariant
+  to re-check if a checkpoint is ever placed with less clearance, or if issue #9
+  grows these radii. Cross-review caught this stated backwards: the code was
+  right and the reason attached to it was inverted, which is the same failure the
+  doc lesson on #36 records.
+
+  **Restored is the load-bearing word, and it was missing here until issue
+  #54.** The rule reads as covering every placement on the map, and that version
+  is false: one zombie stands 3 cells from the boss gate. It is behind the gate,
+  in an earlier segment, so a respawn there does not put it back — which is why
+  the invariant above survives unchanged. What it does not promise is the frame
+  *after*: a zombie the player walked past is still standing wherever it was
+  left, and at 12 units it is exactly on its own detection radius while he
+  cannot answer until 9. Being charged a second later is a fight; being swung at
+  on arrival is what this rule prevents.
 
 ## Dependencies
 

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -1,5 +1,5 @@
 ---
-depends-on: [scenes, scenes/components, scenes/enemies, scenes/ui, assets]
+depends-on: [scenes, scenes/components, scenes/enemies, scenes/map, scenes/ui, assets]
 ---
 
 # scenes/hero/
@@ -240,7 +240,9 @@ numbers.
   tree freezes. Nothing in here needs to know that and nothing in here should:
   this folder reports the death, and the scene decides what it costs.
 
-  **What stops him swinging the instant he arrives is not in this folder.** It
+  **What stops him swinging the instant he arrives is not in this folder**, and
+  that is the second claim here resting on `scenes/map/` — the rock caps above
+  are the first, which is why it is in the frontmatter. It
   is `scenes/map/`'s rule that nothing a respawn *restores* stands within 4 cells
   of the cell it puts him on — 16 units, well outside `acquire_radius` (9) — so
   there is nothing to acquire on the frame he comes back. That is the invariant
@@ -282,4 +284,4 @@ numbers.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: 711281c -->
+<!-- verified-against: 091dfa6 -->

--- a/scenes/hero/hero.gd
+++ b/scenes/hero/hero.gd
@@ -213,11 +213,14 @@ func unit_info() -> Dictionary:
 ## them means the opposite of a delay: he lands fully ready.
 ##
 ## What actually stops him swinging the moment he arrives is not here at all.
-## It is the map's rule that no spawn sits within 4 cells of a respawn cell (see
-## scenes/map/CLAUDE.md), which is well outside [member acquire_radius], so there
-## is nothing to acquire on the frame he comes back. That is the invariant to
-## re-check if a checkpoint is ever placed with less clearance, or if issue #9
-## grows the radii — not this reset.
+## It is the map's rule that nothing a respawn [i]restores[/i] stands within 4
+## cells of the cell it puts him on (see scenes/map/CLAUDE.md), which is well
+## outside [member acquire_radius], so there is nothing to acquire on the frame
+## he comes back. Restored is load-bearing, and issue #54 is where it got added:
+## stated over every placement the rule is false, and one zombie behind the boss
+## gate is the counterexample. That is the invariant to re-check if a checkpoint
+## is ever placed with less clearance, or if issue #9 grows the radii — not this
+## reset.
 func respawn_at(point: Vector3) -> void:
 	_dead = false
 	_clear_orders()

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -312,4 +312,4 @@ contiguous run of open cells without changing what the player sees.
   `scenes/hero/`, which is why it is in the frontmatter above. `Checkpoint`
   never names `Hero` as a type.
 
-<!-- verified-against: 711281c -->
+<!-- verified-against: 6958cf7 -->

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -55,6 +55,14 @@ horizontally from `checkpoints()[k][0]`, which is the cell he actually lands on;
 the path distances quoted elsewhere in this doc are a different metric and run
 longer.
 
+**Say which metric, every time.** The `layout` docstring said "the nearest to
+`S` is 7" beside a clearance rule expressed in straight-line cells, and the two
+figures describe the same pair of cells: 7 by the flood-fill that cuts the
+segments, 6.08 straight-line. Neither was wrong and the pair is unreadable
+together, which is half of how #54's overstatement survived being read.
+Clearance is always straight-line, because it is about what can *see* the hero;
+segment distances are always path, because they are about what he had to walk.
+
 Stating it over *every* placement instead is the overstatement #54 found, and
 the map does not satisfy that version: a segment-1 zombie stands 3 cells from
 the boss gate, behind it. What the narrower rule leaves uncovered is small and

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -45,8 +45,25 @@ player has taken a step. That used to mean `S` alone; since #38 it means every
 of the checkpoint *to their spawns*, so a spawn too close arrives with the hero,
 every time, on a player who has just lost a fight. Both checkpoints on the
 current map were moved to earn that clearance, and the boss-room guard was moved
-four cells deeper into its room for the same reason. Nothing is now within 4
-cells of a respawn cell; the nearest to `S` is 7.
+four cells deeper into its room for the same reason.
+
+**The rule is over what a respawn *restores*, and only that** (issue #54).
+Nothing in segment *k* or later stands within 4 cells of where checkpoint *k*
+puts the hero. The current map meets it exactly — 4.00 cells at both the tunnel
+and the boss gate — and the start cell has 6. Measured straight-line and
+horizontally from `checkpoints()[k][0]`, which is the cell he actually lands on;
+the path distances quoted elsewhere in this doc are a different metric and run
+longer.
+
+Stating it over *every* placement instead is the overstatement #54 found, and
+the map does not satisfy that version: a segment-1 zombie stands 3 cells from
+the boss gate, behind it. What the narrower rule leaves uncovered is small and
+worth knowing. That zombie is not put back by a respawn there — but if the
+player walked past it on the way in, it is still standing 12.0 units away, which
+is exactly its own detection radius, so it can notice a hero who has just come
+back. He cannot answer first: his `acquire_radius` is 9. The invariant
+`scenes/hero/` leans on still holds, because that is about what he can acquire
+on the frame he lands, not about what can walk up to him afterwards.
 
 **`scenes/hero/` leans on that number**, so it is a contract and not just good
 practice. 4 cells is 16 units, comfortably outside his `acquire_radius` of 9, and
@@ -54,13 +71,16 @@ that gap is the only reason he cannot swing on the frame he respawns — his own
 timers are cleared to *full readiness*, deliberately. Shrink the clearance here,
 and the invariant protecting the player is gone with nothing in that folder to
 notice. Issue #9 raising `acquire_radius` does the same from the other end.
+`tests/smoke_startup.gd` measures it on every run, in the restored-only form, so
+the contract is checked rather than remembered — and there is no slack in it.
 
 **`B` is an enemy placement as well now** (issue #39), so the same clearance
-binds it — and unlike a `Z` cell, nothing checks it:
-`_warn_about_split_segments()` reads `_zombie_cells` only. The boss sits 6 cells
-from its checkpoint, outside its own 4.5-cell detection radius as well as the
-hero's acquire radius, so a respawn at the gate does not start with a charge.
-Moving that checkpoint deeper into the room is the edit that would break it.
+binds it — and nothing *in this folder* checks it:
+`_warn_about_split_segments()` reads `_zombie_cells` only. `tests/` covers it
+instead, which is why that test exists at all. The boss sits 6 cells from its
+checkpoint, outside its own 4.5-cell detection radius as well as the hero's
+acquire radius, so a respawn at the gate does not start with a charge. Moving
+that checkpoint deeper into the room is the edit that would break it.
 
 Cells are `CELL_SIZE` = 4 units, matching the KayKit dungeon grid: `wall` is
 4×4×1 and `floor_tile_large` is 4×4.

--- a/scenes/map/level_map.gd
+++ b/scenes/map/level_map.gd
@@ -82,7 +82,7 @@ const EDGES := [
 ## Zombie spawns (`Z`) are kept well clear of the start cell: a zombie inside
 ## its own detection radius (12 units = 3 cells) of `S` would charge the hero
 ## the moment the run begins, before the player has taken a single step. The
-## nearest one here is 7 cells away.
+## nearest one here is 6 cells away.
 ##
 ## [b]That rule binds every `C` cell the hero can respawn on too[/b], and it is
 ## sharper there, because the zombies ahead of a checkpoint are restored to their
@@ -90,8 +90,15 @@ const EDGES := [
 ## every time, on a player who has just lost a fight. Both checkpoints here were
 ## moved to earn it: this one back into the tunnel (it sat at the mouth, one cell
 ## from a spawn) and the boss-room guard four cells deeper into its room (it
-## stood in the doorway the gate covers). Nothing is now within 4 cells of a
-## respawn cell.
+## stood in the doorway the gate covers).
+##
+## [b]So the rule is over what a respawn restores, not over every placement[/b]
+## (issue #54): nothing in segment `k` or later stands within 4 cells of where
+## checkpoint `k` puts the hero, and this map meets that exactly, twice. Written
+## the broader way it is simply false here — a segment-1 zombie sits 3 cells from
+## the boss gate, on the far side of it, and is not something a respawn there
+## puts back. `tests/smoke_startup.gd` measures the restored form on every run;
+## CLAUDE.md carries what the gap between the two does and does not cover.
 ##
 ## The two checkpoints sit on the only places every route passes through that are
 ## *also* late enough to be worth reaching: inside the one-cell tunnel (24 from

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -202,4 +202,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: 711281c -->
+<!-- verified-against: 6958cf7 -->

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -138,4 +138,4 @@ API from `scenes/map/`, and the `health` component's `current`/`max_health` from
 `scenes/components/`. It reads no `scenes/ui/` node: nothing here asserts
 anything about the screen.
 
-<!-- verified-against: 200ccec -->
+<!-- verified-against: 6958cf7 -->

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -120,6 +120,13 @@ PR, so the constraints run outward as well as in:
   the one enemy placement bound by that rule that the map's own build-time
   warning cannot see, because it reads the spawn list. The current map meets it
   exactly (4.000 cells, twice), so there is no slack to spend.
+- **It also settled what that rule says**, which is the more interesting half.
+  The check is per checkpoint over the placements a respawn *there* restores;
+  three folder docs stated it over every placement on the map, and measuring it
+  showed that version to be false by a cell (issue #54, now fixed in those
+  docs). A number three docs cited as a contract had never been measured until
+  something here measured it — which is the argument for this folder, made
+  without anyone planning it.
 
 ## Dependencies
 

--- a/tests/smoke_startup.gd
+++ b/tests/smoke_startup.gd
@@ -14,11 +14,18 @@ extends "res://tests/harness.gd"
 ## and the hero jittered in place, with every static check passing.
 ##
 ## [b]It also checks a map rule that nothing else can.[/b] `scenes/map/` requires
-## that no enemy spawns within 4 cells of a cell the hero can respawn on, and
-## `scenes/hero/` leans on that number: it is the only reason he cannot be swung
-## at on the frame he comes back. The map's own build-time warning reads the
-## spawn list, so it covers `Z` cells and cannot cover the boss — which is
-## exactly the placement that would be moved by someone tuning the last fight.
+## that nothing a respawn restores stands within 4 cells of the cell it lands the
+## hero on, and `scenes/hero/` leans on that number: it is the only reason he
+## cannot be swung at on the frame he comes back. The map's own build-time
+## warning reads the spawn list, so it covers `Z` cells and cannot cover the boss
+## — which is exactly the placement that would be moved by someone tuning the
+## last fight.
+##
+## [b]Restored is the word this file had right and the docs had wrong[/b] (issue
+## #54). The check below was always per-checkpoint over segment >= that
+## checkpoint; three folder docs stated it over every placement, which the
+## current map does not satisfy — a segment-1 zombie sits 3 cells from the boss
+## gate. The docs were corrected to the form measured here.
 
 ## Half a cell. The hero is dropped from `SPAWN_CLEARANCE` above the start cell
 ## and settles under gravity, so "on the start cell" is horizontal.


### PR DESCRIPTION
Four backlog items in one PR. They batch cleanly because each is the same
shape: a check or a doc that trusted the *form* of something instead of
testing whether it could be true. Three touch the hooks, one touches the map
docs; nothing here changes game behaviour.

Fixes #27
Fixes #34
Fixes #35
Fixes #54

## #35 — `verified-against` accepted a stamp that could not be true

The verification check asks "did this folder change since the stamp without
the doc changing?". A stamp from *before the folder existed* passes that
trivially: there are no such commits, because there was no such folder.

Two guards now run before it, each one command, both failing closed:

| Code | Refuses |
|---|---|
| `PREDATES` | the folder does not exist at the stamped commit (`git cat-file -e <stamp>:<dir>`) |
| `UNREACHABLE` | the stamp is not an ancestor of `HEAD` (`git merge-base --is-ancestor`) — a sha copied out of the history rather than one this branch was read at |

**It found live debt on `main` on its first run**, the same way the graph check
did when it landed: `tests/CLAUDE.md` was stamped `200ccec`, one merge before
`tests/` was created by #56. That is fixed here (see the stamp commit below).

One asymmetry worth knowing, and it is written into `.claude/hooks/CLAUDE.md`
rather than left to be rediscovered: `UNREACHABLE` is stricter locally than in
CI, because the PR job checks out the merge with `main` and so has strictly
more ancestors. Branching fresh from `origin/main` — already the rule — is
what keeps the two agreeing.

## #34 — `depends-on` parsing, both halves

**The unclosed-frontmatter fallthrough.** `sed -n '2,/^---$/p'` has no
terminator when the closing `---` is missing, so it read to end of file and a
later prose line at column 0 parsed as a real edge. That is the horizontal-rule
trap arriving by a second route, so the fix is positional rather than another
special case: `frontmatter_closed` answers whether there is a block at all and
`frontmatter` prints the body only when there is one. Callers must report the
absence, so a malformed block can no longer read as an empty one.

**The undocumented single-line requirement.** Both halves of the issue's
suggestion are done, because they land at different moments — one while you are
writing a doc, one while you are staring at a failure:

- the root `CLAUDE.md` now states that the list must sit on one line, and why
  (a wrapped array would parse as *no dependencies at all*);
- `NOFRONT` now distinguishes the three faults. The old single message —
  "no `depends-on: [...]` key in a frontmatter block on line 1" — sent anyone
  with a wrapped list looking for a key that was plainly there.

Verified against a throwaway fixture repo carrying one fault per folder:

```
NOFRONT     unclosed/CLAUDE.md
            no frontmatter block — line 1 must be '---' and a later
            line must close it
NOFRONT     wrapped/CLAUDE.md
            depends-on: is present but is not a single-line
            '[a, b]' list; no other form is parsed
```

**Not attempted:** the issue's closing suggestion that this shape "may deserve
the general treatment rather than another point fix". A gate that lints the
other gates is a design question of its own size, and guessing at it here would
have made this PR about something else. What is written down instead is the
instruction that anything reading frontmatter goes through those two functions
rather than re-deriving a range.

## #27 — the documented ToolSearch invariant named the wrong risk

Fixed as filed, but **the issue's stated premise did not reproduce**, so the
comment was rewritten to say something that survives the next format change
rather than swapping one format claim for another.

Measured across the 30 real transcripts on this machine:

| Form | Occurrences | Matched by the write-back probe |
|---|---|---|
| under `name`, inside a `tool_use` entry | 214 | yes — all 214 |
| under `tool_name`, in a tool-search reference entry | 38 | no |
| in a schema quoted as escaped text | 3 | no |

So on the current format the *old* comment's description is accurate and the
issue's ("current results do use `name`, saved only by JSON escaping") is not.
What the issue is right about is the framing, and that is what is now in the
file: **what separates a call from a mention is the shape a name is stored in,
not the spelling of any one key.** There are three non-call shapes and each
misses for its own reason, so re-testing a key rename would cover one of three.
The comment now names the real trigger — a transcript format storing a tool
*listing* in the structured shape a call uses, by any route — and gives the
test that covers all of them.

`test-check-flowdex.sh` gains a case pinning the escaped-schema shape
(15 passing, up from 14). Both self-reference fixtures still pass, which is
what proves the new comment and fixture are inert as evidence about themselves.

## #54 — the map doc overstated the respawn-clearance rule

Re-measured with a throwaway script driving the real scene, confirming the
issue's table exactly:

| Checkpoint | Nearest **any** placement | Nearest **restored** placement |
|---|---|---|
| 0 — start cell | 24.3 u (6.08 cells) | 24.3 u (6.08 cells) |
| 1 — tunnel | 16.0 u (4.00 cells) | 16.0 u (4.00 cells) |
| 2 — boss gate | **12.0 u (3.00 cells)**, segment 1 | 16.0 u (4.00 cells) |

"Nothing is within 4 cells of a respawn cell" is therefore false by a cell. The
rule holds in the form it is argued from — over the placements a respawn
*restores* — which is exactly what `tests/smoke_startup.gd` has been measuring
since #16. So this is a wording fix, corrected in all six places that stated or
cited it: `scenes/map/CLAUDE.md`, `level_map.gd`, `scenes/hero/CLAUDE.md`,
`hero.gd`, `tests/smoke_startup.gd`, `tests/CLAUDE.md`.

Two things are now written down that were not:

- **the residual the narrower rule does not cover.** That 3-cell zombie is not
  put back by a respawn at the gate, but if the player ran past it on the way
  in it is still standing 12.0 units away — exactly its own `detection_radius`
  — while the hero cannot answer until 9. The invariant `scenes/hero/` leans on
  survives, because it is about what he can acquire *on the frame he lands*.
- **`scenes/map/` no longer claims nothing checks the boss cell.** Nothing in
  *that folder* does; `tests/` does, and that is why the test exists.

## Fallout, and why there is a second commit

Touching two docstrings flags every doc declaring `depends-on: [scenes/map]` or
`[scenes/hero]` — five of them. Issue #54 predicted this and deliberately left
the fix out of #16 for it. Each was read against the change before its stamp
moved, and the second commit records what that reading found:

- `scenes/`, `scenes/ui/` — say nothing about the clearance; unchanged.
- `scenes/enemies/` — states the boss's own clearance (6 cells, segment 2, so a
  respawn at the gate *does* restore it). Correct and consistent with the
  narrowed rule.
- `scenes/map/` — the doc the correction was made in.
- `tests/` — audited end to end against `harness.gd` and the three smoke
  scripts, with the suite run: 1704 frames and 44/100 hp on the traversal,
  4.000 cells twice on the clearance, the 3600-frame budget. All as documented.

Nothing needed correcting beyond what the first commit already carried, which
is the ordinary outcome for this check and worth stating rather than silencing.

## Checks run locally

```
tests/run.sh                        3 files, all smoke tests passed
test-check-flowdex.sh               15 passed, 0 failed
check-folder-docs.sh --audit        exit 0
check-folder-docs.sh --diff ...     exit 0   (what docs-check runs)
check-folder-docs.sh (Stop hook)    exit 0
```

## For the reviewer

- The two new guards are the part to argue with: `UNREACHABLE` is a judgement
  about what a stamp is *allowed* to name, not just whether it resolves.
- The #27 rewrite is a claim about a transcript format, i.e. about something
  outside this repo that will change again. It is written to age into "this
  measurement is old" rather than into "this is wrong" — worth checking that it
  reads that way to someone who did not take the measurement.
- Wiki: [[workflow/folder-docs]] and [[workflow/self-referential-hooks]] are
  updated for this, and [[workflow/backlog-triage]] for the Wave 2 progress.
