### PR TITLE
Hero XP, levels, and two skills to spend the points on

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Top-down single-hero action game with the visual style of classic RTS games (Sta
 
 - **Core loop:** fight through a zombie-filled map; win by killing the boss at the end of it. The map is one route from start to boss whose *width* varies — wide clearings, narrow chokepoints, the occasional dead-end spur worth exploring — rather than a maze to navigate. Issue #37 settled that: the interest is in the encounters, not in wondering which turning is the right one.
 - **Progression:** level up by killing zombies, completing objectives along the way, and defeating minibosses.
+- **A level pays skill points and nothing else.** Reaching a level raises no stat by itself; every stat gain in the game is bought by spending a point. That is what makes two heroes of the same level different *builds* rather than the same hero twice, so it is the rule to defend when levelling starts to feel stingy — the fix is to make points worth more, never to slip a stat into the level itself. Settled by issue #8, and asserted by a smoke test in [`tests/`](tests/CLAUDE.md), because a rule this easy to erode should not rest on remembering it.
 - **Skill tree:** every hero starts identical; a large skill tree lets each run/player build a unique hero. The skill tree is the central customization system — design decisions should protect its depth and build variety.
 
 When making gameplay or architecture decisions, favor what serves this loop (hero movement/combat feel, readable top-down visuals, map/encounter design, skill-tree extensibility).

--- a/project.godot
+++ b/project.godot
@@ -38,6 +38,14 @@ select_command={
 "deadzone": 0.5,
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"double_click":false,"factor":1.0,"button_index":1,"canceled":false,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"button_mask":0)]
 }
+skill_strength={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":49,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)]
+}
+skill_health={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":50,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)]
+}
 
 [layer_names]
 

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -312,4 +312,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 6958cf7 -->
+<!-- verified-against: 4a0d146 -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -1,5 +1,5 @@
 ---
-depends-on: [scenes/map, scenes/hero, scenes/enemies, scenes/ui]
+depends-on: [scenes/map, scenes/hero, scenes/enemies, scenes/ui, scenes/components]
 ---
 
 # scenes/
@@ -125,10 +125,41 @@ what winning *means* belongs here.
   asymmetry is the point: a death has to preserve everything cleared behind the
   armed checkpoint, which is why issue #38 took the reload *out* of that path;
   a restart has to discard exactly that. Rebuilding is the only version of
-  "discard all of it" that cannot forget a piece of run state — including the
-  ones not written yet, like issue #8's XP. The pause flag is the exception that
-  proves it: it lives on the `SceneTree` rather than the scene, so `_restart_run`
-  clears it by hand or the new run comes up frozen.
+  "discard all of it" that cannot forget a piece of run state — **and issue #8
+  is where that stopped being a prediction.** XP, level and skill ranks are the
+  first state a restart has to throw away, and `_restart_run` gained no line for
+  them: they live on the hero, so the reload takes them. The pause flag remains
+  the one exception, and it is the exception that proves the rule — it lives on
+  the `SceneTree` rather than the scene, so it has to be cleared by hand or the
+  new run comes up frozen.
+
+## Progression (issue #8)
+
+`main.gd` connects `Hero.killed` and turns it into XP. It is the same ownership
+as the two sections above: this script decides what a death costs and what
+winning means, so it decides what a kill is worth beside them.
+
+- **The victim names its own price.** `main.gd` reads `xp_reward` off whatever
+  died rather than keeping a per-enemy table here, so a new enemy type carries
+  its value with it and nothing in this folder is edited to introduce one. A
+  victim without the property is worth nothing rather than an error, which is
+  what keeps this from becoming a third member of the hero↔enemy contract.
+- **The hero does not award himself**, which is why `Hero.killed` finally has a
+  consumer after being emitted and dropped since issue #11. `scenes/hero/` knows
+  what it killed; how much a kill is worth in this level is a scene question.
+- **Where the XP lives is `scenes/hero/`'s answer, not this one.** It is an
+  `Experience` child on the hero (`scenes/components/`), so a restart discards it
+  with the scene and a *death* does not — which is the same asymmetry
+  `_restart_run` already draws for everything else. The comment there used to
+  name issue #8's XP as a piece of run state that did not exist yet; it exists
+  now, and it needed no line in `_restart_run` for exactly the reason that
+  comment gave.
+- The HUD is fed the same way everything else here is: `Experience.xp_changed`
+  and `leveled_up` go straight to `HUD` methods, and the skill line is redrawn by
+  `_refresh_skills()` from two signals — `Experience.points_changed` and
+  `Hero.skill_ranked_up` — because the points total and the ranks are drawn
+  together and move separately. `emit_current()` is called once at startup for
+  the reason the health bar is pushed by hand: nothing re-sends those signals.
 
 ## Navmesh gotchas (learned the hard way)
 
@@ -248,7 +279,12 @@ describes. See `scenes/enemies/CLAUDE.md`.
   consumed by `scenes/hero/`, not by anything in this folder. What each *means*
   is that folder's to document; this is only the inventory:
   `move_command` (right mouse), `select_command` (left mouse),
-  `attack_move` (`A`), `cancel_command` (`Escape`).
+  `attack_move` (`A`), `cancel_command` (`Escape`),
+  `skill_strength` (`1`), `skill_health` (`2`).
+  The last two are bound to *physical* keycodes like `attack_move` is, so they
+  land on the same two keys whatever the keyboard layout — and they are the
+  first actions here that are not commands at all: they spend a skill point and
+  leave the hero's orders alone.
 - `LevelMap` emits `built`; nothing consumes it yet.
 - `main.gd` consumes `Checkpoint.reached` and calls `Checkpoint.set_armed()`
   back on every pad, so exactly one is lit. It calls `Hero.respawn_at()` and, on
@@ -257,13 +293,17 @@ describes. See `scenes/enemies/CLAUDE.md`.
   `HUD.restart_requested` in return.
 - `main.gd` consumes `Hero.died`, `Hero.health.health_changed`,
   `Hero.attack_move_armed_changed` and `Hero.select_clicked`, forwarding each to
-  `scenes/ui/`. Unconsumed so far: `Hero.move_ordered` and `Hero.attack_ordered`
-  — this doc used to earmark them "for the selection UI, issue #36", and that
-  turned out to be wrong: selection is deliberately inert and reads nothing
-  about what the hero is doing. They now have no planned consumer. `Zombie.died`
-  is consumed **on the boss and nowhere else** (issue #39) — every trash zombie's
-  is still dropped, as is the hero's attributed `Hero.killed`, and both remain
-  the XP hooks for issue #8.
+  `scenes/ui/`. Since issue #8 it also consumes `Hero.killed` and
+  `Hero.skill_ranked_up`, plus `xp_changed`, `leveled_up` and `points_changed`
+  from the hero's `Experience` child — see "Progression" above. Unconsumed so
+  far: `Hero.move_ordered` and `Hero.attack_ordered` — this doc used to earmark
+  them "for the selection UI, issue #36", and that turned out to be wrong:
+  selection is deliberately inert and reads nothing about what the hero is
+  doing. They now have no planned consumer. `Zombie.died` is consumed **on the
+  boss and nowhere else** (issue #39) — every trash zombie's is still dropped.
+  It was the other candidate XP hook and stayed unused: `Hero.killed` won it,
+  because a death anything could have caused is the wrong signal to pay a hero
+  for.
 
 ## Tooling note
 

--- a/scenes/components/CLAUDE.md
+++ b/scenes/components/CLAUDE.md
@@ -37,7 +37,7 @@ inherited or copy-pasted. Nothing in here knows about a specific actor.
   so far.
   - `grant(amount)` / `spend(amount) -> bool` / `xp_to_next()` /
     `emit_current()`; `level`, `xp` and `skill_points` are readable state.
-  - Signals: `xp_changed(current, maximum, level)` — both numbers measured
+  - Signals: `xp_changed(current, needed, level)` — both numbers measured
     toward the *next* level rather than cumulatively, so a bar can be drawn
     without reaching back in, the same contract `health_changed` has —
     `leveled_up(level, points_awarded)`, and `points_changed(points)`.

--- a/scenes/components/CLAUDE.md
+++ b/scenes/components/CLAUDE.md
@@ -24,13 +24,59 @@ inherited or copy-pasted. Nothing in here knows about a specific actor.
     emits nothing of its own beyond `health_changed`: whoever revives an owner
     is also moving it and clearing its death state, so a signal here would
     announce a half-finished resurrection.
+  - **`set_max_health(value)` moves the ceiling** — the seam this doc predicted
+    the skill tree would pull on, first pulled by issue #8's Health skill. **A
+    raise heals by the same amount rather than diluting the bar**: buying +10 at
+    40/100 leaves 50/110, not 40/110, because a point that visibly does nothing
+    the moment it is spent reads as a point wasted. A lowering takes the ceiling
+    with it and clamps. Like `heal()` it will not resurrect — a corpse keeps its
+    zero however far the ceiling moves — and it emits `health_changed` even for
+    one, since the maximum a bar is drawn from really did change.
+- `experience.gd` (`class_name Experience`) — XP, levels, and the skill points a
+  level pays out (issue #8). A `Node` child of `hero.tscn` and of nothing else
+  so far.
+  - `grant(amount)` / `spend(amount) -> bool` / `xp_to_next()` /
+    `emit_current()`; `level`, `xp` and `skill_points` are readable state.
+  - Signals: `xp_changed(current, maximum, level)` — both numbers measured
+    toward the *next* level rather than cumulatively, so a bar can be drawn
+    without reaching back in, the same contract `health_changed` has —
+    `leveled_up(level, points_awarded)`, and `points_changed(points)`.
+  - **`leveled_up` is the hook the skill tree hangs off** (issue #9). It fires
+    once per level *inside* the loop that awards them, so a listener sees each
+    level it is being told about rather than the last of a batch — and the loop
+    is not defensive coding: one kill crosses two thresholds as soon as a boss
+    or an objective is worth more than a level.
+  - **This node hands out points and never touches a stat.** That is its half of
+    the game rule in the root `CLAUDE.md` — a level pays points and nothing else
+    — and it is also what keeps the component actor-agnostic: deciding what a
+    point *buys* needs to know which actor is spending it, so it belongs to
+    whoever owns the stats. Today `scenes/hero/`; issue #9's data model after
+    that.
+  - **`spend()` refuses rather than reporting**, and returning the answer is the
+    point of routing purchases through it: a caller that read `skill_points`,
+    decided for itself and then decremented would work right up until two skills
+    were bought in the same frame.
+  - **There is deliberately no reset.** A run's progression is discarded by
+    `scenes/main.gd` reloading the scene, and a death is explicitly *not* allowed
+    to cost it — so the two callers a reset would have both want the opposite of
+    one. Compare `revive()` above, which exists because `Health` genuinely has a
+    caller that needs it.
 
 ## Convention
 
-**Owners expose their own `take_damage()` that forwards here.** `Hero` and
-`Zombie` both do. An attacker calls `victim.take_damage(n)` and never touches
-the `Health` child, which leaves each actor free to react to a hit (armour,
-stagger, waking an unaware zombie) without every attacker learning about it.
+**Owners expose their own method that forwards here, and callers use that.**
+`Hero` and `Zombie` both forward `take_damage()`; `Hero` forwards
+`gain_experience()` in exactly the same shape. An attacker calls
+`victim.take_damage(n)` and never touches the `Health` child, which leaves each
+actor free to react to a hit (armour, stagger, waking an unaware zombie) without
+every attacker learning about it — and the same seam is what lets a hero react
+to a level later without `scenes/main.gd` being told.
+
+**Reading is not writing, and only writing goes through the owner.** Both
+`scenes/main.gd` and `scenes/ui/` connect to these components' signals directly,
+which is fine: a signal is already the component announcing itself, and routing
+it through the owner would only add a forwarding hop with nothing to decide. It
+is the *mutation* that needs an owner in the path.
 
 ## Why a component
 
@@ -38,14 +84,25 @@ Two actors needed identical HP logic on day one, and the skill tree (issue #9)
 will want one place to raise max health or apply damage modifiers. Splitting it
 out now costs one node per actor and avoids two drifting copies.
 
+**`Experience` is here on the weaker version of that argument, and it is worth
+being honest about which.** Only the hero levels today, so it is not sharing
+anything with a second actor the way `Health` was on day one. What it does share
+is the shape: per-actor state with no opinion about which actor, reachable as a
+named child, with the same signal-carries-both-numbers contract — so a levelling
+ally or a rival that grows over a run needs no second copy of the arithmetic.
+The test that kept it here rather than folding it into `scenes/hero/` is the one
+this folder's opening line states: nothing in the file knows about a hero.
+
 ## Dependencies
 
-None — plain `Node`, no scene or autoload requirements. Consumed by
-`scenes/hero/` and `scenes/enemies/`. Both signals are also read by `scenes/ui/`
-— `health_changed` drives the hero's bar and the selected unit's, and `died`
-tells `scenes/ui/` to drop a dying unit's selection rather than show a corpse.
-(That folder subscribes at the selection layer, not in the bar itself.) It finds the
-component by the `health` property on a unit, so the name is part of its
-contract; this doc does not depend on it in return.
+None — both are plain `Node`s, with no scene or autoload requirements. `Health`
+is consumed by `scenes/hero/` and `scenes/enemies/`; `Experience` by
+`scenes/hero/` alone, with `scenes/main.gd` granting and the HUD drawing from its
+signals. `Health`'s two signals are also read by `scenes/ui/` — `health_changed`
+drives the hero's bar and the selected unit's, and `died` tells `scenes/ui/` to
+drop a dying unit's selection rather than show a corpse. (That folder subscribes
+at the selection layer, not in the bar itself.) Both components are found by a
+named property on the unit — `health` and `experience` — so those names are part
+of the contract; this doc does not depend on the folders using them in return.
 
 <!-- verified-against: 8a4044b -->

--- a/scenes/components/experience.gd
+++ b/scenes/components/experience.gd
@@ -1,0 +1,98 @@
+class_name Experience
+extends Node
+## Levels earned by killing things, and the skill points they pay out (issue #8).
+##
+## Added as a child node for the same reason [Health] is: it is per-actor state
+## with no opinion about which actor, so a levelling ally or a rival that grows
+## over a run needs no second copy of the arithmetic.
+##
+## [b]A level awards points and nothing else.[/b] Levelling up does not raise a
+## single stat by itself — every stat gain in the game is bought by spending a
+## point, which is what keeps two heroes of the same level genuinely different
+## builds rather than the same hero twice. That rule is the game's, not this
+## node's, which is why it is written in the root CLAUDE.md; what this node
+## enforces is only its half: it hands out points and never touches a stat.
+## Deciding what a point buys belongs to whoever owns the stats — today
+## scenes/hero/, and issue #9's data model after that.
+##
+## Owners are expected to expose the granting, the same way they forward
+## [method Health.take_damage] rather than letting an attacker reach through to
+## the component.
+
+## Emitted whenever XP or the level moves. Carries everything a bar needs, so a
+## HUD never reaches back into this node — [param current] and [param needed] are
+## both measured toward the *next* level, not cumulatively over the run.
+signal xp_changed(current: float, needed: float, level: int)
+
+## Emitted once per level gained, in order, with the points that level paid.
+## [b]This is the hook the skill tree hangs off[/b] (issue #9): a listener that
+## grants a talent choice, opens a panel or plays a sting subscribes here and
+## needs to know nothing else about XP.
+signal leveled_up(level: int, points_awarded: int)
+
+## Emitted when the unspent-point total changes, by earning or by spending.
+signal points_changed(points: int)
+
+## XP required for the very first level-up, and how much more each subsequent
+## level costs. Linear on purpose: a curve is a balance decision, and there is
+## nothing to balance it against until the skill tree exists. Exports rather
+## than constants so that decision can be made per-actor without touching this.
+@export var xp_to_first_level := 30.0
+@export var xp_step_per_level := 15.0
+
+## Points paid per level gained.
+@export var points_per_level := 1
+
+## Runs start at level 1 with nothing banked.
+var level := 1
+var xp := 0.0
+var skill_points := 0
+
+
+## XP needed to reach the next level, from the current one.
+func xp_to_next() -> float:
+	return xp_to_first_level + xp_step_per_level * float(level - 1)
+
+
+## Award XP, levelling up as many times as it pays for.
+##
+## The loop is not defensive coding: one kill can cross two thresholds once a
+## boss or an objective is worth more than a level, and a version that levelled
+## once and banked the rest would swallow a point silently.
+func grant(amount: float) -> void:
+	if amount <= 0.0:
+		return
+	xp += amount
+	var leveled := false
+	while xp >= xp_to_next():
+		xp -= xp_to_next()
+		level += 1
+		skill_points += points_per_level
+		leveled = true
+		# Inside the loop, so a listener that reads `level` or `skill_points`
+		# sees the level being announced rather than the last of a batch.
+		leveled_up.emit(level, points_per_level)
+	if leveled:
+		points_changed.emit(skill_points)
+	xp_changed.emit(xp, xp_to_next(), level)
+
+
+## Spend [param amount] points, or refuse and change nothing.
+##
+## The refusal is the whole value of routing spending through here: a caller
+## that checked [member skill_points] itself and then decremented it would work
+## until two skills were bought in the same frame.
+func spend(amount := 1) -> bool:
+	if amount <= 0 or amount > skill_points:
+		return false
+	skill_points -= amount
+	points_changed.emit(skill_points)
+	return true
+
+
+## Push the current state at a fresh listener. Nothing re-sends these signals,
+## so a HUD connected after the fact would otherwise draw an empty bar until the
+## first kill.
+func emit_current() -> void:
+	points_changed.emit(skill_points)
+	xp_changed.emit(xp, xp_to_next(), level)

--- a/scenes/components/experience.gd.uid
+++ b/scenes/components/experience.gd.uid
@@ -1,0 +1,1 @@
+uid://rn1oiae1qwux

--- a/scenes/components/health.gd
+++ b/scenes/components/health.gd
@@ -49,6 +49,30 @@ func heal(amount: float) -> void:
 	health_changed.emit(current, max_health)
 
 
+## Move the ceiling, for the skill point that buys hit points (issue #8).
+##
+## [b]A raise heals by the same amount rather than diluting the bar.[/b] Buying
+## +10 max health at 40/100 leaves 50/110, not 40/110 — a point that visibly
+## does nothing at the moment it is spent reads as a point wasted. A *lowering*
+## takes the ceiling with it and clamps, which is the honest direction for a
+## debuff to work in.
+##
+## Deliberately will not resurrect. A corpse keeps its zero however far the
+## ceiling moves, for the reason [method heal] gives: coming back is
+## [method revive]'s decision to make and nothing else's.
+func set_max_health(value: float) -> void:
+	value = maxf(value, 1.0)
+	if is_equal_approx(value, max_health):
+		return
+	var raised := maxf(value - max_health, 0.0)
+	max_health = value
+	if not is_dead():
+		current = clampf(current + raised, 0.0, max_health)
+	# Emitted even for a corpse: the number did change, and a bar drawn from the
+	# last signal would otherwise keep the old maximum until something else moved.
+	health_changed.emit(current, max_health)
+
+
 ## Put a dead owner back on its feet at full health (issue #38's checkpoint
 ## respawn). The explicit decision [method heal] refuses to make for you.
 ##

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -277,4 +277,4 @@ wider than this will not.
   the boss has no model of its own at all, so whatever it eventually wears is a
   separate question from what the horde does.
 
-<!-- verified-against: 6958cf7 -->
+<!-- verified-against: 4a0d146 -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -125,6 +125,7 @@ change in `scenes/ui/`, because a unit describes itself to the info bar through
 | `leash_radius` | 26 | 22 | under the 24 units from its post to the gate |
 | `alert_delay` | 0.5 | 1.0 | a longer, more readable wind-up |
 | `regen_delay` / `regen_per_second` | 6 / 3 | 8 / 12 | leaving the fight resets it |
+| `xp_reward` | 10 | 100 | ten zombies' worth, for the fight that ends the run |
 | `display_name` | `"Zombie"` | `"Zombie Warlord"` | what the info bar calls it |
 
 **`roam_speed` is the one that looks inert and is not**, which is worth stating
@@ -236,10 +237,18 @@ wider than this will not.
   folder that does not mention this one.
 - Emits `died(zombie)`. **`scenes/main.gd` connects it on the boss and on
   nothing else** (issue #39): one enemy in the level has a death that ends the
-  run, and every other one is still dropped. It remains the hook XP will hang
-  off (issue #8), and the hero still emits his own `killed(victim)` from the
-  swing that lands the blow, which is the *attributed* version of the same
-  moment.
+  run, and every other one is still dropped. **It did not become the XP hook**
+  (issue #8) — `Hero.killed`, fired from the swing that lands the blow, did,
+  because this signal announces a death without saying who caused it and a hero
+  should not be paid for one he had no part in. Nothing here changed for XP
+  beyond the export below.
+- **A unit says what killing it is worth**, through the `xp_reward` export.
+  Per-instance like every other stat here, so the boss is worth ten zombies
+  without a second script, and read *off the victim* by `scenes/main.gd` rather
+  than looked up in a table there — the same principle as `unit_info()`, and it
+  means a new enemy type carries its value with it. It is deliberately **not** a
+  third member of the contract with `scenes/hero/`: that folder never reads it,
+  and a victim without the property is worth nothing rather than an error.
 - **Describes itself to the unit info bar** through `unit_info()` and the
   `display_name` export (per-instance like every stat, so the boss-room guard
   the class docs describe can announce itself without a new scene). The travel

--- a/scenes/enemies/boss.tscn
+++ b/scenes/enemies/boss.tscn
@@ -35,6 +35,7 @@ chase_speed = 2.2
 attack_range = 3.0
 attack_damage = 25.0
 attack_cooldown = 2.0
+xp_reward = 100.0
 regen_delay = 8.0
 regen_per_second = 12.0
 

--- a/scenes/enemies/zombie.gd
+++ b/scenes/enemies/zombie.gd
@@ -100,6 +100,11 @@ const HIT_FLASH_COLOUR := Color(1.0, 0.88, 0.88)
 @export var attack_range := 2.0
 @export var attack_damage := 9.0
 @export var attack_cooldown := 1.3
+## What killing this is worth (issue #8). Per-instance like every stat here, so
+## the boss is worth more than a corridor shambler without a second script —
+## and read off the victim rather than assumed by the killer, the same way
+## [method unit_info] lets a unit report its own numbers.
+@export var xp_reward := 10.0
 
 @export_group("Regeneration")
 ## Seconds without taking damage before health starts coming back.

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -5,13 +5,15 @@ depends-on: [scenes, scenes/components, scenes/enemies, scenes/map, scenes/ui, a
 # scenes/hero/
 
 The player-controlled hero (issue #5: movement; issue #7: taking damage and
-dying; issue #11: his own attack; issue #38: coming back from a death).
+dying; issue #11: his own attack; issue #38: coming back from a death; issue #8:
+levelling up and spending what a level pays).
 
 - `hero.tscn` — `CharacterBody3D` (collision layer 3, mask 1|2 — see the
   layer table in `scenes/CLAUDE.md`) with a placeholder capsule + a small
   "nose" box marking the facing direction **under a `Visual` node**, a
-  `CollisionShape3D`, a `NavigationAgent3D`, and a `Health` child (100 HP,
-  `scenes/components/`). In the `hero` group — that is how zombies find him,
+  `CollisionShape3D`, a `NavigationAgent3D`, a `Health` child (100 HP,
+  `scenes/components/`) and an `Experience` child from the same folder. In the
+  `hero` group — that is how zombies find him,
   so don't rename it. The KayKit Knight is already in the repo
   (`assets/characters/hero/Knight.glb`, imported in issue #12) — swapping the
   capsule for it is outstanding work, not a pending dependency. The node
@@ -33,6 +35,12 @@ the control model the whole game is styled after. Actions are in
 | `A` then left-click (`attack_move` + `select_command`) | attack it | attack-move there |
 | Left-click alone (`select_command`) | select it | select the hero back |
 | `A` again, or `Escape` (`cancel_command`) | disarms `A` | disarms `A` |
+| `1` / `2` (`skill_strength` / `skill_health`) | buys a rank — see Skills | buys a rank — see Skills |
+
+**`1` and `2` are the only inputs here that are not commands**, which is why the
+last row reads the same on both sides: they spend a point and touch nothing
+about what the hero is doing. In particular they do **not** disarm `A` and do
+not cancel an order — a player banking a level mid-fight keeps the fight.
 
 `A` toggles rather than latching, and a right-click also disarms it, so there
 are three ways out of the armed state and none of them requires knowing which.
@@ -95,9 +103,12 @@ movement need per-frame precision.
 ## Stats
 
 All exports, not constants, because the skill tree (issue #9) will want to
-modify them and a `const` is not a seam. There is deliberately **no stat or
-modifier system yet** — that is issue #9's job, and inventing one here would
-prejudge it.
+modify them and a `const` is not a seam. **There is still deliberately no stat
+or modifier system** — no modifier objects, no sources, no stacking rules. Issue
+#8 needed exactly two stats to move and does it by recomputing each from a base
+value plus a rank (see Skills below), which is small enough to delete. That was
+the whole reason this section said "none yet" for so long: issue #9 owns the
+model, and a placeholder that could survive it would prejudge it.
 
 | Export | Default | Note |
 |--------|---------|------|
@@ -108,6 +119,8 @@ prejudge it.
 | `acquire_radius` | 9.0 | Under the zombie's 12 detection: he is noticed first |
 | `regen_delay` / `regen_per_second` | 5.0 / 4.0 | See below |
 | `display_name` | `"Hero"` | What the unit info bar calls him |
+| `strength_damage_per_rank` / `health_per_rank` | 2.0 / 10.0 | What one rank of each skill buys |
+| `skill_max_rank` | 5 | Ranks available in each skill |
 
 `unit_info()` reports the name plus damage, cooldown and move speed for that
 bar. Display-only, and the hero picks *which* of his numbers is the interesting
@@ -142,6 +155,48 @@ What would change the answer is a stat that makes the *approach* part of the
 fight — a ranged attacker, or anything that lets an enemy hurt him on the way
 in. Issue #9 should re-read this paragraph before it starts moving these
 numbers.
+
+## Skills (issue #8)
+
+Two skills, bought with the points an `Experience` level pays out. `1` buys a
+rank of Strength (`+2` damage), `2` buys a rank of Health (`+10` max HP), five
+ranks each.
+
+**This is the smallest thing that proves the level-up hook has a consumer, and
+it is not the skill tree.** Two entries in a `const SKILLS` table, a rank
+counter, and `_apply_skills()` recomputing two stats from base + rank. **Issue
+#9 should delete it, not extend it** — the whole reason this folder carried no
+stat system until now was to avoid prejudging that issue, and a placeholder
+worth keeping would prejudge it just as effectively as a real one.
+
+Three things about it are decisions rather than defaults:
+
+- **Stats are recomputed, never accumulated.** `_apply_skills()` sets
+  `attack_damage` to base + ranks every time, so it is idempotent and cannot
+  drift; adding the bonus to the live value on each purchase would go wrong the
+  first time anything else ever wrote to that stat. The bases are captured in
+  `_ready()`, which is what makes the export values still mean "the hero as
+  authored".
+- **The ledger is here and the arithmetic is not.** `Experience`
+  (`scenes/components/`) counts XP, levels and points and never touches a stat;
+  this folder decides what a point buys. That split is what keeps the component
+  actor-agnostic, and it is the same seam issue #9 will need.
+- **`spend_skill_point()` refuses silently** — for an unknown skill, a maxed
+  rank, or an empty pool — and returns whether it bought anything. The HUD
+  already shows `0 points`, and there is nothing a player can do about it but go
+  and kill something. Note the ordering inside it: the rank cap is checked
+  *before* `Experience.spend()`, because spending first would mean handing a
+  point back.
+
+`skill_summary()` reports the skills, ranks and effect text for the HUD, for the
+same reason `unit_info()` reports the stats: what a rank *does* is a fact about
+this actor, and a panel that formatted it would have to be edited for every new
+skill. See the contract in `scenes/ui/CLAUDE.md`.
+
+**A level pays points and raises nothing by itself.** That rule is the game's,
+not this folder's — it lives in the root `CLAUDE.md` — and this is the folder
+that could break it silently, since it owns every stat a level might be tempted
+to touch. `tests/smoke_progression.gd` asserts it directly.
 
 ## Picking things out of the world
 
@@ -225,6 +280,14 @@ numbers.
   `Health.revive()` is called last, so `health_changed` reaches the HUD with the
   hero already alive and standing where he belongs.
 
+  **A death costs no progression**, and `respawn_at()` needed no line to make
+  that true: XP, level, points and ranks live on the `Experience` child and in
+  the rank ledger, neither of which a respawn touches. `Health.revive()` fills
+  him to whatever ceiling his Health ranks have bought, because
+  `set_max_health()` moved the ceiling itself rather than adding a bonus on top
+  of it. Discarding a run's progression is a *restart*, and that is a scene
+  reload owned by `scenes/main.gd` — see the asymmetry it documents.
+
   Two pieces of that are easy to miss. **The nav agent's target**, which nothing
   else clears — leave it and the first order of the new life is judged finished
   or not against a destination from the previous one. And **the timers**, which
@@ -274,13 +337,26 @@ numbers.
   for the selection UI in issue #36; that turned out to be wrong, because
   selection is deliberately inert and reads nothing about what the hero is
   doing. They now have no planned consumer.
-  Emits `killed(victim)`, the XP hook for issue #8,
-  fired from the swing that lands the killing blow so attribution is exact
-  rather than "something died". Emits `attack_move_armed_changed(armed)`, which
+  Emits `killed(victim)`, **consumed by `scenes/main.gd` since issue #8** after
+  being emitted and dropped since #11. It fires from the swing that lands the
+  killing blow, so attribution is exact rather than "something died" — which is
+  why it won the XP hook over `Zombie.died`, a signal any source of damage would
+  trigger. Emits `attack_move_armed_changed(armed)`, which
   `scenes/main.gd` consumes to show the armed-attack indicator, and `died`,
   which `scenes/main.gd` answers with `respawn_at()` at the armed checkpoint.
+  Emits `skill_ranked_up(skill, rank)` **after** the stat it bought has been
+  applied, so a listener reads the new numbers rather than the old ones.
   Consumes `Health.died` from its own child, and calls `Health.revive()` on the
   way back.
+- **`gain_experience(amount)` is the XP entry point**, and it exists so that
+  `scenes/main.gd` never reaches into the `Experience` child — the same
+  convention `take_damage()` follows for `Health`, and the same seam that lets
+  the hero react to a level later without every caller learning about it. It
+  deliberately has *no* `_dead` guard where `take_damage()` does: refusing damage
+  to a corpse is the rule, but refusing credit to one would swallow a kill that
+  lands after he falls. Nothing produces one today; the first damage-over-time
+  effect can, and losing XP is the worse direction to be wrong in.
+  `spend_skill_point()` calls `Experience.spend()` the same way.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -360,4 +360,4 @@ to touch. `tests/smoke_progression.gd` asserts it directly.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: 091dfa6 -->
+<!-- verified-against: 4a0d146 -->

--- a/scenes/hero/hero.gd
+++ b/scenes/hero/hero.gd
@@ -39,11 +39,15 @@ signal move_ordered(world_point: Vector3)
 ## A+click, or by acquiring a target on his own.
 signal attack_ordered(target: Node3D)
 
-## Emitted when a target dies from this hero's damage. The XP hook for issue #8;
-## nothing consumes it yet. Attribution is exact — it fires from the swing that
-## landed the killing blow, not from the victim's own death signal, which any
-## source of damage would trigger.
+## Emitted when a target dies from this hero's damage. The XP hook for issue #8,
+## and scenes/main.gd is what consumes it. Attribution is exact — it fires from
+## the swing that landed the killing blow, not from the victim's own death
+## signal, which any source of damage would trigger.
 signal killed(victim: Node3D)
+
+## Emitted when a skill point has been spent and the stat it bought has already
+## been applied, so a listener reads the new numbers rather than the old ones.
+signal skill_ranked_up(skill: StringName, rank: int)
 
 ## Emitted when the attack command is armed or disarmed, so the HUD can show
 ## the player that the next left-click means "attack" rather than "select".
@@ -114,6 +118,23 @@ const RETARGET_INTERVAL := 0.2
 ## How far the visual jabs forward on a swing, in metres.
 const SWING_LUNGE := 0.45
 
+## The two skills a level's points can be spent on (issue #8), and the hotkey
+## each is bought with. Strength buys damage, Health buys hit points.
+##
+## [b]This is deliberately the smallest thing that proves the level-up hook has
+## a consumer, and it is not the skill tree.[/b] Two hard-coded skills, a rank
+## counter and a stat recomputed from base plus rank — no modifier objects, no
+## sources, no stacking rules, no data files. Issue #9 owns the actual model and
+## should replace all of this rather than extend it; the reason this folder had
+## no stat system until now was to avoid prejudging that, and a placeholder
+## small enough to delete keeps it unprejudged.
+const SKILL_STRENGTH := &"strength"
+const SKILL_HEALTH := &"health"
+const SKILLS := {
+	SKILL_STRENGTH: {"name": "Strength", "hotkey": "1", "action": &"skill_strength"},
+	SKILL_HEALTH: {"name": "Health", "hotkey": "2", "action": &"skill_health"},
+}
+
 ## What the unit info bar calls him. An export rather than a constant for the
 ## same reason the stats are: it is per-instance, so a named or unique hero
 ## needs no new code.
@@ -143,6 +164,13 @@ const SWING_LUNGE := 0.45
 @export var regen_delay := 5.0
 @export var regen_per_second := 4.0
 
+@export_group("Skills")
+## What one rank of each skill buys. See the SKILLS note above for why the two
+## effects are hard-coded here rather than described by data.
+@export var strength_damage_per_rank := 2.0
+@export var health_per_rank := 10.0
+@export var skill_max_rank := 5
+
 var _gravity: float = ProjectSettings.get_setting("physics/3d/default_gravity")
 var _dead := false
 
@@ -159,13 +187,26 @@ var _retarget_timer := 0.0
 var _regen_timer := 0.0
 var _swing_tween: Tween = null
 
+## Ranks bought so far, one entry per key of [constant SKILLS].
+var _skill_ranks := {}
+## The stats as authored, before any rank was bought. Kept because ranks are
+## *recomputed* rather than accumulated: adding the bonus to the live stat each
+## time would drift the moment anything else ever wrote to it.
+var _base_attack_damage := 0.0
+var _base_max_health := 0.0
+
 @onready var health: Health = $Health
+@onready var experience: Experience = $Experience
 @onready var _nav_agent: NavigationAgent3D = $NavigationAgent3D
 @onready var _visual: Node3D = $Visual
 
 
 func _ready() -> void:
 	health.died.connect(_on_health_died)
+	for skill in SKILLS:
+		_skill_ranks[skill] = 0
+	_base_attack_damage = attack_damage
+	_base_max_health = health.max_health
 
 
 func is_dead() -> bool:
@@ -182,6 +223,21 @@ func take_damage(amount: float) -> void:
 	health.take_damage(amount)
 
 
+## XP entry point, and [method take_damage]'s counterpart: whoever is paying the
+## hero calls this rather than reaching into the Experience child, so he stays
+## free to react to a level later — a flourish, a heal, a shout — without every
+## caller learning about it.
+##
+## Deliberately has no `_dead` guard where [method take_damage] does, and the
+## asymmetry is the point: refusing damage to a corpse is the rule, whereas
+## refusing *credit* to one would silently swallow a kill that lands after the
+## hero falls. Nothing can produce one today — he cannot swing while dead — but
+## the first damage-over-time effect can, and losing XP is the worse direction
+## to be wrong in.
+func gain_experience(amount: float) -> void:
+	experience.grant(amount)
+
+
 ## Headline stats for the unit info bar (scenes/ui/, issue #36).
 ##
 ## The unit reports its own numbers rather than the panel reaching in for named
@@ -195,6 +251,72 @@ func unit_info() -> Dictionary:
 		"attack_cooldown": attack_cooldown,
 		"move_speed": move_speed,
 	}
+
+
+# --- Skills ------------------------------------------------------------------
+
+## How many ranks of [param skill] have been bought. Unknown skills read 0.
+func skill_rank(skill: StringName) -> int:
+	return int(_skill_ranks.get(skill, 0))
+
+
+## Buy a rank of [param skill], if there is a point to spend and room to spend
+## it. Returns whether anything happened, so a caller can answer a refused
+## keypress without inspecting the ledger itself.
+##
+## Refusal is silent by design here: a HUD showing 0 points already says why,
+## and there is nothing a player can do about it but go and kill something.
+func spend_skill_point(skill: StringName) -> bool:
+	if not SKILLS.has(skill):
+		return false
+	if skill_rank(skill) >= skill_max_rank:
+		return false
+	# Last, and only once the rank is known to be buyable: spend() debits the
+	# point, so a check after it would have to hand one back.
+	if not experience.spend(1):
+		return false
+	_skill_ranks[skill] = skill_rank(skill) + 1
+	_apply_skills()
+	skill_ranked_up.emit(skill, skill_rank(skill))
+	return true
+
+
+## The skills, their ranks and what each has bought so far, for the HUD.
+##
+## Reported by the hero rather than assembled by the panel, exactly as
+## [method unit_info] is and for the same reason: what a rank *does* is a fact
+## about this actor, and a screen that formatted it would have to learn the
+## effects to display them.
+func skill_summary() -> Array[Dictionary]:
+	var summary: Array[Dictionary] = []
+	for skill in SKILLS:
+		summary.append({
+			"name": SKILLS[skill]["name"],
+			"hotkey": SKILLS[skill]["hotkey"],
+			"rank": skill_rank(skill),
+			"max_rank": skill_max_rank,
+			"effect": _skill_effect_text(skill),
+		})
+	return summary
+
+
+## Recompute every stat a skill touches, from its base value plus the ranks
+## bought. Idempotent, which is what makes it safe to call on every purchase.
+func _apply_skills() -> void:
+	attack_damage = _base_attack_damage + skill_rank(SKILL_STRENGTH) * strength_damage_per_rank
+	# Health owns the ceiling and what moving it does to the current value — a
+	# raise heals by the same amount rather than diluting the bar.
+	health.set_max_health(_base_max_health + skill_rank(SKILL_HEALTH) * health_per_rank)
+
+
+func _skill_effect_text(skill: StringName) -> String:
+	var rank := skill_rank(skill)
+	match skill:
+		SKILL_STRENGTH:
+			return "+%d dmg" % roundi(rank * strength_damage_per_rank)
+		SKILL_HEALTH:
+			return "+%d hp" % roundi(rank * health_per_rank)
+	return ""
 
 
 ## Come back at [param point] with full health, ready to take orders (issue #38).
@@ -318,6 +440,15 @@ func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("cancel_command"):
 		_set_attack_move_armed(false)
 		return
+
+	# Spending a point is not a command, so it deliberately does not disarm `A`
+	# or cancel an order — a player banking a level mid-fight keeps whatever the
+	# hero was doing. Driven from the table so a third skill is one entry, and
+	# above the click handlers because none of these are mouse buttons anyway.
+	for skill in SKILLS:
+		if event.is_action_pressed(SKILLS[skill]["action"]):
+			spend_skill_point(skill)
+			return
 
 	# Use the position carried by the click itself rather than the live mouse
 	# position: the two can differ by the time the event is handled, and it

--- a/scenes/hero/hero.tscn
+++ b/scenes/hero/hero.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=8 format=3]
+[gd_scene load_steps=9 format=3]
 
 [ext_resource type="Script" path="res://scenes/hero/hero.gd" id="1_hero"]
 [ext_resource type="Script" path="res://scenes/components/health.gd" id="2_health"]
+[ext_resource type="Script" path="res://scenes/components/experience.gd" id="3_experience"]
 
 [sub_resource type="CapsuleMesh" id="CapsuleMesh_body"]
 radius = 0.4
@@ -48,3 +49,6 @@ target_desired_distance = 1.0
 [node name="Health" type="Node" parent="."]
 script = ExtResource("2_health")
 max_health = 100.0
+
+[node name="Experience" type="Node" parent="."]
+script = ExtResource("3_experience")

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -79,6 +79,15 @@ func _ready() -> void:
 	_hero.health.health_changed.connect(_hud.set_hero_health)
 	_hero.died.connect(_on_hero_died)
 	_hero.attack_move_armed_changed.connect(_hud.set_attack_move_armed)
+	# Progression (issue #8). `killed` has been emitted and unconsumed since
+	# issue #11 waiting for exactly this.
+	_hero.killed.connect(_on_hero_killed)
+	_hero.experience.xp_changed.connect(_hud.set_experience)
+	_hero.experience.leveled_up.connect(_hud.flash_level_up)
+	# Two signals, one panel: the points total and the ranks are drawn together,
+	# and each of these moves one of them.
+	_hero.experience.points_changed.connect(_refresh_skills.unbind(1))
+	_hero.skill_ranked_up.connect(_refresh_skills.unbind(2))
 	# The hero owns the left mouse button because he owns the command scheme it
 	# belongs to, and hands on the clicks his attack command did not take.
 	_hero.select_clicked.connect(_selection.select_at)
@@ -88,9 +97,36 @@ func _ready() -> void:
 	_hud.restart_requested.connect(_restart_run)
 
 	_hud.set_hero_health(_hero.health.current, _hero.health.max_health)
+	# Same reason the health bar is pushed by hand: nothing re-sends these, so a
+	# HUD connected after the fact would draw an empty XP bar until the first kill.
+	_hero.experience.emit_current()
+	_refresh_skills()
 	# Last, and after the connection above: the hero starts selected, and the
 	# info bar only learns that from the signal this emits.
 	_selection.select_unit(_hero)
+
+
+## The hero landed a killing blow, so he is paid for it (issue #8).
+##
+## [b]The victim says what it is worth[/b], rather than a table here deciding
+## what each enemy type pays: this script already knows both enemy scenes, but a
+## reward it owned would have to be edited for every new one, and the value is a
+## fact about the thing that died. Same rule that lets a unit report its own
+## stats to the info bar. A victim with no reward is worth nothing rather than
+## an error, which is what keeps the hero's contract with the enemies group at
+## the two methods it has always been.
+## Granted through the hero rather than into his Experience child, the same way
+## an attacker calls take_damage() rather than reaching for his Health — see the
+## convention in scenes/components/CLAUDE.md.
+func _on_hero_killed(victim: Node3D) -> void:
+	var reward = victim.get(&"xp_reward")
+	_hero.gain_experience(float(reward) if reward != null else 0.0)
+
+
+## Redraw the skill line. Both the points total and the ranks live on it, and the
+## two move independently, so it is one method rather than two half-updates.
+func _refresh_skills() -> void:
+	_hud.set_skills(_hero.experience.skill_points, _hero.skill_summary())
 
 
 ## One zombie per `Z` cell from [param from_segment] onward. The map says where

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -82,6 +82,16 @@ notice. Issue #9 raising `acquire_radius` does the same from the other end.
 `tests/smoke_startup.gd` measures it on every run, in the restored-only form, so
 the contract is checked rather than remembered — and there is no slack in it.
 
+**The hero's stats became buyable in issue #8 and this survived it**, which is
+worth stating because the shape of the threat changed rather than went away. He
+can now spend points on damage and on hit points, and on nothing else — no skill
+touches `acquire_radius` or any other radius, so the 16-against-9 gap above is
+exactly what it was. What that issue actually did was make the "issue #9 raises
+it" sentence stop being hypothetical: there is now a mechanism for a stat to move
+mid-run, and the first skill that widens a radius breaks this contract from the
+hero's side with nothing here to see it. Re-read this section when one is added,
+not when the tree lands.
+
 **`B` is an enemy placement as well now** (issue #39), so the same clearance
 binds it — and nothing *in this folder* checks it:
 `_warn_about_split_segments()` reads `_zombie_cells` only. `tests/` covers it

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -330,4 +330,4 @@ contiguous run of open cells without changing what the player sees.
   `scenes/hero/`, which is why it is in the frontmatter above. `Checkpoint`
   never names `Hero` as a type.
 
-<!-- verified-against: 6958cf7 -->
+<!-- verified-against: 4a0d146 -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -239,4 +239,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: 6958cf7 -->
+<!-- verified-against: 4a0d146 -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -9,9 +9,10 @@ Everything drawn over the game, plus unit selection (issue #36). Split out of
 five elements and one of them non-trivial.
 
 - `hud.tscn` / `hud.gd` (`class_name HUD`) — the `CanvasLayer`. Holds the hero's
-  health bar (bottom-left), the armed-attack indicator, the controls crib sheet
-  (top-left), the death screen, the checkpoint confirmation, the victory panel
-  (issue #39), and an instance of the info bar.
+  health bar (bottom-left), the XP bar and skill line stacked above it (issue
+  #8), the armed-attack indicator, the controls crib sheet (top-left), the death
+  screen, the checkpoint and level-up banners, the victory panel (issue #39), and
+  an instance of the info bar.
 - `unit_info_bar.tscn` / `unit_info_bar.gd` (`class_name UnitInfoBar`) — the
   bottom-centre panel: name, live HP as `current / max`, and damage / attack
   speed / move speed.
@@ -73,6 +74,38 @@ would have to agree about the armed state *mid-event* — the hero disarms `A`
 while handling the very click that used it — so an armed click would land as
 both an attack and a selection, or as neither, depending on which node
 `_unhandled_input` reached first.
+
+## Progression readout (issue #8)
+
+Three elements, all in the bottom-left stack under the health bar's rules —
+fed by method call, never reached into:
+
+- **`set_experience(current, needed, level)`** draws the XP bar and the `Lv N`
+  beside it. Both numbers are measured toward the *next* level rather than
+  cumulatively over the run, which is what a bar can actually draw; that is the
+  same contract `health_changed` has, and it is the component's decision, not
+  this folder's.
+- **`set_skills(points, skills)`** draws the one-line skill list. It **formats
+  and never interprets**: `skills` is what the unit reports about itself through
+  `Hero.skill_summary()`, effect strings included, for the same reason
+  `unit_info()` exists — what a rank buys is a fact about the hero, and a panel
+  that knew it would need editing for every new skill. The line turns gold while
+  points are unspent, because the count is the only part that changes what a
+  keypress does.
+- **`flash_level_up(level, points)`** is the transient half, and it exists for
+  the same reason `flash_checkpoint()` does: the bar below already says it, and
+  a bar does not *reach* a player mid-fight — which is exactly when the kill that
+  levelled them happened.
+
+**The two banners share one implementation and not one tween.** `_flash()` and
+`_clear_flash()` keep a tween per label in a dictionary, because arming a
+checkpoint and levelling on the same kill is ordinary rather than a corner case;
+a single shared tween would leave one banner half-faded. They sit on separate
+lines so both are legible at once. `_clear_flashes()` takes both down, and the
+death and victory screens call it for the reason recorded below — with the
+level-up banner the more likely of the two to be up, since the kill that levels
+the hero is often the one that leaves him low, and the boss is worth enough XP
+that the winning blow frequently levels him outright.
 
 ## The victory panel (issue #39)
 
@@ -164,13 +197,13 @@ difference worth stating rather than assuming.
   anything. That protection lives in another folder, which is exactly why the
   two are not allowed to differ here — a reader finding one guarded and one not
   would reasonably conclude the difference meant something.
-- **The checkpoint flash is cancelled when the death screen goes up.** Arming a
+- **Every banner is cancelled when the death screen goes up.** Arming a
   checkpoint and dying seconds later is not a corner case — a zombie chasing the
   hero across a threshold produces it — and a "CHECKPOINT" still fading behind
-  "YOU DIED" reads as congratulating the player on the death. Killing the tween
-  is the load-bearing half: it drives `modulate:a`, so hiding the label without
-  it leaves the fade running and re-hiding it a second later, over whatever came
-  next.
+  "YOU DIED" reads as congratulating the player on the death. "LEVEL 3" does it
+  twice over. Killing the tween is the load-bearing half: it drives `modulate:a`,
+  so hiding the label without it leaves the fade running and re-hiding it a
+  second later, over whatever came next.
 - **`flash_checkpoint()` is the second half of the checkpoint feedback, not the
   whole of it.** The lit pad in the world is the lasting signal and this is the
   transient one, for a player watching the fight rather than the floor they just
@@ -188,7 +221,11 @@ difference worth stating rather than assuming.
   `set_attack_move_armed()`, `show_death()` / `hide_death()`,
   `flash_checkpoint()` and `show_victory()` — the last two from
   `Checkpoint.reached` and the boss's `Zombie.died`, the only HUD calls that do
-  not originate with the hero.
+  not originate with the hero. Issue #8 added `set_experience()`,
+  `set_skills()` and `flash_level_up()`, driven from the hero's `Experience`
+  child (`scenes/components/`) and from `Hero.skill_ranked_up`. Nothing here
+  reads that component: `scenes/main.gd` connects its signals and calls these,
+  which is the same inward-only arrangement everything else in this folder has.
 - Emits `HUD.restart_requested`, consumed by `scenes/main.gd`. It is the only
   signal this folder sends into the game rather than draws from it, and it is
   also what pairs with the pause: that script sets `get_tree().paused`, so it is

--- a/scenes/ui/hud.gd
+++ b/scenes/ui/hud.gd
@@ -19,23 +19,30 @@ extends CanvasLayer
 ## "start another one" does is that script's decision and not a widget's.
 signal restart_requested
 
-## How long the checkpoint confirmation holds before it starts fading, and how
-## long the fade takes. Long enough to read mid-fight, short enough that it is
-## gone before the fight the checkpoint was banked for.
-const CHECKPOINT_HOLD := 1.1
-const CHECKPOINT_FADE := 0.7
+## How long a transient banner holds before it starts fading, and how long the
+## fade takes. Long enough to read mid-fight, short enough that it is gone
+## before the fight the checkpoint was banked for.
+const FLASH_HOLD := 1.1
+const FLASH_FADE := 0.7
 
 @onready var _hero_health_bar: ProgressBar = $HeroHealthBar
 @onready var _hero_health_value: Label = $HeroHealthBar/Value
+@onready var _xp_bar: ProgressBar = $XPBar
+@onready var _xp_value: Label = $XPBar/Value
+@onready var _skills_label: Label = $SkillsLabel
 @onready var _attack_move_label: Label = $AttackMoveLabel
 @onready var _death_label: Label = $DeathLabel
 @onready var _death_sub_label: Label = $DeathSubLabel
 @onready var _checkpoint_label: Label = $CheckpointLabel
+@onready var _level_up_label: Label = $LevelUpLabel
 @onready var _unit_info_bar: UnitInfoBar = $UnitInfoBar
 @onready var _victory_panel: Control = $VictoryPanel
 @onready var _restart_button: Button = $VictoryPanel/RestartButton
 
-var _checkpoint_tween: Tween = null
+## The running fade for each flashing label, so two banners up at once do not
+## share one tween — arming a checkpoint and levelling on the same kill is an
+## ordinary thing to do, not a corner case.
+var _flash_tweens := {}
 
 
 func _ready() -> void:
@@ -55,6 +62,36 @@ func set_hero_health(current: float, maximum: float) -> void:
 	_hero_health_value.text = "%d / %d" % [roundi(current), roundi(maximum)]
 
 
+## The XP bar and the level beside it (issue #8). Both numbers are measured
+## toward the *next* level rather than cumulatively, which is what the bar draws.
+func set_experience(current: float, needed: float, level: int) -> void:
+	_xp_bar.max_value = maxf(needed, 1.0)
+	_xp_bar.value = current
+	_xp_value.text = "Lv %d     %d / %d XP" % [level, floori(current), roundi(needed)]
+
+
+## The unspent points and what they can be spent on.
+##
+## [param skills] is what the unit reports about itself — see
+## [method Hero.skill_summary]. This method formats and never interprets: the
+## effect strings are the hero's words, because what a rank buys is a fact about
+## him and a panel that knew it would have to be updated with every new skill.
+func set_skills(points: int, skills: Array) -> void:
+	var parts: PackedStringArray = ["%d point%s" % [points, "" if points == 1 else "s"]]
+	for skill in skills:
+		parts.append("[%s] %s %d/%d  %s" % [
+			skill.get("hotkey", "?"),
+			skill.get("name", "?"),
+			int(skill.get("rank", 0)),
+			int(skill.get("max_rank", 0)),
+			skill.get("effect", ""),
+		])
+	_skills_label.text = "    ".join(parts)
+	# The points total is the only part that ever needs chasing: it is what turns
+	# a keypress from a no-op into a purchase.
+	_skills_label.modulate = Color(1, 0.85, 0.4) if points > 0 else Color(0.72, 0.76, 0.84)
+
+
 ## Point the info bar at the selected unit. Connected to
 ## [signal UnitSelection.selection_changed].
 func show_unit(unit: Node3D) -> void:
@@ -68,11 +105,13 @@ func set_attack_move_armed(armed: bool) -> void:
 
 
 func show_death() -> void:
-	# Cancel any checkpoint flash still fading. Arming a checkpoint and dying
-	# seconds later is not a corner case — a zombie chasing the hero across a
-	# threshold produces exactly that — and "CHECKPOINT" fading out behind "YOU
-	# DIED" reads as congratulating the player on the death.
-	_clear_checkpoint_flash()
+	# Cancel any banner still fading. Arming a checkpoint and dying seconds later
+	# is not a corner case — a zombie chasing the hero across a threshold produces
+	# exactly that — and "CHECKPOINT" fading out behind "YOU DIED" reads as
+	# congratulating the player on the death. "LEVEL 3" does it twice over: the
+	# kill that levels the hero is very often the one that leaves him low enough
+	# for the next zombie to finish.
+	_clear_flashes()
 	_death_label.show()
 	_death_sub_label.show()
 
@@ -91,9 +130,10 @@ func hide_death() -> void:
 ## reach — and the death screen's [method hide_death] is the counter-example that
 ## makes the distinction worth stating rather than assuming.
 func show_victory() -> void:
-	# Same reason show_death() does it: a "CHECKPOINT" still fading out under the
-	# end of the run is reading out the wrong moment.
-	_clear_checkpoint_flash()
+	# Same reason show_death() does it: a "CHECKPOINT" or a "LEVEL 4" still fading
+	# out under the end of the run is reading out the wrong moment — and the boss
+	# is worth enough XP that the winning blow very often levels the hero.
+	_clear_flashes()
 	# The death screen is a different case and worth being honest about: it
 	# cannot be up, because scenes/main.gd stops answering a death once the run
 	# is won. Taking it down anyway makes this panel's claim on the screen a rule
@@ -111,19 +151,47 @@ func show_victory() -> void:
 ## The lit pad in the world is the lasting signal; this is the one that reaches a
 ## player who is watching the fight rather than the floor they just crossed.
 func flash_checkpoint() -> void:
-	_clear_checkpoint_flash()
-	_checkpoint_label.modulate.a = 1.0
-	_checkpoint_label.show()
-	_checkpoint_tween = create_tween()
-	_checkpoint_tween.tween_interval(CHECKPOINT_HOLD)
-	_checkpoint_tween.tween_property(_checkpoint_label, "modulate:a", 0.0, CHECKPOINT_FADE)
-	_checkpoint_tween.tween_callback(_checkpoint_label.hide)
+	_flash(_checkpoint_label)
 
 
-## Kill a running fade and take the label down. Both callers need the tween
+## Announce a level and what it paid (issue #8).
+##
+## The bar below already shows both, and this exists because it does not *reach*
+## a player mid-fight — which is exactly when the kill that levelled them
+## happened. Same argument as the checkpoint flash, and it sits on its own line
+## above it so a kill that does both is legible rather than one banner over the
+## other.
+func flash_level_up(level: int, points_awarded: int) -> void:
+	_level_up_label.text = "LEVEL %d — %d skill point%s" % [
+		level, points_awarded, "" if points_awarded == 1 else "s",
+	]
+	_flash(_level_up_label)
+
+
+## Bring a transient banner up and fade it out again.
+func _flash(label: Label) -> void:
+	_clear_flash(label)
+	label.modulate.a = 1.0
+	label.show()
+	var tween := create_tween()
+	_flash_tweens[label] = tween
+	tween.tween_interval(FLASH_HOLD)
+	tween.tween_property(label, "modulate:a", 0.0, FLASH_FADE)
+	tween.tween_callback(label.hide)
+
+
+## Kill a running fade and take the label down. Every caller needs the tween
 ## stopped first: it drives `modulate:a`, so it would keep animating a hidden
 ## label and then re-hide it a second later, over whatever came next.
-func _clear_checkpoint_flash() -> void:
-	if _checkpoint_tween != null and _checkpoint_tween.is_valid():
-		_checkpoint_tween.kill()
-	_checkpoint_label.hide()
+func _clear_flash(label: Label) -> void:
+	var tween: Tween = _flash_tweens.get(label)
+	if tween != null and tween.is_valid():
+		tween.kill()
+	_flash_tweens.erase(label)
+	label.hide()
+
+
+## Take every banner down at once, for the two screens that own the whole view.
+func _clear_flashes() -> void:
+	_clear_flash(_checkpoint_label)
+	_clear_flash(_level_up_label)

--- a/scenes/ui/hud.tscn
+++ b/scenes/ui/hud.tscn
@@ -27,6 +27,41 @@ text = "100 / 100"
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="XPBar" type="ProgressBar" parent="."]
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 24.0
+offset_top = -86.0
+offset_right = 284.0
+offset_bottom = -66.0
+grow_vertical = 0
+max_value = 30.0
+value = 0.0
+show_percentage = false
+
+[node name="Value" type="Label" parent="XPBar"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_font_sizes/font_size = 13
+text = "Lv 1     0 / 30 XP"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="SkillsLabel" type="Label" parent="."]
+anchor_top = 1.0
+anchor_bottom = 1.0
+offset_left = 24.0
+offset_top = -112.0
+offset_right = 524.0
+offset_bottom = -90.0
+grow_vertical = 0
+theme_override_colors/font_color = Color(0.72, 0.76, 0.84, 1)
+theme_override_font_sizes/font_size = 14
+text = "0 points    [1] Strength 0/5    [2] Health 0/5"
+vertical_alignment = 1
+
 [node name="UnitInfoBar" parent="." instance=ExtResource("2_info_bar")]
 
 [node name="AttackMoveLabel" type="Label" parent="."]
@@ -55,7 +90,8 @@ offset_bottom = 96.0
 theme_override_colors/font_color = Color(0.72, 0.76, 0.84, 1)
 text = "Right-click: move / attack
 Left-click: select a unit
-A + left-click: attack / attack-move"
+A + left-click: attack / attack-move
+1 / 2: spend a skill point"
 
 [node name="DeathLabel" type="Label" parent="."]
 visible = false
@@ -163,5 +199,23 @@ grow_vertical = 2
 theme_override_colors/font_color = Color(0.78, 0.66, 1, 1)
 theme_override_font_sizes/font_size = 28
 text = "CHECKPOINT"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="LevelUpLabel" type="Label" parent="."]
+visible = false
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -240.0
+offset_top = -212.0
+offset_right = 240.0
+offset_bottom = -168.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(1, 0.85, 0.4, 1)
+theme_override_font_sizes/font_size = 30
+text = "LEVEL 2 — 1 skill point"
 horizontal_alignment = 1
 vertical_alignment = 1

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -96,6 +96,14 @@ reports a cascade and the first line was already the answer.
   measured on one machine, and CI runs a different build on a different OS.
   Budgets are generous on purpose: the traversal test allows 3600 frames for a
   walk that takes 1704.
+- **A test may read a component directly; it must not write to one.** Reaching
+  past an actor into its `Health` or `Experience` child to *set up* a state is
+  the tempting shortcut here, and `scenes/components/` states the convention
+  without exceptions — writes go through the owner's forwarding method. A test
+  is the worst place to take the first exception, because it is the file
+  somebody copies when they write the next one. `smoke_progression.gd` tops up
+  XP through the hero and reads the component for its assertions, which is the
+  shape to follow. Cross-review of PR #58 caught it doing the opposite.
 - **`hero` and `level` are deliberately untyped.** Naming `Hero` or `LevelMap`
   would make this folder fail to parse whenever the global class cache is
   missing — the state a fresh checkout is in until `--import` has run, which is
@@ -141,12 +149,13 @@ PR, so the constraints run outward as well as in:
 Everything here is downstream and nothing depends on it, which is why the
 frontmatter above is long. It reads `scenes/main.tscn` and the startup order
 `scenes/` owns, the command API and `killed` signal of `scenes/hero/` — plus its
-skill API (`spend_skill_point`, `skill_rank`, `skill_max_rank` and the two
-per-rank exports) since issue #8 — the `is_dead()`/group contract and
+skill API (`gain_experience`, `spend_skill_point`, `skill_rank`,
+`skill_max_rank` and the two per-rank exports) since issue #8 — the
+`is_dead()`/group contract and
 `xp_reward` of `scenes/enemies/`, `LevelMap`'s public geometry API from
 `scenes/map/`, and the `health` and `experience` components'
 `current`/`max_health` and `level`/`xp`/`skill_points` from `scenes/components/`.
 It reads no `scenes/ui/` node: nothing here asserts anything about the screen,
 including the XP bar #8 added.
 
-<!-- verified-against: 4a0d146 -->
+<!-- verified-against: 5e30f99 -->

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -153,8 +153,9 @@ skill API (`gain_experience`, `spend_skill_point`, `skill_rank`,
 `skill_max_rank` and the two per-rank exports) since issue #8 — the
 `is_dead()`/group contract and
 `xp_reward` of `scenes/enemies/`, `LevelMap`'s public geometry API from
-`scenes/map/`, and the `health` and `experience` components'
-`current`/`max_health` and `level`/`xp`/`skill_points` from `scenes/components/`.
+`scenes/map/`, and from `scenes/components/` the `health` and `experience`
+children — `current`/`max_health` on one, and `level`/`xp`/`skill_points`,
+`xp_to_next()` and the `leveled_up` signal on the other.
 It reads no `scenes/ui/` node: nothing here asserts anything about the screen,
 including the XP bar #8 added.
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -23,6 +23,7 @@ placed one cell from a spawn.
 | `smoke_startup.gd` | The level assembles as authored and the navmesh is real |
 | `smoke_traversal.gd` | The hero walks start cell to boss room |
 | `smoke_combat.gd` | He kills, acquires his own targets, and heals afterwards |
+| `smoke_progression.gd` | Kills pay XP, levels pay points, and points pay stats |
 
 ## Running them
 
@@ -120,6 +121,13 @@ PR, so the constraints run outward as well as in:
   the one enemy placement bound by that rule that the map's own build-time
   warning cannot see, because it reads the spawn list. The current map meets it
   exactly (4.000 cells, twice), so there is no slack to spend.
+- **`smoke_progression.gd` guards a rule with no other keeper** (issue #8): that
+  reaching a level raises no stat by itself, and every stat gain is bought with
+  a point. The root `CLAUDE.md` states it as design intent and `scenes/hero/`
+  owns every stat that could quietly break it — but nothing else *checks* it,
+  and the failure mode is friendly rather than obviously wrong ("levelling feels
+  stingy, give it a little something"). It is the first assertion here that is
+  primarily **negative**: what must *not* have changed.
 - **It also settled what that rule says**, which is the more interesting half.
   The check is per checkpoint over the placements a respawn *there* restores;
   three folder docs stated it over every placement on the map, and measuring it
@@ -132,10 +140,13 @@ PR, so the constraints run outward as well as in:
 
 Everything here is downstream and nothing depends on it, which is why the
 frontmatter above is long. It reads `scenes/main.tscn` and the startup order
-`scenes/` owns, the command API and `killed` signal of `scenes/hero/`, the
-`is_dead()`/group contract of `scenes/enemies/`, `LevelMap`'s public geometry
-API from `scenes/map/`, and the `health` component's `current`/`max_health` from
-`scenes/components/`. It reads no `scenes/ui/` node: nothing here asserts
-anything about the screen.
+`scenes/` owns, the command API and `killed` signal of `scenes/hero/` — plus its
+skill API (`spend_skill_point`, `skill_rank`, `skill_max_rank` and the two
+per-rank exports) since issue #8 — the `is_dead()`/group contract and
+`xp_reward` of `scenes/enemies/`, `LevelMap`'s public geometry API from
+`scenes/map/`, and the `health` and `experience` components'
+`current`/`max_health` and `level`/`xp`/`skill_points` from `scenes/components/`.
+It reads no `scenes/ui/` node: nothing here asserts anything about the screen,
+including the XP bar #8 added.
 
 <!-- verified-against: 6958cf7 -->

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -149,4 +149,4 @@ per-rank exports) since issue #8 — the `is_dead()`/group contract and
 It reads no `scenes/ui/` node: nothing here asserts anything about the screen,
 including the XP bar #8 added.
 
-<!-- verified-against: 6958cf7 -->
+<!-- verified-against: 4a0d146 -->

--- a/tests/smoke_progression.gd
+++ b/tests/smoke_progression.gd
@@ -12,9 +12,15 @@ extends "res://tests/harness.gd"
 ## The kills are real, because kill-to-XP is the wiring under test and a granted
 ## number would prove only that the component adds up. Once a level has been
 ## earned the honest way, the second one is topped up through
-## [method Experience.grant] rather than by walking to five more zombies: what is
-## being checked past that point is spending, and the walking is already covered
-## by the other tests.
+## [method Hero.gain_experience] rather than by walking to five more zombies:
+## what is being checked past that point is spending, and the walking is already
+## covered by the other tests.
+##
+## [b]The top-up goes through the hero, not into his Experience child.[/b] The
+## two are the same call — one forwards to the other — but scenes/components/
+## states "only writing goes through the owner" without exceptions, and a test
+## is the worst place to take the first one: it is the file a reader copies when
+## they write the second.
 
 ## Budget for one engagement — closing the distance plus the fight. Measured at
 ## ~6-10 s each in smoke_combat.gd, and the first kills here are the same fight.
@@ -79,7 +85,7 @@ func _check() -> void:
 		"still rank %d" % hero.skill_rank(&"strength"))
 
 	# --- 5. the other skill, and what a raised ceiling does to current hp ------
-	progress.grant(progress.xp_to_next())
+	hero.gain_experience(progress.xp_to_next())
 	if not check("a second level pays a second point",
 		progress.level == 3 and progress.skill_points == 1,
 		"level %d, %d point(s)" % [progress.level, progress.skill_points]):
@@ -99,7 +105,7 @@ func _check() -> void:
 	# Deliberately overfunded, so what stops the purchases is the cap and not an
 	# empty pool — those are the two refusals, and a test that cannot tell them
 	# apart proves neither.
-	progress.grant(progress.xp_to_next() * 20.0)
+	hero.gain_experience(progress.xp_to_next() * 20.0)
 	var rank_before: int = hero.skill_rank(&"strength")
 	var points_before: int = progress.skill_points
 	var max_rank: int = hero.skill_max_rank

--- a/tests/smoke_progression.gd
+++ b/tests/smoke_progression.gd
@@ -1,0 +1,151 @@
+extends "res://tests/harness.gd"
+## Kills pay XP, XP pays levels, levels pay skill points — and nothing else
+## (issue #8).
+##
+## [b]The assertion this file exists for is a negative one:[/b] that reaching a
+## level changes no stat by itself. That is the design rule the whole skill tree
+## rests on — two heroes of the same level are different builds because of what
+## they spent, not what they reached — and it is the kind of rule that decays
+## quietly, since the obvious "improvement" is to make levelling feel generous by
+## slipping a stat into it.
+##
+## The kills are real, because kill-to-XP is the wiring under test and a granted
+## number would prove only that the component adds up. Once a level has been
+## earned the honest way, the second one is topped up through
+## [method Experience.grant] rather than by walking to five more zombies: what is
+## being checked past that point is spending, and the walking is already covered
+## by the other tests.
+
+## Budget for one engagement — closing the distance plus the fight. Measured at
+## ~6-10 s each in smoke_combat.gd, and the first kills here are the same fight.
+const ENGAGE_BUDGET := 1800
+
+var _levels: Array = []
+
+
+func _check() -> void:
+	var progress = hero.experience
+	check("the hero starts at level 1 with nothing banked",
+		progress.level == 1 and progress.skill_points == 0 and is_zero_approx(progress.xp),
+		"level %d, %.0f xp, %d point(s)" % [progress.level, progress.xp, progress.skill_points])
+
+	# Connected before the first swing, so what is measured is every level the
+	# run produced rather than the ones that happened after we started looking.
+	progress.leveled_up.connect(func(level: int, points: int) -> void: _levels.append([level, points]))
+
+	var damage_at_start: float = hero.attack_damage
+	var max_health_at_start: float = hero.health.max_health
+	var needed: float = progress.xp_to_next()
+	note("level 2 costs %.0f xp; a zombie is worth %.0f" % [needed, _nearest_reward()])
+
+	# --- 1. a kill pays XP ----------------------------------------------------
+	if not await _kill_one("the first kill lands"):
+		return
+	check("killing a zombie grants xp", progress.xp > 0.0 or progress.level > 1,
+		"%.0f xp toward level %d" % [progress.xp, progress.level])
+
+	# --- 2. enough kills level him up -----------------------------------------
+	# Bounded rather than counted: how many kills a level costs is a balance
+	# number and this test must not be the thing that freezes it.
+	var kills := 1
+	while progress.level < 2 and kills < 8:
+		if not await _kill_one("kill %d lands" % (kills + 1)):
+			return
+		kills += 1
+	if not check("killing zombies levels the hero up", progress.level == 2,
+		"level %d after %d kill(s)" % [progress.level, kills]):
+		return
+	check("the level-up fired once, with a point", _levels == [[2, 1]],
+		"leveled_up fired %s" % [_levels])
+	check("the level paid a skill point", progress.skill_points == 1,
+		"%d point(s) unspent" % progress.skill_points)
+
+	# --- 3. and the level alone changed no stat -------------------------------
+	# The rule this file exists for. Levelling is worth points and nothing else;
+	# every stat gain in the game is bought.
+	check("levelling up on its own raises no stat",
+		is_equal_approx(hero.attack_damage, damage_at_start)
+			and is_equal_approx(hero.health.max_health, max_health_at_start),
+		"%.0f dmg / %.0f max hp, unchanged" % [hero.attack_damage, hero.health.max_health])
+
+	# --- 4. spending a point is what raises one -------------------------------
+	check("a point buys a rank of strength", hero.spend_skill_point(&"strength"))
+	check("strength raised the hero's damage",
+		is_equal_approx(hero.attack_damage, damage_at_start + hero.strength_damage_per_rank),
+		"%.0f -> %.0f dmg" % [damage_at_start, hero.attack_damage])
+	check("the point is gone", progress.skill_points == 0)
+	check("a second point cannot be spent from an empty pool",
+		not hero.spend_skill_point(&"strength"),
+		"still rank %d" % hero.skill_rank(&"strength"))
+
+	# --- 5. the other skill, and what a raised ceiling does to current hp ------
+	progress.grant(progress.xp_to_next())
+	if not check("a second level pays a second point",
+		progress.level == 3 and progress.skill_points == 1,
+		"level %d, %d point(s)" % [progress.level, progress.skill_points]):
+		return
+	var hp_before: float = hero.health.current
+	check("a point buys a rank of health", hero.spend_skill_point(&"health"))
+	check("health raised the ceiling",
+		is_equal_approx(hero.health.max_health, max_health_at_start + hero.health_per_rank),
+		"%.0f -> %.0f max hp" % [max_health_at_start, hero.health.max_health])
+	# The half that is easy to get wrong: buying hit points at 40/100 must leave
+	# 50/110, not 40/110. A point that visibly does nothing reads as one wasted.
+	check("and healed by the same amount rather than diluting the bar",
+		is_equal_approx(hero.health.current, hp_before + hero.health_per_rank),
+		"%.0f -> %.0f hp" % [hp_before, hero.health.current])
+
+	# --- 6. a rank cannot be bought past its cap ------------------------------
+	# Deliberately overfunded, so what stops the purchases is the cap and not an
+	# empty pool — those are the two refusals, and a test that cannot tell them
+	# apart proves neither.
+	progress.grant(progress.xp_to_next() * 20.0)
+	var rank_before: int = hero.skill_rank(&"strength")
+	var points_before: int = progress.skill_points
+	var max_rank: int = hero.skill_max_rank
+	var attempts := max_rank + 2
+	var bought := 0
+	for i in attempts:
+		if hero.spend_skill_point(&"strength"):
+			bought += 1
+	check("a skill stops at its maximum rank",
+		hero.skill_rank(&"strength") == max_rank,
+		"rank %d of %d" % [hero.skill_rank(&"strength"), max_rank])
+	check("and every refused purchase past it spent nothing",
+		bought == max_rank - rank_before and progress.skill_points == points_before - bought,
+		"%d of %d attempts bought a rank, %d of %d points left"
+			% [bought, attempts, progress.skill_points, points_before])
+	done()
+
+
+## Order the nearest zombie killed and wait it out. Returns false once something
+## has already failed, so the caller can stop rather than pile on.
+func _kill_one(what: String) -> bool:
+	var target = _nearest_enemy()
+	if not check("%s: there is something to fight" % what, target != null):
+		return false
+	hero.command_attack(target)
+	return await wait_for(
+		what,
+		func() -> bool: return not is_instance_valid(target) or target.is_dead(),
+		ENGAGE_BUDGET,
+		{"the hero lost the fight": func() -> bool: return hero.is_dead()},
+	)
+
+
+func _nearest_reward() -> float:
+	var target = _nearest_enemy()
+	return target.xp_reward if target != null else 0.0
+
+
+## Nearest living enemy to the hero, horizontally.
+func _nearest_enemy():
+	var best = null
+	var best_distance := INF
+	for enemy in living_enemies():
+		var offset: Vector3 = enemy.global_position - hero.global_position
+		offset.y = 0.0
+		if offset.length() < best_distance:
+			best_distance = offset.length()
+			best = enemy
+	return best

--- a/tests/smoke_progression.gd.uid
+++ b/tests/smoke_progression.gd.uid
@@ -1,0 +1,1 @@
+uid://b34dgokoweghv


### PR DESCRIPTION
Fixes #8 — the last item in the **First playable** milestone.

Killing something grants XP, XP grants levels, and a level grants **skill points and nothing else**. Every stat gain in the game is bought by spending a point.

That last part is the design decision this PR settles, and it is recorded in the root `CLAUDE.md` because it is design intent rather than a fact about any one folder: two heroes of the same level should be different *builds*, not the same hero twice. It is easy to erode in a friendly direction ("levelling feels stingy, give it a little something"), so `tests/smoke_progression.gd` asserts it directly — the first assertion in `tests/` that is primarily negative.

## What is in it

| Where | What |
|-------|------|
| `scenes/components/experience.gd` | New `Experience` component beside `Health`: XP, levels, unspent points. `leveled_up(level, points)` is the hook issue #9's tree hangs off. |
| `scenes/components/health.gd` | `set_max_health()` — the seam that doc predicted the skill tree would pull on. |
| `scenes/hero/` | Two placeholder skills, `gain_experience()`, `spend_skill_point()`, `skill_summary()`. |
| `scenes/main.gd` | Consumes `Hero.killed` and grants the reward. |
| `scenes/enemies/` | `xp_reward` — 10 on a zombie, 100 on the boss. |
| `scenes/ui/` | XP bar, skill line, and a `LEVEL UP` banner. |
| `project.godot` | `skill_strength` (`1`) and `skill_health` (`2`), physical keycodes. |
| `tests/smoke_progression.gd` | 22 checks. |

Curve: 30 XP for level 2, +15 per level after. A zombie is 10, so level 2 costs three kills.

## The two skills are a placeholder, and issue #9 should delete them

`scenes/hero/CLAUDE.md` has said since #11 that there is deliberately **no stat or modifier system**, because inventing one would prejudge #9. That is still true and this PR keeps it true: two entries in a `const` table, a rank counter, and `_apply_skills()` recomputing two stats from base + rank. No modifier objects, no sources, no stacking rules, no data files.

I have deliberately kept it small enough to throw away rather than good enough to extend — a placeholder worth keeping would prejudge #9 just as effectively as a real system. **Worth a reviewer's opinion**: if you would rather #8 shipped with no spendable skills at all, the XP/level/points half stands on its own and the skills are a clean revert. They are here because a level-up signal with no consumer is a hook nobody has proved.

## Decisions worth arguing with

- **`Hero.killed` won the XP hook over `Zombie.died`.** Both have been sitting unconsumed and both docs named them as candidates. `killed` fires from the swing that lands the blow, so attribution is exact; `died` announces a death without saying who caused it, and a hero should not be paid for one he had no part in.
- **The victim names its own price.** `main.gd` reads `xp_reward` off whatever died rather than keeping a table, so a new enemy type carries its value with it. Deliberately *not* a third member of the hero↔enemy contract — `scenes/hero/` never reads it, and a victim without the property is worth nothing rather than an error.
- **Granting goes through `Hero.gain_experience()`, not into the child.** `scenes/components/CLAUDE.md`'s convention is that owners forward; I noticed mid-change that I had broken it and added the forwarding method. That doc now also says explicitly that *reading* a component's signals directly is fine and only mutation needs an owner in the path — both `main.gd` and `scenes/ui/` already did the former.
- **`gain_experience()` has no `_dead` guard where `take_damage()` does.** Refusing damage to a corpse is the rule; refusing *credit* to one would silently swallow a kill that lands after the hero falls. Unreachable today, reachable with the first damage-over-time effect, and losing XP is the worse direction to be wrong in.
- **Buying +10 max HP heals for 10.** 40/100 becomes 50/110, not 40/110 — a point that visibly does nothing when spent reads as a point wasted. Asserted in the test.
- **`1` and `2` are the first inputs in `scenes/hero/` that are not commands.** They spend a point and leave orders alone: they do not disarm `A` and do not cancel a move. A player banking a level mid-fight keeps the fight.
- **A death costs no progression; a restart discards all of it.** Neither needed a line of code — XP lives on the hero, so `respawn_at()` does not touch it and the scene reload takes it. `scenes/CLAUDE.md` predicted exactly this in the `_restart_run` note about "state nobody has added yet"; that note is now updated to say it happened.

## Docs

The change touches five code folders, so the `depends-on` graph flags six docs. Five were edited substantively in the first commit; `scenes/map/CLAUDE.md` was not, so I read it end to end for the second commit and it earned its keep:

> its respawn-clearance contract leans on the hero's `acquire_radius`, and this is the first PR to give any hero stat a way to move mid-run. No skill touches a radius, so the contract holds unchanged — but the "issue #9 might raise it" sentence beside it has stopped being hypothetical.

That is now written where it binds, with a note to re-read it when a skill widens a radius rather than when the tree lands.

## Testing

```
bash tests/run.sh "$GODOT"
```

All four suites pass. `smoke_traversal` is unchanged frame-for-frame (1704 frames, arrives with 44/100 hp), so nothing here moved the difficulty. New test output:

```
PASS  the hero starts at level 1 with nothing banked  (level 1, 0 xp, 0 point(s))
PASS  killing a zombie grants xp  (10 xp toward level 1)
PASS  killing zombies levels the hero up  (level 2 after 3 kill(s))
PASS  the level-up fired once, with a point  (leveled_up fired [[2, 1]])
PASS  levelling up on its own raises no stat  (12 dmg / 100 max hp, unchanged)
PASS  strength raised the hero's damage  (12 -> 14 dmg)
PASS  health raised the ceiling  (100 -> 110 max hp)
PASS  and healed by the same amount rather than diluting the bar  (46 -> 56 hp)
PASS  a skill stops at its maximum rank  (rank 5 of 5)
PASS  and every refused purchase past it spent nothing  (4 of 7 attempts bought a rank, 5 of 9 points left)
PASSED 22 check(s)
```

The HUD strings were checked against a live scene too:

```
xp bar : Lv 2     5 / 45 XP
skills : 1 point    [1] Strength 0/5  +0 dmg    [2] Health 0/5  +0 hp
banner : LEVEL 2 — 1 skill point
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
