### PR TITLE
Draw the four skills no key could reach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,17 @@ every PR (`docs-check` workflow). It runs four checks:
 | verification | A folder whose files changed since its `verified-against` stamp without the doc being touched — including history that predates these hooks, merge-conflict resolutions, and commits from anyone running without hooks — plus a stamp that cannot be true at all: one naming a commit where the folder does not exist, or one that is not an ancestor of `HEAD` |
 | dependency graph | A `depends-on` entry naming a folder with no doc, or naming itself — and the one this check exists for: a doc left unread after code it *depends on* changed |
 
+**The same-change rule's `project.godot` half is the one that misfires**, and it
+is worth recording where rather than only in issue #40. That file holds two
+registries this doc explicitly does *not* own, so adding an input action forces
+an edit here to describe something `scenes/CLAUDE.md` is the owner of. PR #62 is
+the second recorded instance: it added `toggle_skills` and had nothing true to
+say here beyond this paragraph. Left as-is deliberately — the check cannot tell
+which *section* of `project.godot` moved, and a rule that fires too often is a
+smaller fault than one that lets a renderer or physics change through unread.
+Note what it is not: the rest of the same-change rule, which fires on a folder's
+own code, has never misfired.
+
 ### The `depends-on` graph
 
 Every check above looks at a folder in isolation, so all of them miss the same

--- a/project.godot
+++ b/project.godot
@@ -46,6 +46,10 @@ skill_health={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":50,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)]
 }
+toggle_skills={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":75,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)]
+}
 
 [layer_names]
 

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -348,4 +348,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: d5fb938 -->
+<!-- verified-against: 79c5b4d -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -355,4 +355,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 79c5b4d -->
+<!-- verified-against: 0bc0fe6 -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -160,6 +160,33 @@ winning means, so it decides what a kill is worth beside them.
   `Hero.skill_ranked_up` — because the points total and the ranks are drawn
   together and move separately. `emit_current()` is called once at startup for
   the reason the health bar is pushed by hand: nothing re-sends those signals.
+- **Issue #62's skill panel hangs off that same method**, which is the whole
+  reason it needed no new plumbing: the panel draws the same two moving numbers,
+  so it is fed from `_refresh_skills()` alongside the crib line, from the fuller
+  `Hero.skill_catalogue()` report.
+
+## The skill panel's two wires (issue #62)
+
+`scenes/ui/` draws the tree and owns neither what it costs nor what it costs the
+run, so both answers are given here — the same split the victory screen already
+had.
+
+- **`skill_rank_up_requested` buys through `Hero.spend_skill_point()`**, the very
+  method the `1` and `2` keys use, refusals and all. The panel's buttons are
+  already disabled on exactly the nodes that method would refuse, so a click
+  arriving anyway is a race with a level-up and should lose the same way a
+  keypress would. Nothing is redrawn from the handler: a purchase emits
+  `skill_ranked_up`, which is already wired.
+- **`skill_panel_toggled` freezes the run**, and **this script owns the pause
+  flag** for the reason it already owns it at the victory screen: `paused` lives
+  on the `SceneTree` rather than the scene, so it survives anything the scene
+  does and exactly one script may set it. Choosing a build is a considered
+  decision and the zombies do not wait; a tree readable only when nothing is
+  chasing you would be unusable at the exact moment a level is banked.
+- **Both carry the `_run_over` guard**, and it matters in opposite directions —
+  here, unpausing a won run would take the win back. `scenes/ui/` refuses to open
+  the panel once the victory screen is up, so this is the second of two guards on
+  the same case rather than the only one.
 
 ## Navmesh gotchas (learned the hard way)
 
@@ -275,16 +302,23 @@ describes. See `scenes/enemies/CLAUDE.md`.
   `scenes/map/checkpoint.tscn` at runtime. Two exports are wired here as
   `NodePath`s and both point at the hero: the camera's `target` and
   `UnitSelection.hero`.
-- **Input actions** are defined in `project.godot` and every one of them is
-  consumed by `scenes/hero/`, not by anything in this folder. What each *means*
-  is that folder's to document; this is only the inventory:
+- **Input actions** are defined in `project.godot`. What each *means* belongs to
+  the folder that consumes it; this is only the inventory:
   `move_command` (right mouse), `select_command` (left mouse),
   `attack_move` (`A`), `cancel_command` (`Escape`),
-  `skill_strength` (`1`), `skill_health` (`2`).
-  The last two are bound to *physical* keycodes like `attack_move` is, so they
-  land on the same two keys whatever the keyboard layout — and they are the
-  first actions here that are not commands at all: they spend a skill point and
-  leave the hero's orders alone.
+  `skill_strength` (`1`), `skill_health` (`2`), `toggle_skills` (`K`).
+  Every letter-key action is bound to a *physical* keycode, so they land on the
+  same keys whatever the keyboard layout.
+  **All but one are consumed by `scenes/hero/`**, and the exceptions are worth
+  naming because the list has stopped being uniform twice:
+  - `skill_strength` / `skill_health` are consumed there but are **not
+    commands** — they spend a skill point and leave the hero's orders alone.
+  - `toggle_skills` is consumed by **`scenes/ui/`** (issue #62), the only action
+    read outside `scenes/hero/`. Opening a panel issues no order, so routing it
+    through the command scheme would put a screen toggle in the file that owns
+    attack-move. `cancel_command` is now read in *both* folders — the panel
+    closes on `Escape` and consumes the event, so it never also disarms an attack
+    in the game behind it.
 - `LevelMap` emits `built`; nothing consumes it yet.
 - `main.gd` consumes `Checkpoint.reached` and calls `Checkpoint.set_armed()`
   back on every pad, so exactly one is lit. It calls `Hero.respawn_at()` and, on
@@ -295,7 +329,9 @@ describes. See `scenes/enemies/CLAUDE.md`.
   `Hero.attack_move_armed_changed` and `Hero.select_clicked`, forwarding each to
   `scenes/ui/`. Since issue #8 it also consumes `Hero.killed` and
   `Hero.skill_ranked_up`, plus `xp_changed`, `leveled_up` and `points_changed`
-  from the hero's `Experience` child — see "Progression" above. Unconsumed so
+  from the hero's `Experience` child — see "Progression" above. Issue #62 added
+  `HUD.skill_rank_up_requested` and `HUD.skill_panel_toggled`, the second and
+  third signals to run from `scenes/ui/` back into the game. Unconsumed so
   far: `Hero.move_ordered` and `Hero.attack_ordered` — this doc used to earmark
   them "for the selection UI, issue #36", and that turned out to be wrong:
   selection is deliberately inert and reads nothing about what the hero is

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -184,9 +184,16 @@ had.
   decision and the zombies do not wait; a tree readable only when nothing is
   chasing you would be unusable at the exact moment a level is banked.
 - **Both carry the `_run_over` guard**, and it matters in opposite directions —
-  here, unpausing a won run would take the win back. `scenes/ui/` refuses to open
-  the panel once the victory screen is up, so this is the second of two guards on
-  the same case rather than the only one.
+  here, unpausing a won run would take the win back.
+- **The guard alone was not enough, and the gap is worth knowing.** `_run_over` is
+  set the instant the boss falls; the victory screen waits `VICTORY_DELAY` (1.2 s)
+  for the corpse to finish toppling. In between, this script refuses to touch the
+  pause flag while `scenes/ui/` had not yet retired the panel — so opening it in
+  that beat gave a panel over a live level, freezing nothing, against an invariant
+  that folder states unconditionally. `_on_boss_died()` now retires the panel
+  *before* the wait rather than with the screen. Cross-review of PR #62 found it,
+  and it is the second time a `_run_over` window has needed closing on both sides
+  of a wait — `_on_hero_died()` tests it twice for the same reason.
 
 ## Navmesh gotchas (learned the hard way)
 

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -165,6 +165,17 @@ with before touching the rest:
   harder is what would turn this from a rule into a coin flip. The 8 s delay is
   what keeps a two-second reposition free.
 
+**Both of those margins stopped being theoretical in issue #62**, and that is the
+only thing that change did to this folder — no stat moved. `reach` and `recovery`
+are two of the four nodes that had no hotkey and so could not be bought in play
+at all; the panel in `scenes/ui/` now sells them. So the 2.8-against-3.0 reach
+gap and the 7-against-12 regeneration margin describe builds a player can
+actually arrive at, where until now they described builds only
+`tests/smoke_skills.gd` ever constructed. The numbers were always checked; what
+changed is that they are now *encountered*. If either turns out to be wrong, it
+will be wrong in play rather than in a test, which is the first time that has
+been true of this table.
+
 The stats are a first pass and are meant to be argued with: nothing in the game
 was balanced against an end boss before there was one.
 
@@ -286,4 +297,4 @@ wider than this will not.
   the boss has no model of its own at all, so whatever it eventually wears is a
   separate question from what the horde does.
 
-<!-- verified-against: d5fb938 -->
+<!-- verified-against: 79c5b4d -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -297,4 +297,4 @@ wider than this will not.
   the boss has no model of its own at all, so whatever it eventually wears is a
   separate question from what the horde does.
 
-<!-- verified-against: 79c5b4d -->
+<!-- verified-against: 0bc0fe6 -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -414,4 +414,4 @@ to touch. `tests/smoke_progression.gd` asserts it directly.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: 79c5b4d -->
+<!-- verified-against: 0bc0fe6 -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -212,16 +212,31 @@ prerequisites, and nothing about what a stat name means.
 tree.** Which key buys what is a fact about this hero's control scheme;
 `scenes/skills/` must not learn about input actions, or a tree could not be
 shared with a second actor or re-bound without editing game content.
-`SKILL_HOTKEYS` is that mapping, and it reaches two of the tree's six nodes —
-the rest are buyable only through `spend_skill_point()` until there is a panel
-to click, which is the state a design PR with no UI leaves behind.
+`SKILL_HOTKEYS` is that mapping, and it reaches two of the tree's six nodes. The
+other four were buyable only through `spend_skill_point()` until **issue #62 gave
+`scenes/ui/` a panel to click**; the keys stayed as they were, because four more
+hotkeys would have been a worse answer than a panel.
 
-`skill_summary()` accordingly reports **the bound skills, not the whole tree**:
-that HUD line is a reminder of what the keys do, and a node the player cannot
-press has no business on it. It still carries ranks and effect text for the same
-reason `unit_info()` carries stats — what a rank *does* is a fact about this
-actor, and a panel that formatted it would have to be edited for every new
-skill. See the contract in `scenes/ui/CLAUDE.md`.
+**Two reports, not one, and the split is deliberate** — see the contract in
+`scenes/ui/CLAUDE.md`:
+
+- `skill_summary()` reports **the bound skills**. That HUD line is a reminder of
+  what the keys do, and a node the player cannot press has no business on it.
+- `skill_catalogue()` reports **every node**, locked ones included, which is what
+  a panel draws — a tree you cannot see the locked half of is a list. It carries
+  everything a card prints so the panel never interprets: cost, rank, refusal,
+  the authored `description`, and what the *next* rank would buy. That last one
+  asks `describe(rank + 1)`, per the note in `scenes/skills/`: `describe()`
+  reports what a rank *has* bought, so asking for the current one advertises
+  nothing at rank 0.
+
+Both carry ranks and effect text for the same reason `unit_info()` carries
+stats — what a rank *does* is a fact about this actor, and a panel that formatted
+it would have to be edited for every new skill.
+
+**Narrowing `skill_catalogue()` to the bound skills would restore #62's bug with
+the panel still on screen**, which is why `tests/smoke_skills.gd` asserts it
+reports strictly more than the keys reach rather than merely reporting something.
 
 **A level pays points and raises nothing by itself.** That rule is the game's,
 not this folder's — it lives in the root `CLAUDE.md` — and this is the folder

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -414,4 +414,4 @@ to touch. `tests/smoke_progression.gd` asserts it directly.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: aeec030 -->
+<!-- verified-against: 79c5b4d -->

--- a/scenes/hero/hero.gd
+++ b/scenes/hero/hero.gd
@@ -372,6 +372,52 @@ func skill_summary() -> Array[Dictionary]:
 	return summary
 
 
+## Every node of this hero's tree and its live state, for the skill panel (issue
+## #62).
+##
+## The whole-tree counterpart to [method skill_summary], and the two are
+## deliberately different reports rather than one with a flag. That one is the
+## crib sheet for the keys and carries only what a keypress can reach; this one
+## carries what a panel draws, which is every node whether it is buyable, capped
+## or still locked — a tree you cannot see the locked half of is not a tree, it
+## is a list.
+##
+## Same rule as [method unit_info] about who assembles it: the panel formats and
+## never interprets, so everything it would otherwise have to work out — what a
+## rank costs, why it cannot be bought, what the next one would buy — is answered
+## here. [member SkillNode.description] is passed through untouched; it is the one
+## field that is authored prose rather than derived.
+##
+## [param depth] is the tree's own prerequisite depth, not a screen position. How
+## a panel arranges the tiers is its business — see [method SkillTree.depth].
+func skill_catalogue() -> Array[Dictionary]:
+	var catalogue: Array[Dictionary] = []
+	if skill_tree == null:
+		return catalogue
+	for id in skill_tree.ids():
+		var node := skill_tree.node(id)
+		if node == null:
+			continue
+		var rank := skill_rank(id)
+		catalogue.append({
+			"id": id,
+			"name": node.display_name,
+			"description": node.description,
+			"rank": rank,
+			"max_rank": node.max_rank,
+			"cost": skill_tree.cost_of_next_rank(id),
+			"depth": skill_tree.depth(id),
+			# "" exactly when a click would succeed, so the panel never has to
+			# decide for itself what makes a node buyable.
+			"refusal": skill_refusal(id),
+			"effect": node.describe(rank),
+			# rank + 1, per the note on describe(): it reports what a rank *has*
+			# bought, so asking for the current one advertises nothing at rank 0.
+			"next_effect": node.describe(rank + 1) if rank < node.max_rank else "",
+		})
+	return catalogue
+
+
 ## Everything wrong with this hero's tree: the faults the tree can see itself,
 ## plus the one only an actor can — an effect naming a stat this hero does not
 ## have. Empty when it is sound.

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -269,6 +269,12 @@ func _on_hero_died() -> void:
 func _on_boss_died(_boss: Zombie) -> void:
 	# Before the wait, not after — see the guard in _on_hero_died().
 	_run_over = true
+	# Also before the wait, and for a reason of its own: from this line on this
+	# script refuses to touch the pause flag, so a skill panel opened during the
+	# beat below would come up over a level that is still running. Retiring it here
+	# rather than with the victory screen keeps "the game freezes while it is up"
+	# true without an exception. Cross-review of PR #62 found the window.
+	_hud.retire_skill_panel()
 	await get_tree().create_timer(VICTORY_DELAY).timeout
 	if not is_inside_tree():
 		return

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -92,9 +92,12 @@ func _ready() -> void:
 	# belongs to, and hands on the clicks his attack command did not take.
 	_hero.select_clicked.connect(_selection.select_at)
 	_selection.selection_changed.connect(_hud.show_unit)
-	# The one wire that runs the other way, from the HUD back into the game: the
-	# victory screen asks, this script decides what starting a run means.
+	# The wires that run the other way, from the HUD back into the game: the
+	# victory screen asks, this script decides what starting a run means — and
+	# since issue #62 the skill panel asks on the same terms.
 	_hud.restart_requested.connect(_restart_run)
+	_hud.skill_rank_up_requested.connect(_on_skill_rank_up_requested)
+	_hud.skill_panel_toggled.connect(_on_skill_panel_toggled)
 
 	_hud.set_hero_health(_hero.health.current, _hero.health.max_health)
 	# Same reason the health bar is pushed by hand: nothing re-sends these, so a
@@ -125,8 +128,45 @@ func _on_hero_killed(victim: Node3D) -> void:
 
 ## Redraw the skill line. Both the points total and the ranks live on it, and the
 ## two move independently, so it is one method rather than two half-updates.
+##
+## The panel (issue #62) is redrawn from the same two events and in the same
+## place, because it draws the same two moving numbers. It takes a second, fuller
+## report rather than the crib line's: the line lists what a key can buy, the
+## panel lists every node whether a key reaches it or not.
 func _refresh_skills() -> void:
 	_hud.set_skills(_hero.experience.skill_points, _hero.skill_summary())
+	_hud.set_skill_catalogue(_hero.experience.skill_points, _hero.skill_catalogue())
+
+
+## The player clicked a node in the skill panel (issue #62).
+##
+## It goes through the same [method Hero.spend_skill_point] the `1` and `2` keys
+## use, refusals and all, rather than a path of its own — the panel's buttons are
+## already disabled on exactly the nodes that method would refuse, so a click that
+## arrives here anyway is a race with a level-up and should lose the same way a
+## keypress would. Nothing is redrawn from here: a purchase emits
+## `skill_ranked_up`, which is already wired to `_refresh_skills`.
+func _on_skill_rank_up_requested(skill: StringName) -> void:
+	_hero.spend_skill_point(skill)
+
+
+## Freeze the run while the skill panel is up (issue #62).
+##
+## **This script owns the pause flag**, as it does for the victory screen and for
+## the same reason: `paused` lives on the SceneTree rather than the scene, so it
+## survives anything the scene does and exactly one script may set it. The HUD
+## reports that the panel opened; what that costs the run is decided here.
+##
+## Choosing a build is a considered decision and the zombies do not wait, so the
+## alternative — a tree readable only by a player who is not currently being
+## chased — would make the panel unusable at exactly the moment a level is banked.
+##
+## The `_run_over` guard is the same one the respawn path carries, and it matters
+## for the opposite reason there: unpausing a won run would take the win back.
+func _on_skill_panel_toggled(open: bool) -> void:
+	if _run_over:
+		return
+	get_tree().paused = open
 
 
 ## One zombie per `Z` cell from [param from_segment] onward. The map says where

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -334,4 +334,4 @@ contiguous run of open cells without changing what the player sees.
   `scenes/hero/`, which is why it is in the frontmatter above. `Checkpoint`
   never names `Hero` as a type.
 
-<!-- verified-against: 79c5b4d -->
+<!-- verified-against: 0bc0fe6 -->

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -334,4 +334,4 @@ contiguous run of open cells without changing what the player sees.
   `scenes/hero/`, which is why it is in the frontmatter above. `Checkpoint`
   never names `Hero` as a type.
 
-<!-- verified-against: d5fb938 -->
+<!-- verified-against: 79c5b4d -->

--- a/scenes/skills/CLAUDE.md
+++ b/scenes/skills/CLAUDE.md
@@ -120,13 +120,20 @@ thing that knows what a stat name means.
 - **`describe()` reports what a rank *has* bought, so it is empty at rank 0.**
   A panel that wants to advertise what the *next* rank would buy should ask for
   rank + 1 rather than expecting this to guess which it meant.
-- **The tree is larger than the keyboard**, and four of its six nodes have no
-  way to be bought in play yet. That is the state a design PR with no UI leaves
-  behind, not an oversight — `scenes/hero/` holds the two temporary key
-  bindings, and the skill panel is its own issue.
+- **The tree is larger than the keyboard**, and `scenes/hero/` holds the two
+  temporary key bindings. The other four nodes became buyable in issue #62, from
+  a panel in `scenes/ui/` rather than from more hotkeys.
 - Nodes carry no position and no hotkey. Where one is drawn belongs to the panel
   drawing it; which key buys it belongs to whoever owns the control scheme. A
   tree that knew either could not be shared with a second actor.
+- **`depth(id)` is the one concession to a panel, and it is not a position.** It
+  reports how deep in the prerequisite chain a node sits — 0 for one that is open
+  from the start — which is a fact about this graph and stays true however it is
+  drawn. Whether a panel turns depths into rows, columns or rings is entirely its
+  business, and two panels may disagree; what neither should do is re-derive the
+  structure from `requires` itself. It is cycle-safe rather than trusting
+  `validate()`, because it runs on every redraw and a malformed `.tres` must not
+  take the screen down with it.
 
 ## Dependencies
 

--- a/scenes/skills/CLAUDE.md
+++ b/scenes/skills/CLAUDE.md
@@ -146,4 +146,4 @@ plain `Resource` scripts. The declared edge on `scenes/hero/` is about the
 `scenes/hero/` is the only consumer today: it owns the ledger, the fold, and the
 key bindings. `tests/smoke_skills.gd` drives the tree through him.
 
-<!-- verified-against: d5fb938 -->
+<!-- verified-against: 79c5b4d -->

--- a/scenes/skills/skill_tree.gd
+++ b/scenes/skills/skill_tree.gd
@@ -79,6 +79,36 @@ func cost_of_next_rank(id: StringName) -> int:
 	return target.cost_per_rank if target != null else 0
 
 
+## How deep in the prerequisite chain [param id] sits: 0 for a node that is open
+## from the start, otherwise one past the deepest thing it requires.
+##
+## [b]This is graph structure, not layout.[/b] A node still carries no position —
+## whether a panel turns these into rows, columns or rings is entirely its
+## business, and two panels may disagree. What is not negotiable is that
+## "swiftness is open from the start and reach is not" is a fact about the tree,
+## and computing it from [member SkillNode.requires] is the only way to keep it
+## true when a node is added to the .tres.
+##
+## Cycle-safe by construction: a node already on the path contributes nothing
+## rather than recursing. [method validate] is what actually reports a ring; this
+## only declines to hang on one, because it runs at every redraw and a malformed
+## .tres must not take the panel down with it.
+func depth(id: StringName) -> int:
+	return _depth(id, {})
+
+
+func _depth(id: StringName, walking: Dictionary) -> int:
+	var target := node(id)
+	if target == null or walking.has(id):
+		return 0
+	walking[id] = true
+	var deepest := -1
+	for required_id in target.requires:
+		deepest = maxi(deepest, _depth(required_id, walking))
+	walking.erase(id)
+	return deepest + 1
+
+
 ## Points it would take to buy every rank of every node. What a full build
 ## costs, and the number a test can hold the tree to.
 func total_cost() -> int:

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -338,4 +338,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: 79c5b4d -->
+<!-- verified-against: 0bc0fe6 -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -331,4 +331,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: d5fb938 -->
+<!-- verified-against: 79c5b4d -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -1,5 +1,5 @@
 ---
-depends-on: [scenes, scenes/hero, scenes/enemies, scenes/components, scenes/map]
+depends-on: [scenes, scenes/hero, scenes/enemies, scenes/components, scenes/map, scenes/skills]
 ---
 
 # scenes/ui/
@@ -19,6 +19,9 @@ five elements and one of them non-trivial.
 - `unit_selection.tscn` / `unit_selection.gd` (`class_name UnitSelection`) — a
   `Node3D` in `main.tscn` holding the selection ring. Owns *what* is selected;
   the HUD only draws it.
+- `skill_panel.tscn` / `skill_panel.gd` (`class_name SkillPanel`) — the skill
+  tree as something clickable (issue #62), instanced inside `hud.tscn`. See
+  below.
 
 **Every element is fed by a method call.** `scenes/main.gd` wires the hero's
 signals to `HUD` methods and never touches a Label, so this folder can re-lay
@@ -57,6 +60,14 @@ No class is named here, so a boss or a second enemy type needs no change in this
 folder — but the three above are a real runtime contract, which is why
 `scenes/hero` and `scenes/enemies` are in the frontmatter.
 
+**`scenes/skills` is in it for a weaker reason, and the difference is worth
+knowing.** No script here loads, names or imports anything from that folder — the
+skill panel reads plain dictionaries. What rests on it is a *claim* in this doc:
+that the panel's rows are prerequisite depth and that its refusal text is the
+tree's own words. Change what `SkillTree.depth()` means and no code here breaks
+while this doc quietly stops being true, which is precisely the drift the edge
+exists to flag.
+
 **A unit reports its own numbers rather than the panel reaching in for named
 properties**, because the property that matters differs per actor: the hero's
 travel speed is his `move_speed`, a zombie's is its *chase* speed, and only they
@@ -93,11 +104,12 @@ fed by method call, never reached into:
   points are unspent, because the count is the only part that changes what a
   keypress does.
   **It is a crib sheet for the keys, not a view of the skill tree**, and issue
-  #9 is where those stopped being the same list: the hero now has an authored
-  tree larger than the two keys bound to it, and `skill_summary()` reports the
-  bound ones. Drawing the rest needs a panel, which is not this folder's yet —
-  and when it is, it is a new element rather than a longer line, because six
-  entries do not fit on one.
+  #9 is where those stopped being the same list: the hero has an authored tree
+  larger than the two keys bound to it, and `skill_summary()` reports the bound
+  ones. Issue #62 drew the rest, and did it as **a new element rather than a
+  longer line** — six entries do not fit on one. The two are fed from different
+  reports (`skill_summary()` and `skill_catalogue()`) and refreshed together,
+  because both move on the same two events.
 - **`flash_level_up(level, points)`** is the transient half, and it exists for
   the same reason `flash_checkpoint()` does: the bar below already says it, and
   a bar does not *reach* a player mid-fight — which is exactly when the kill that
@@ -112,6 +124,76 @@ death and victory screens call it for the reason recorded below — with the
 level-up banner the more likely of the two to be up, since the kill that levels
 the hero is often the one that leaves him low, and the boss is worth enough XP
 that the winning blow frequently levels him outright.
+
+## The skill panel (issue #62)
+
+`K` opens the tree, `K` or `Escape` closes it, and every node is a card with a
+button. Issue #9 shipped the tree with no UI, which left four of its six nodes
+with **no way to be bought in play at all** — `1` and `2` reach two of them.
+Four more hotkeys would have been a worse answer than none.
+
+**It formats and never interprets**, which is the same rule the skill line keeps
+and is worth restating because this panel is much more tempting to break. Every
+number and sentence on a card arrives ready to print from
+`Hero.skill_catalogue()`: the cost, the rank, the description, what the next rank
+would buy, and *why* a node cannot be bought — that last one is
+`SkillTree.refusal()`'s own words, so "Reach needs Strength 3" is game content
+rather than a string built here. Nothing in this folder knows what a rank does.
+**A new skill in the `.tres` therefore appears here with no edit to this folder**,
+which is the test of whether the split is real.
+
+**The layout is derived, not authored.** Cards are grouped into rows by
+`SkillTree.depth()` — prerequisite depth, not a position. A node still carries no
+coordinates, so the alternative was a position per node stored *here* and edited
+every time game content gained a skill. Two things follow: an empty tier draws no
+row (the depths present are read off the data, not assumed to run 0..n), and a
+`depth()` that returned a constant would silently collapse the tree into one row,
+which is why `tests/` asserts more than one tier exists.
+
+**It rebuilds outright on every redraw** rather than patching cards in place.
+Redraws happen when a point is earned or spent — never per frame — and a rebuilt
+panel cannot show a rank that was refunded or a refusal that has since been met.
+Note `queue_free()` alone is not enough: it frees at the end of the frame, so the
+rows are also `remove_child`ed immediately or a redraw in the same frame stacks
+the new rows under the old.
+
+**Three things it does not own**, all for reasons this folder already records
+elsewhere:
+
+- **It does not buy anything.** `rank_up_requested` goes out through
+  `HUD.skill_rank_up_requested` to `scenes/main.gd`, which calls the hero. Same
+  arrangement as `restart_requested`: this folder does not own the points, the
+  ledger or the rules, and a widget that spent them would be a second owner of
+  all three.
+- **It does not pause the game**, though the game *is* paused while it is up.
+  `skill_panel_toggled(open)` reports; `scenes/main.gd` sets `get_tree().paused`,
+  because that flag lives on the `SceneTree` rather than the scene and needs
+  exactly one owner — the same argument the victory panel makes.
+- **It does not decide when it is unavailable.** `show_victory()` calls
+  `set_unavailable()` on it, which is this folder keeping "the victory panel owns
+  the screen" true from the inside. A skill panel openable behind a won run would
+  also *unpause* it on the way out, which is the sharper version of the same rule.
+
+**It carries `PROCESS_MODE_ALWAYS` for the reason the victory panel does**, and
+needs it twice over: a paused node receives neither input nor GUI dispatch, so
+without it the panel could neither close itself nor answer a click on its own
+buttons.
+
+**This folder reads exactly one input action, and it is the first one anywhere
+outside `scenes/hero/`.** That folder owns every other action because every other
+action is a command to a unit; opening a panel issues no order and changes
+nothing about what the hero is doing. It does not break the left-mouse-button
+rule above either — a keyboard action nothing else claims is not a second
+listener on `select_command`. `Escape` is deliberately shared with the hero's
+`cancel_command`: the panel consumes the event when it is open, so closing it
+does not also disarm an attack in the game behind it.
+
+**Banners come down when it opens.** The death and victory screens already do
+this, and the skill panel is the likeliest collision of the three rather than a
+corner case: "LEVEL 7 — 1 skill point" is the banner that *tells* the player to
+open this panel, so a player who acts on it immediately reads it straight across
+the panel's own title. Found by screenshotting the panel, not by reasoning about
+it.
 
 ## The victory panel (issue #39)
 
@@ -232,10 +314,14 @@ difference worth stating rather than assuming.
   child (`scenes/components/`) and from `Hero.skill_ranked_up`. Nothing here
   reads that component: `scenes/main.gd` connects its signals and calls these,
   which is the same inward-only arrangement everything else in this folder has.
-- Emits `HUD.restart_requested`, consumed by `scenes/main.gd`. It is the only
-  signal this folder sends into the game rather than draws from it, and it is
-  also what pairs with the pause: that script sets `get_tree().paused`, so it is
-  the one that has to clear it.
+- Emits `HUD.restart_requested`, consumed by `scenes/main.gd`, and since issue
+  #62 `HUD.skill_rank_up_requested(skill)` and `HUD.skill_panel_toggled(open)` on
+  the same terms — the three signals this folder sends into the game rather than
+  draws from it, all re-emitted straight from a child panel. Two of them pair
+  with the pause: that script sets `get_tree().paused`, so it is the one that has
+  to clear it, whether the run was won or the tree was merely opened.
+  Issue #8's `set_skills()` gained `set_skill_catalogue(points, catalogue)`
+  beside it, fed from `Hero.skill_catalogue()`.
 - **`scenes/main.gd` re-selects the hero on every respawn**, before it clears
   the restored segment. That ordering is its concern, not this folder's, but it
   is the reason a freed selection is rare rather than routine — the

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -169,10 +169,17 @@ elsewhere:
   `skill_panel_toggled(open)` reports; `scenes/main.gd` sets `get_tree().paused`,
   because that flag lives on the `SceneTree` rather than the scene and needs
   exactly one owner — the same argument the victory panel makes.
-- **It does not decide when it is unavailable.** `show_victory()` calls
-  `set_unavailable()` on it, which is this folder keeping "the victory panel owns
-  the screen" true from the inside. A skill panel openable behind a won run would
-  also *unpause* it on the way out, which is the sharper version of the same rule.
+- **It does not decide when it is unavailable.** Two callers retire it, and they
+  fire at different moments on purpose. `show_victory()` does, which is this
+  folder keeping "the victory panel owns the screen" true from the inside — a
+  skill panel openable behind a won run would also *unpause* it on the way out.
+  And `retire_skill_panel()` does, called by `scenes/main.gd` the instant the boss
+  falls, **~1.2 s before the screen appears**. That gap is why the second exists:
+  the run is decided when the boss dies, and from that moment that script stops
+  touching the pause flag, so a panel opened during the beat would come up over a
+  level still running and freeze nothing. Cross-review of PR #62 found it. The
+  freeze below is stated without an exception, and this is what keeps that honest
+  rather than nearly true.
 
 **It carries `PROCESS_MODE_ALWAYS` for the reason the victory panel does**, and
 needs it twice over: a paused node receives neither input nor GUI dispatch, so

--- a/scenes/ui/hud.gd
+++ b/scenes/ui/hud.gd
@@ -130,6 +130,19 @@ func _on_skill_panel_toggled(open: bool) -> void:
 		_clear_flashes()
 
 
+## The run is over; the skill panel is finished for good.
+##
+## Separate from [method show_victory] because the two do not happen at the same
+## moment: the run is decided when the boss falls, and the screen waits a beat for
+## the corpse to finish toppling. Between those, `scenes/main.gd` has stopped
+## answering for the pause — so a panel that could still be opened in that gap
+## would come up over a live level and *not* freeze it, which is the one thing
+## this folder promises about it unconditionally. Cross-review of PR #62 found the
+## window; it is ~1.2 s wide and this is what closes it.
+func retire_skill_panel() -> void:
+	_skill_panel.set_unavailable()
+
+
 ## Point the info bar at the selected unit. Connected to
 ## [signal UnitSelection.selection_changed].
 func show_unit(unit: Node3D) -> void:

--- a/scenes/ui/hud.gd
+++ b/scenes/ui/hud.gd
@@ -19,6 +19,18 @@ extends CanvasLayer
 ## "start another one" does is that script's decision and not a widget's.
 signal restart_requested
 
+## The player clicked a node in the skill panel (issue #62). Passed straight
+## through from [signal SkillPanel.rank_up_requested] for the same reason
+## [signal restart_requested] exists: this folder draws the tree and does not own
+## the points, so what buying means is scenes/main.gd's decision.
+signal skill_rank_up_requested(skill: StringName)
+
+## The skill panel opened or closed, and the game is meant to freeze while it is
+## up. Reported rather than acted on: `get_tree().paused` lives on the SceneTree
+## rather than the scene, so the script that sets it has to be the one that clears
+## it — see the note on the victory panel in this folder's doc.
+signal skill_panel_toggled(open: bool)
+
 ## How long a transient banner holds before it starts fading, and how long the
 ## fade takes. Long enough to read mid-fight, short enough that it is gone
 ## before the fight the checkpoint was banked for.
@@ -36,6 +48,7 @@ const FLASH_FADE := 0.7
 @onready var _checkpoint_label: Label = $CheckpointLabel
 @onready var _level_up_label: Label = $LevelUpLabel
 @onready var _unit_info_bar: UnitInfoBar = $UnitInfoBar
+@onready var _skill_panel: SkillPanel = $SkillPanel
 @onready var _victory_panel: Control = $VictoryPanel
 @onready var _restart_button: Button = $VictoryPanel/RestartButton
 
@@ -47,6 +60,9 @@ var _flash_tweens := {}
 
 func _ready() -> void:
 	_restart_button.pressed.connect(restart_requested.emit)
+	_skill_panel.rank_up_requested.connect(skill_rank_up_requested.emit)
+	_skill_panel.toggled.connect(skill_panel_toggled.emit)
+	_skill_panel.toggled.connect(_on_skill_panel_toggled)
 	# The whole tree is paused while the victory panel is up — that is what makes
 	# the run over rather than merely won — and a paused Control is skipped by GUI
 	# input dispatch, which would leave the button dead under the cursor. This is
@@ -90,6 +106,28 @@ func set_skills(points: int, skills: Array) -> void:
 	# The points total is the only part that ever needs chasing: it is what turns
 	# a keypress from a no-op into a purchase.
 	_skills_label.modulate = Color(1, 0.85, 0.4) if points > 0 else Color(0.72, 0.76, 0.84)
+
+
+## The whole tree, for the panel (issue #62).
+##
+## Separate from [method set_skills] because they draw different things from
+## different reports — that one is the crib sheet for the two keys, this is every
+## node including the locked ones. They are refreshed together because both move
+## on the same two events, which is scenes/main.gd's business and not this
+## folder's.
+func set_skill_catalogue(points: int, catalogue: Array) -> void:
+	_skill_panel.set_catalogue(points, catalogue)
+
+
+## Banners come down when the skill panel goes up, the same rule the death and
+## victory screens keep — and this is the likeliest collision of the three rather
+## than a corner case. "LEVEL 7 — 1 skill point" is the banner that *tells* the
+## player to open this panel, so a player who does what it says immediately reads
+## it across the panel's own title. Measured on the first screenshot of the panel,
+## not reasoned about.
+func _on_skill_panel_toggled(open: bool) -> void:
+	if open:
+		_clear_flashes()
 
 
 ## Point the info bar at the selected unit. Connected to
@@ -140,6 +178,10 @@ func show_victory() -> void:
 	# of this folder, rather than something true only while a guard in another
 	# folder keeps it true.
 	hide_death()
+	# The skill panel goes down and stays down for the same reason, and one
+	# stronger: it freezes and unfreezes the tree, so closing it behind a victory
+	# screen would hand the player a won run they can still walk around in.
+	_skill_panel.set_unavailable()
 	_victory_panel.show()
 	# After show(), which is what makes the button focusable. Enter then works as
 	# well as a click, and by this point nothing else on screen takes input at all.

--- a/scenes/ui/hud.tscn
+++ b/scenes/ui/hud.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3]
+[gd_scene load_steps=4 format=3]
 
 [ext_resource type="Script" path="res://scenes/ui/hud.gd" id="1_hud"]
 [ext_resource type="PackedScene" path="res://scenes/ui/unit_info_bar.tscn" id="2_info_bar"]
+[ext_resource type="PackedScene" path="res://scenes/ui/skill_panel.tscn" id="3_skill_panel"]
 
 [node name="HUD" type="CanvasLayer"]
 script = ExtResource("1_hud")
@@ -91,7 +92,8 @@ theme_override_colors/font_color = Color(0.72, 0.76, 0.84, 1)
 text = "Right-click: move / attack
 Left-click: select a unit
 A + left-click: attack / attack-move
-1 / 2: spend a skill point"
+1 / 2: spend a skill point
+K: skill tree"
 
 [node name="DeathLabel" type="Label" parent="."]
 visible = false
@@ -127,6 +129,8 @@ theme_override_font_sizes/font_size = 20
 text = "Returning to the last checkpoint"
 horizontal_alignment = 1
 vertical_alignment = 1
+
+[node name="SkillPanel" parent="." instance=ExtResource("3_skill_panel")]
 
 [node name="VictoryPanel" type="Control" parent="."]
 visible = false

--- a/scenes/ui/skill_panel.gd
+++ b/scenes/ui/skill_panel.gd
@@ -1,0 +1,228 @@
+class_name SkillPanel
+extends Control
+## The skill tree as something a player can actually click (issue #62).
+##
+## Issue #9 landed the tree with no UI, which left four of its six nodes with no
+## way to be bought in play at all — `1` and `2` reach Strength and Health and
+## nothing reaches the rest. Inventing four more hotkeys would be a worse answer
+## than none, so this is the answer instead.
+##
+## [b]It formats and never interprets[/b], the same rule the skill line above it
+## keeps: every number and every sentence here comes from
+## [method Hero.skill_catalogue]. This script does not know what a rank buys, what
+## one costs, or why one cannot be bought — it knows how to lay six of them out
+## and which one was clicked. A new skill in the .tres therefore appears here with
+## no edit to this folder, which is the whole test of whether the split is real.
+##
+## [b]The layout is derived, not authored.[/b] Nodes are grouped into rows by
+## their prerequisite depth, so the row a node lands in follows from what it
+## requires. The alternative — a position per node, edited here — would have to be
+## touched every time game content gained a skill, which is exactly the coupling
+## the tree was designed to avoid. See [method SkillTree.depth].
+
+## The player clicked a node they want a rank of. Nothing here buys anything:
+## this folder does not own the points, the ledger, or the rules, and a widget
+## that spent them would be the second owner of all three. Same arrangement as
+## [signal HUD.restart_requested].
+signal rank_up_requested(skill: StringName)
+
+## The panel opened or closed. The tree is frozen while it is up and
+## `scenes/main.gd` is what freezes it — this only reports the change, for the
+## reason recorded on [signal HUD.restart_requested]: the pause flag lives on the
+## SceneTree rather than the scene, so exactly one script may own it.
+signal toggled(open: bool)
+
+const LOCKED_COLOR := Color(0.55, 0.58, 0.66)
+const OPEN_COLOR := Color(0.86, 0.88, 0.94)
+const AFFORDABLE_COLOR := Color(1, 0.85, 0.4)
+const MAXED_COLOR := Color(0.62, 0.84, 0.66)
+
+@onready var _rows: VBoxContainer = $Frame/Margin/Body/Rows
+@onready var _points_label: Label = $Frame/Margin/Body/Points
+
+## Refused while the run is over. The victory panel owns the screen at that point
+## and says so in its own folder doc; this keeps that true from here rather than
+## relying on nobody pressing the key.
+var _available := true
+
+
+func _ready() -> void:
+	# The tree is paused while this is up, and a paused node receives neither
+	# input nor GUI dispatch — which would leave the panel unable to close itself
+	# and every button dead under the cursor. Set here rather than in the scene
+	# file so the reason travels with the line, exactly as the victory panel does.
+	process_mode = Node.PROCESS_MODE_ALWAYS
+	hide()
+
+
+## [b]This folder reads one key, and this is it.[/b] Every other input action in
+## the project is consumed by `scenes/hero/`, because every other one is a command
+## to a unit. Opening a panel is not: it issues no order and changes nothing about
+## what the hero is doing, so routing it through the command scheme would put a
+## screen toggle in the file that owns attack-move.
+##
+## Safe alongside that scheme for the reason `scenes/ui/`'s doc already records
+## about the victory button: this is a keyboard action nothing else claims, not a
+## second listener on the mouse button the hero owns.
+func _unhandled_input(event: InputEvent) -> void:
+	if event.is_action_pressed(&"toggle_skills"):
+		toggle()
+		get_viewport().set_input_as_handled()
+	elif visible and event.is_action_pressed(&"cancel_command"):
+		# Escape closes it. The hero also treats Escape as "disarm", and both can
+		# run without conflicting — but only because this consumes the event, so
+		# closing the panel does not also reach into the game behind it.
+		close()
+		get_viewport().set_input_as_handled()
+
+
+func toggle() -> void:
+	if visible:
+		close()
+	elif _available:
+		open()
+
+
+func open() -> void:
+	if visible or not _available:
+		return
+	show()
+	toggled.emit(true)
+
+
+func close() -> void:
+	if not visible:
+		return
+	hide()
+	toggled.emit(false)
+
+
+## Take the panel down and keep it down. Called when the run is won: the victory
+## panel owns the screen from then on, and a skill tree openable behind it would
+## also unfreeze the game on the way out.
+func set_unavailable() -> void:
+	_available = false
+	close()
+
+
+## Redraw from the hero's own report of his tree.
+##
+## Rebuilt outright rather than patched in place. Redraws happen when a point is
+## earned or spent — rare, and never per-frame — and a rebuild cannot leave a card
+## showing a rank that was refunded or a refusal that has since been met. The
+## patched version would be faster and would have state to get wrong.
+func set_catalogue(points: int, catalogue: Array) -> void:
+	if not is_node_ready():
+		return
+	_points_label.text = "%d skill point%s to spend" % [points, "" if points == 1 else "s"]
+	_points_label.modulate = AFFORDABLE_COLOR if points > 0 else OPEN_COLOR
+	for row in _rows.get_children():
+		row.queue_free()
+		# Freed at the end of the frame, so a rebuild in the same frame would
+		# otherwise stack the new rows under the old ones.
+		_rows.remove_child(row)
+	for depth in _depths(catalogue):
+		_rows.add_child(_build_row(depth, catalogue))
+
+
+## The prerequisite depths present in [param catalogue], shallowest first. Read
+## off the data rather than assumed to be 0..n: a tree whose middle tier is empty
+## should draw as two rows, not three with a gap.
+func _depths(catalogue: Array) -> Array[int]:
+	var depths: Array[int] = []
+	for entry in catalogue:
+		var depth := int(entry.get("depth", 0))
+		if not depths.has(depth):
+			depths.append(depth)
+	depths.sort()
+	return depths
+
+
+func _build_row(depth: int, catalogue: Array) -> HBoxContainer:
+	var row := HBoxContainer.new()
+	row.alignment = BoxContainer.ALIGNMENT_CENTER
+	row.add_theme_constant_override(&"separation", 12)
+	for entry in catalogue:
+		if int(entry.get("depth", 0)) == depth:
+			row.add_child(_build_card(entry))
+	return row
+
+
+## One node: what it is, what it has bought, and a button that asks for the next
+## rank. Every string in here arrives ready to print.
+func _build_card(entry: Dictionary) -> Control:
+	var rank := int(entry.get("rank", 0))
+	var max_rank := int(entry.get("max_rank", 0))
+	var refusal := String(entry.get("refusal", ""))
+	var maxed := rank >= max_rank
+
+	var card := PanelContainer.new()
+	# A floor on the height, not a fixed one. Cards hold a wrapping description and
+	# an effect line that is empty until something is bought, so left to themselves
+	# they come out at three different heights in one row and the buttons sit at
+	# three different places. The spacer below pins the button to the bottom of
+	# whatever height the row settles on.
+	card.custom_minimum_size = Vector2(228, 140)
+
+	var body := VBoxContainer.new()
+	body.add_theme_constant_override(&"separation", 2)
+	card.add_child(body)
+
+	var heading := Label.new()
+	heading.text = "%s   %d/%d" % [entry.get("name", "?"), rank, max_rank]
+	heading.add_theme_font_size_override(&"font_size", 16)
+	# Three states worth telling apart at a glance, and the colours are the ones
+	# the skill line already uses for two of them: gold means a point would be
+	# taken right now, green means there is nothing left to buy here, grey means
+	# locked or unaffordable and the button says which.
+	if maxed:
+		heading.modulate = MAXED_COLOR
+	elif refusal.is_empty():
+		heading.modulate = AFFORDABLE_COLOR
+	else:
+		heading.modulate = LOCKED_COLOR if rank == 0 else OPEN_COLOR
+	body.add_child(heading)
+
+	var description := Label.new()
+	description.text = String(entry.get("description", ""))
+	description.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	description.add_theme_font_size_override(&"font_size", 12)
+	description.modulate = LOCKED_COLOR
+	body.add_child(description)
+
+	var bought := Label.new()
+	# Empty at rank 0, which is what describe() reports and the right answer: a
+	# node nothing has been spent on has bought nothing to list.
+	bought.text = String(entry.get("effect", ""))
+	bought.visible = not bought.text.is_empty()
+	bought.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	bought.add_theme_font_size_override(&"font_size", 12)
+	bought.modulate = OPEN_COLOR
+	body.add_child(bought)
+
+	var spacer := Control.new()
+	spacer.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	body.add_child(spacer)
+
+	body.add_child(_build_button(entry, refusal, maxed))
+	return card
+
+
+func _build_button(entry: Dictionary, refusal: String, maxed: bool) -> Button:
+	var button := Button.new()
+	button.disabled = not refusal.is_empty()
+	if maxed:
+		button.text = "Maxed"
+	elif refusal.is_empty():
+		button.text = "Buy — %d pt" % int(entry.get("cost", 0))
+	else:
+		button.text = refusal
+	# The next rank's effect, on the control that would buy it. describe() reports
+	# what a rank *has* bought, so the catalogue asks it for rank + 1 — a button
+	# advertising the current rank would read blank on everything unbought.
+	var next_effect := String(entry.get("next_effect", ""))
+	button.tooltip_text = next_effect if not next_effect.is_empty() else refusal
+	button.add_theme_font_size_override(&"font_size", 12)
+	var id: StringName = entry.get("id", &"")
+	button.pressed.connect(func() -> void: rank_up_requested.emit(id))
+	return button

--- a/scenes/ui/skill_panel.gd.uid
+++ b/scenes/ui/skill_panel.gd.uid
@@ -1,0 +1,1 @@
+uid://vllgyegxn8l

--- a/scenes/ui/skill_panel.tscn
+++ b/scenes/ui/skill_panel.tscn
@@ -1,0 +1,56 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scenes/ui/skill_panel.gd" id="1_panel"]
+
+[node name="SkillPanel" type="Control"]
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+script = ExtResource("1_panel")
+
+[node name="Dim" type="ColorRect" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.02, 0.03, 0.06, 0.72)
+
+[node name="Frame" type="PanelContainer" parent="."]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Margin" type="MarginContainer" parent="Frame"]
+theme_override_constants/margin_left = 28
+theme_override_constants/margin_top = 20
+theme_override_constants/margin_right = 28
+theme_override_constants/margin_bottom = 20
+
+[node name="Body" type="VBoxContainer" parent="Frame/Margin"]
+theme_override_constants/separation = 10
+
+[node name="Title" type="Label" parent="Frame/Margin/Body"]
+theme_override_colors/font_color = Color(0.86, 0.88, 0.94, 1)
+theme_override_font_sizes/font_size = 26
+text = "Skill tree"
+horizontal_alignment = 1
+
+[node name="Points" type="Label" parent="Frame/Margin/Body"]
+theme_override_font_sizes/font_size = 16
+text = "0 skill points to spend"
+horizontal_alignment = 1
+
+[node name="Rows" type="VBoxContainer" parent="Frame/Margin/Body"]
+theme_override_constants/separation = 12
+
+[node name="Hint" type="Label" parent="Frame/Margin/Body"]
+theme_override_colors/font_color = Color(0.55, 0.58, 0.66, 1)
+theme_override_font_sizes/font_size = 12
+text = "K or Escape to close — rows are prerequisite depth, top row is open from the start"
+horizontal_alignment = 1

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -208,4 +208,4 @@ children — `current`/`max_health` on one, and `level`/`xp`/`skill_points`,
 It reads no `scenes/ui/` node: nothing here asserts anything about the screen,
 including the XP bar #8 added.
 
-<!-- verified-against: 79c5b4d -->
+<!-- verified-against: 0bc0fe6 -->

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -24,7 +24,7 @@ placed one cell from a spawn.
 | `smoke_traversal.gd` | The hero walks start cell to boss room |
 | `smoke_combat.gd` | He kills, acquires his own targets, and heals afterwards |
 | `smoke_progression.gd` | Kills pay XP, levels pay points, and points pay stats |
-| `smoke_skills.gd` | The skill tree is sound, gates what it says, and sells nothing it must not |
+| `smoke_skills.gd` | The skill tree is sound, gates what it says, sells nothing it must not, and every node of it is reachable |
 
 ## Running them
 
@@ -154,6 +154,24 @@ PR, so the constraints run outward as well as in:
   Neither folder can see a `.tres` in a third one. Both are asserted against a
   **fully invested** hero — the test buys the whole tree out — because a cap is
   only worth checking at the cap.
+- **`smoke_skills.gd` also guards that the tree stays reachable** (issue #62).
+  Four of six nodes had no hotkey and so no way to be bought in play; the panel
+  answers that by drawing whatever `Hero.skill_catalogue()` hands it, which makes
+  that one report the whole of what a player can reach. Narrowing it to the bound
+  skills — which is exactly what `skill_summary()` beside it deliberately does —
+  would restore the bug **with the panel still on screen**. So the assertion is
+  that the catalogue lists strictly more than the keys reach, not merely that it
+  lists something. It also checks the tree falls into more than one prerequisite
+  tier, because a `SkillTree.depth()` returning a constant would collapse the
+  panel to one row and satisfy every other check here: the same "how would you
+  tell this from a function that does nothing" gap the cycle check exists for.
+- **It asserts all of that without reading a single `scenes/ui/` node**, which is
+  the deliberate part. Everything the panel prints comes from the hero, so the
+  hero is where it can be checked — and this folder's boundary below stays true.
+  What that leaves unproven is that the panel *renders*: a throwaway script drove
+  the real `HUD` for PR #62 and found two layout faults, and that script was not
+  kept. Issue #55 is the standing question of whether throwaways like it belong
+  here; this is a second data point for it.
 - **It also settled what that rule says**, which is the more interesting half.
   The check is per checkpoint over the placements a respawn *there* restores;
   three folder docs stated it over every placement on the map, and measuring it
@@ -168,8 +186,9 @@ Everything here is downstream and nothing depends on it, which is why the
 frontmatter above is long. It reads `scenes/main.tscn` and the startup order
 `scenes/` owns, the command API and `killed` signal of `scenes/hero/` — plus his
 skill API (`gain_experience`, `spend_skill_point`, `skill_rank`,
-`skill_refusal`, `skill_problems` and the `skill_tree` export) since issues #8
-and #9 — and through that export the read side of `scenes/skills/`
+`skill_refusal`, `skill_problems`, `skill_summary`, `skill_catalogue` and the
+`skill_tree` export) since issues #8, #9 and #62 — and through that export the
+read side of `scenes/skills/`
 (`SkillTree.ids`, `node`, `cost_of_next_rank`, `total_cost`, `validate`, and a
 node's `max_rank` / `requires` / `effects`; `requires` is also *written*, on a
 deep duplicate, to build the broken tree above). Also the

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -200,4 +200,4 @@ children — `current`/`max_health` on one, and `level`/`xp`/`skill_points`,
 It reads no `scenes/ui/` node: nothing here asserts anything about the screen,
 including the XP bar #8 added.
 
-<!-- verified-against: aeec030 -->
+<!-- verified-against: 79c5b4d -->

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -168,10 +168,18 @@ PR, so the constraints run outward as well as in:
 - **It asserts all of that without reading a single `scenes/ui/` node**, which is
   the deliberate part. Everything the panel prints comes from the hero, so the
   hero is where it can be checked — and this folder's boundary below stays true.
-  What that leaves unproven is that the panel *renders*: a throwaway script drove
-  the real `HUD` for PR #62 and found two layout faults, and that script was not
-  kept. Issue #55 is the standing question of whether throwaways like it belong
-  here; this is a second data point for it.
+  What that leaves unproven is anything about the screen itself, and PR #62 wrote
+  **two** throwaways against it rather than one. The first drove the real `HUD`
+  and, with a screenshot, found two layout faults. The second reproduced a
+  cross-review finding — a 1.2 s window after the boss dies in which the panel
+  could be opened over a still-running level — and was run against the code with
+  the fix backed out to prove it discriminated, which is the same discipline the
+  cycle check above owes. Neither was kept, and both reached into `scenes/ui/`
+  private members to do their work, which is exactly why they are not here.
+  **Issue #55 is the standing question of whether throwaways like these belong in
+  this folder; PR #62 is two more data points for it, and the second is the
+  stronger kind — a test that caught a real regression window rather than
+  confirming something already believed.**
 - **It also settled what that rule says**, which is the more interesting half.
   The check is per checkpoint over the placements a respawn *there* restores;
   three folder docs stated it over every placement on the map, and measuring it

--- a/tests/smoke_skills.gd
+++ b/tests/smoke_skills.gd
@@ -67,7 +67,52 @@ func _check() -> void:
 	check("and the hero's own tree was not the one edited",
 		hero.skill_problems().is_empty())
 
-	# --- 2. a gated node is refused until its prerequisite is met --------------
+	# --- 2. the panel is offered every node, not just the ones a key reaches ---
+	# Issue #62's entire content: four of the six nodes had no hotkey, so no way
+	# to be bought in play at all. The panel answers that by drawing the tree, and
+	# it draws exactly what `skill_catalogue()` hands it — nothing more is
+	# reachable than is listed here. A catalogue narrowed to the *bound* skills,
+	# which is what `skill_summary()` deliberately reports, would restore the bug
+	# with the panel still on screen and every other check in this file green.
+	var catalogue: Array[Dictionary] = hero.skill_catalogue()
+	var listed := {}
+	for entry in catalogue:
+		listed[entry["id"]] = true
+	var missing := PackedStringArray()
+	for id in tree.ids():
+		if not listed.has(id):
+			missing.append(String(id))
+	check("the panel is offered every node in the tree", missing.is_empty(),
+		"missing %s" % ", ".join(missing))
+	var bound: int = hero.skill_summary().size()
+	check("including the ones no hotkey reaches", catalogue.size() > bound,
+		"%d in the tree against %d the keys reach" % [catalogue.size(), bound])
+
+	# The panel formats and never interprets, so a card is only as right as this
+	# report. Checked against the hero's own answers rather than trusted.
+	var disagreements := PackedStringArray()
+	for entry in catalogue:
+		var id: StringName = entry["id"]
+		if String(entry["refusal"]) != hero.skill_refusal(id):
+			disagreements.append("%s refusal" % id)
+		if int(entry["rank"]) != hero.skill_rank(id):
+			disagreements.append("%s rank" % id)
+		if int(entry["cost"]) != tree.cost_of_next_rank(id):
+			disagreements.append("%s cost" % id)
+	check("and what it says of each agrees with the hero", disagreements.is_empty(),
+		"; ".join(disagreements))
+
+	# The panel's rows are prerequisite depth, so a depth() that returned a
+	# constant would draw one row and still satisfy everything above — the same
+	# "how would you tell it from a function that does nothing" gap the cycle
+	# check above exists to close.
+	var tiers := {}
+	for entry in catalogue:
+		tiers[int(entry["depth"])] = true
+	check("and they fall into more than one prerequisite tier", tiers.size() > 1,
+		"tiers %s" % str(tiers.keys()))
+
+	# --- 3. a gated node is refused until its prerequisite is met --------------
 	# Funded first and deliberately overfunded, so what refuses the purchase is
 	# the prerequisite and not an empty pool. Those are the two refusals, and a
 	# test that cannot tell them apart proves neither.
@@ -85,7 +130,7 @@ func _check() -> void:
 			return
 	check("meeting the prerequisite opens it", hero.skill_refusal(&"reach").is_empty())
 
-	# --- 3. a node costs what it says it costs --------------------------------
+	# --- 4. a node costs what it says it costs --------------------------------
 	var cost: int = tree.cost_of_next_rank(&"reach")
 	var points_before: int = hero.experience.skill_points
 	check("the gated skill costs more than one point", cost > 1, "%d points" % cost)
@@ -94,7 +139,7 @@ func _check() -> void:
 		hero.experience.skill_points == points_before - cost,
 		"%d -> %d points" % [points_before, hero.experience.skill_points])
 
-	# --- 4. buying the whole tree ---------------------------------------------
+	# --- 5. buying the whole tree ---------------------------------------------
 	# Every node to its cap, in whatever order the sweep reaches them. That the
 	# order does not matter is the fold's property, not an accident: adds are
 	# summed against the authored base and scales multiply what is left.
@@ -116,7 +161,7 @@ func _check() -> void:
 		not hero.spend_skill_point(&"strength"),
 		hero.skill_refusal(&"strength"))
 
-	# --- 5. what a full build must still not be able to do --------------------
+	# --- 6. what a full build must still not be able to do --------------------
 	# See the header. Both numbers belong to other folders; this is the only
 	# place either is checked against what the tree sells.
 	var boss = _boss()

--- a/tests/smoke_skills.gd.uid
+++ b/tests/smoke_skills.gd.uid
@@ -1,0 +1,1 @@
+uid://bjq8pl5khbh7b


### PR DESCRIPTION
Fixes #62.

Issue #9 landed the skill tree with no UI, which left **four of its six nodes with no way to be bought in play at all**: `1` and `2` reach Strength and Health, and nothing reached Swiftness, Reach, Frenzy or Recovery. The game's central customization system was two-thirds invisible on the playable link. Four more hotkeys would have been a worse answer than none, so this is a panel — `K` to open, `K` or `Escape` to close, one card per node.

## The shape, and why it is this shape

**The panel formats and never interprets.** That is `scenes/ui/`'s existing rule and it is what decided the design. `Hero.skill_catalogue()` is a new whole-tree counterpart to `skill_summary()`, reporting every node with everything a card prints: cost, rank, refusal, the authored `description`, and what the *next* rank would buy. Nothing in `scenes/ui/` knows what a rank does, so **a new skill in the `.tres` appears on screen with no edit to that folder**.

Two existing pieces did more work than expected here, both flagged by the issue:

- `SkillTree.refusal()` already returned *why* a node cannot be bought, so "Reach needs Strength 3" on a disabled button is game content, not a string built in the UI.
- `SkillNode.description` was authored and read by nothing. It is now the card body.

**The layout is derived, not authored.** Cards group into rows by a new `SkillTree.depth()` — prerequisite depth, not a position. The issue left this call open; authored positions would have to be edited in `scenes/ui/` every time game content gained a skill, which is exactly the coupling the tree was designed to avoid. A node still carries no coordinates, and whether a panel turns depths into rows, columns or rings stays the panel's business.

**Buying and pausing both go back out to `scenes/main.gd`**, on the terms `HUD.restart_requested` already established: `scenes/ui/` owns neither the points nor the pause flag. Purchases go through the same `spend_skill_point()` the `1` and `2` keys use, refusals and all.

## Decisions I made that the issue left open

Both are cheap to reverse — say the word and I will.

- **The panel pauses the run.** Choosing a build is a considered decision and the zombies do not wait; a tree readable only when nothing is chasing you is unusable at the exact moment a level is banked. It follows the victory panel's precedent (`PROCESS_MODE_ALWAYS`, pause owned by `scenes/main.gd`).
- **`K`, and it is the first input action consumed outside `scenes/hero/`.** That folder owns every other action because every other action is a command to a unit; opening a panel issues no order. `Escape` is shared with `cancel_command` — the panel consumes the event when open, so closing it does not also disarm an attack in the game behind it.

## Testing

`smoke_skills.gd` gains four checks, and the shape of them is deliberate:

- The catalogue lists **strictly more than the keys reach** (6 against 2), not merely that it lists something. Narrowing it back to the bound skills is exactly how this bug returns *with the panel still on screen*, and that is the regression worth a test.
- The tree falls into **more than one prerequisite tier**, because a `depth()` returning a constant would collapse the panel to one row and satisfy every other check here. Same "how would you tell this from a function that does nothing" gap the cycle check exists to close.

Full suite green (60 checks). Note `tests/` still reads **no `scenes/ui/` node** — everything the panel prints comes from the hero, so the hero is where it is checked, and that folder's stated boundary holds.

**What that leaves unproven is that the panel renders**, so I drove the real `HUD` with a throwaway script and then screenshotted it. Both were worth doing:

- The throwaway caught nothing broken but confirmed the wiring end to end — 6 cards in 2 rows, 3 enabled, clicking one buys a rank, the rebuild does not stack rows, pause and unpause land.
- **The screenshot caught two faults reasoning had not.** The level-up banner sat straight across the panel's title — and that is the *common* path, since "LEVEL 7 — 1 skill point" is the banner that tells you to open it. And uneven card heights left the buy buttons unaligned within a row. Both fixed; this is #53's lesson paying out again.

Neither script is kept. Whether they should be is issue #55's standing question, and this is a second data point for it.

## Docs

Seven docs flagged by the `depends-on` graph, which is the measured price for a change touching five code folders. Five were being edited anyway. Two needed cold re-reads and **one of them turned something up**:

- **`scenes/enemies/`** discusses two margins against a maxed hero — the 2.8-against-3.0 reach gap, and 7 HP/s against the boss's 12 for a full Recovery build. Both were written as though a player could get there. **`reach` and `recovery` are two of the four nodes that had no hotkey**, so until this PR those were builds only `smoke_skills.gd` ever constructed. No number moved; the table now describes encounters rather than test fixtures, and that is worth saying where the numbers live.
- **`scenes/map/`** was read and needed nothing — its clearance contract rests on `acquire_radius`, still not sellable, still asserted from both ends.

`scenes/ui/` gains a `depends-on` edge to `scenes/skills/`, and the doc says plainly that it is a weaker edge than the others: no script there imports anything from that folder, but this doc now *claims* the rows are prerequisite depth and the refusal text is the tree's own. Change what `depth()` means and no code breaks while the doc quietly stops being true — which is the drift the edge exists to flag.

## Two things worth flagging to a reviewer

- **The root `CLAUDE.md` edit is forced, not earned.** `project.godot` changed (one input action), and `docs-check` requires a root edit for that — but the root explicitly does *not* own the input-action registry; `scenes/CLAUDE.md` does. This is issue #40 exactly, so rather than invent something, I recorded the instance in the enforcement section. Happy to take a different edit if you would rather.
- **`tests/smoke_skills.gd.uid` is committed here** and is unrelated to this change. PR #61 left it untracked while every other script in the repo has its `.uid` tracked; `--import` regenerates it, so it shows up as noise on any branch. Say if you would rather it went separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
