### PR TITLE
Say when a stat moves, so the info bar stops showing the old one

### DIFF
--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -332,6 +332,14 @@ describes. See `scenes/enemies/CLAUDE.md`.
   the way, `HUD.show_death()` / `hide_death()` / `flash_checkpoint()` —
   plus `HUD.show_victory()` when the boss falls. It consumes
   `HUD.restart_requested` in return.
+- **Not every hero signal `scenes/ui/` uses comes through here**, and issue #65
+  added the second one. That folder subscribes directly to whatever unit is
+  *selected* — its `Health.health_changed` and `died` since #36, and its
+  `stats_changed` now — because this script does not know what is selected and
+  a wire through it would need a second record of that. The rule this folder
+  keeps is narrower than it looks: what `main.gd` owns is the wiring of the
+  **hero as the hero**, and a widget reading the unit it is currently drawing is
+  not that.
 - `main.gd` consumes `Hero.died`, `Hero.health.health_changed`,
   `Hero.attack_move_armed_changed` and `Hero.select_clicked`, forwarding each to
   `scenes/ui/`. Since issue #8 it also consumes `Hero.killed` and
@@ -355,4 +363,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: f285e52 -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -271,7 +271,14 @@ wider than this will not.
   and a victim without the property is worth nothing rather than an error.
 - **Describes itself to the unit info bar** through `unit_info()` and the
   `display_name` export (per-instance like every stat, so the boss-room guard
-  the class docs describe can announce itself without a new scene). The travel
+  the class docs describe can announce itself without a new scene).
+  **It does not emit `stats_changed`**, the optional fourth member issue #65
+  added to that contract, and the absence is a decision rather than an omission:
+  nothing moves a zombie's numbers after it spawns, so there is never a stale row
+  to redraw. The hero has one because a skill point moves his mid-run. Anything
+  here that ever gains a buff, an enrage or a scaling stat owes the signal —
+  without it the panel silently shows the numbers the thing spawned with, which
+  reads as a balance question rather than a UI one. The travel
   speed it reports is `chase_speed`, not `roam_speed`: what a player wants when
   they click a zombie is how fast it closes on them. Selecting a zombie does
   nothing to it — `scenes/ui/` never issues an order. That folder also watches
@@ -297,4 +304,4 @@ wider than this will not.
   the boss has no model of its own at all, so whatever it eventually wears is a
   separate question from what the horde does.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: f285e52 -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -135,6 +135,23 @@ decisions rather than gaps:
 bar. Display-only, and the hero picks *which* of his numbers is the interesting
 one — see the contract in `scenes/ui/CLAUDE.md`.
 
+**And since issue #65 he says when those numbers move**, with `stats_changed`.
+A report alone is a snapshot: `scenes/ui/` reads it once when a unit is selected
+and cannot notice a value changing afterwards, so buying a rank of Strength left
+the old damage on screen until the player selected another unit and came back.
+The signal is `Health.health_changed` for the rest of the row, and it is
+**emitted from `_apply_skills()` rather than from `spend_skill_point()`** — the
+fold is the one place a sellable stat is written, so an item, a buff or a respec
+moving one announces itself through the same signal with nothing new wired up.
+It carries no payload for the same reason `unit_info()` exists: a listener
+re-asks, rather than being told which numbers it should care about.
+
+Two things it is deliberately not. It is **not** `skill_ranked_up`, which says a
+*rank* was bought and is what pays the HUD's skill line — a stat can move without
+a purchase, and the reverse is what a behaviour-grant skill would be. And it is
+**not** emitted at `_ready()`, where the fold does not run: the authored values
+are what a fresh selection already reads.
+
 Measured 1v1 against one zombie: ~18 HP lost per kill, ~6 s of fighting.
 
 **The end boss inverts the reach advantage deliberately** (issue #39): its 3.0
@@ -394,6 +411,8 @@ to touch. `tests/smoke_progression.gd` asserts it directly.
   which `scenes/main.gd` answers with `respawn_at()` at the armed checkpoint.
   Emits `skill_ranked_up(skill, rank)` **after** the stat it bought has been
   applied, so a listener reads the new numbers rather than the old ones.
+  Emits `stats_changed` from the fold itself (issue #65), consumed by
+  `scenes/ui/` — see below.
   Consumes `Health.died` from its own child, and calls `Health.revive()` on the
   way back.
 - **The skill tree is a resource, not a node** (`scenes/skills/`), preloaded as

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -433,4 +433,4 @@ to touch. `tests/smoke_progression.gd` asserts it directly.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: f285e52 -->

--- a/scenes/hero/hero.gd
+++ b/scenes/hero/hero.gd
@@ -49,6 +49,23 @@ signal killed(victim: Node3D)
 ## been applied, so a listener reads the new numbers rather than the old ones.
 signal skill_ranked_up(skill: StringName, rank: int)
 
+## Emitted when the numbers [method unit_info] reports have been recomputed, so
+## anything drawing them can redraw (issue #65).
+##
+## [b]This is [signal Health.health_changed] for the stats beside the bar[/b], and
+## it exists for the same reason: a panel cannot notice a value changing under it.
+## Without one, the info bar read [method unit_info] once at selection and kept
+## showing the damage the hero had before a rank was bought, until the player
+## selected something else and came back.
+##
+## Deliberately says *that* they moved and not *why*. It fires from the fold —
+## the one place every sellable stat is written — rather than from the purchase
+## that triggered it, so an item, a buff or a respec moving a stat later announces
+## itself through this with nothing new wired up. That is also why it carries no
+## payload: a reader re-asks [method unit_info], which is the report that decides
+## which numbers are worth showing in the first place.
+signal stats_changed
+
 ## Emitted when the attack command is armed or disarmed, so the HUD can show
 ## the player that the next left-click means "attack" rather than "select".
 signal attack_move_armed_changed(armed: bool)
@@ -477,6 +494,11 @@ func _apply_skills() -> void:
 		var added := float(_stat_added.get(stat, 0.0))
 		var scaled := float(_stat_scaled.get(stat, 1.0))
 		_write_stat(stat, (base + added) * scaled)
+	# After every write, so a listener re-reading unit_info() gets the new numbers
+	# rather than a half-folded set. Emitted from here rather than from
+	# spend_skill_point() because this is the only place a sellable stat moves —
+	# see the note on the signal.
+	stats_changed.emit()
 
 
 func _read_stat(stat: StringName) -> float:

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -334,4 +334,4 @@ contiguous run of open cells without changing what the player sees.
   `scenes/hero/`, which is why it is in the frontmatter above. `Checkpoint`
   never names `Hero` as a type.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: f285e52 -->

--- a/scenes/skills/CLAUDE.md
+++ b/scenes/skills/CLAUDE.md
@@ -92,6 +92,12 @@ thing that knows what a stat name means.
 - **An actor that uses a tree must provide `add_stat(stat, amount)` and
   `scale_stat(stat, factor)`**, and must recompute from authored bases rather
   than accumulating — `apply()` runs on every recompute, not once per purchase.
+  **The fold is idempotent in its values and not in its announcements**, which
+  issue #65 is the first thing to rely on: `scenes/hero/` emits `stats_changed`
+  at the end of it, so running it twice writes the same numbers and says so
+  twice. That is the harmless direction — a listener redraws what it already
+  drew — but an actor that ever hangs something *costly* off the recompute owns
+  that cost, not this folder.
 - **It must check `stats_used()` against the stats it accepts.** Stat names are
   strings; this is what makes a typo a load-time complaint rather than a point
   spent on nothing.
@@ -146,4 +152,4 @@ plain `Resource` scripts. The declared edge on `scenes/hero/` is about the
 `scenes/hero/` is the only consumer today: it owns the ledger, the fold, and the
 key bindings. `tests/smoke_skills.gd` drives the tree through him.
 
-<!-- verified-against: 79c5b4d -->
+<!-- verified-against: f285e52 -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -336,7 +336,8 @@ difference worth stating rather than assuming.
   component of one. Subscribed and dropped with the selection, exactly as the
   other two are, and not wired through `scenes/main.gd` for the reason that
   folder's doc gives: it does not know what is selected, so a wire through it
-  would be a second record of something this folder already holds. `scenes/main.gd` also calls `set_hero_health()`,
+  would be a second record of something this folder already holds.
+- `scenes/main.gd` also calls `set_hero_health()`,
   `set_attack_move_armed()`, `show_death()` / `hide_death()`,
   `flash_checkpoint()` and `show_victory()` — the last two from
   `Checkpoint.reached` and the boss's `Zombie.died`, the only HUD calls that do

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -331,7 +331,12 @@ difference worth stating rather than assuming.
 - Instanced by `scenes/main.tscn`; `UnitSelection.hero` is wired from there as a
   `NodePath`, the way the camera's `target` is.
 - Consumes `Hero.select_clicked`, and `Health.health_changed` / `Health.died` on
-  whatever is selected. `scenes/main.gd` also calls `set_hero_health()`,
+  whatever is selected — plus `stats_changed` on the same unit since issue #65,
+  which is the first signal this folder takes from a *unit* rather than from a
+  component of one. Subscribed and dropped with the selection, exactly as the
+  other two are, and not wired through `scenes/main.gd` for the reason that
+  folder's doc gives: it does not know what is selected, so a wire through it
+  would be a second record of something this folder already holds. `scenes/main.gd` also calls `set_hero_health()`,
   `set_attack_move_armed()`, `show_death()` / `hide_death()`,
   `flash_checkpoint()` and `show_victory()` — the last two from
   `Checkpoint.reached` and the boss's `Zombie.died`, the only HUD calls that do
@@ -357,4 +362,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: f285e52 -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -55,6 +55,7 @@ provides:
 | `unit_info() -> Dictionary` | `name`, `damage`, `attack_cooldown`, `move_speed` |
 | a `Health` child (`scenes/components/`) | the HP bar, and the death fallback |
 | `is_dead()` | refusing to select a corpse |
+| `stats_changed` *(optional)* | redrawing the stats row when a number moves |
 
 No class is named here, so a boss or a second enemy type needs no change in this
 folder — but the three above are a real runtime contract, which is why
@@ -73,6 +74,24 @@ properties**, because the property that matters differs per actor: the hero's
 travel speed is his `move_speed`, a zombie's is its *chase* speed, and only they
 know which of theirs is worth showing. Missing keys render as a dash rather than
 failing, so a partial reporter is safe.
+
+**The fourth member is optional, and the reason it exists is worth keeping**
+(issue #65). `unit_info()` is a *snapshot*, and this folder had no way to notice
+one going stale: the row was drawn once when a unit was selected, so buying a
+rank of Strength left the old damage on screen until the player selected
+something else and came back. The HP bar never had the bug, because it was
+subscribed to `Health.health_changed` all along — `stats_changed` is that same
+arrangement for the rest of the row, subscribed to while a unit is shown and
+dropped when the selection moves on.
+
+Optional rather than required, on the folder's existing habit of degrading:
+nothing about a zombie's numbers moves today, and a unit that never emits is one
+whose row never needs redrawing — which is exactly the old behaviour, so a unit
+without it is no worse off than every unit was before. **What the option costs is
+that a future actor whose stats move and which forgets to emit is silently
+wrong**, and it looks like a balance bug rather than a UI one. That is the same
+trade the missing-keys dash makes, and it is why the constant naming the signal
+is written once in `unit_info_bar.gd` rather than three times.
 
 ## The hero owns the left mouse button, not this folder
 

--- a/scenes/ui/unit_info_bar.gd
+++ b/scenes/ui/unit_info_bar.gd
@@ -3,7 +3,7 @@ extends PanelContainer
 ## The bottom-of-screen panel describing the selected unit (issue #36): its
 ## name, live hit points, and the three numbers that decide a fight.
 ##
-## It reads a unit through two duck-typed hooks and never names Hero or Zombie:
+## It reads a unit through three duck-typed hooks and never names Hero or Zombie:
 ##
 ## - [code]unit_info() -> Dictionary[/code] for the display name and the stats,
 ##   so a unit reports its own numbers rather than this panel guessing which
@@ -12,11 +12,25 @@ extends PanelContainer
 ##   one worth showing.
 ## - a [code]Health[/code] child for the bar, subscribed to while it is shown so
 ##   damage lands on screen as it happens.
+## - an optional [code]stats_changed[/code] signal, subscribed to on the same
+##   terms so a stat moving under this panel lands on screen too (issue #65).
+##
+## [b]Both subscriptions exist for one reason: nothing here can notice a value
+## changing by itself.[/b] The stats row used to be read once at selection and
+## never again, so buying a rank of Strength left the old damage on screen until
+## the player selected another unit and came back. A unit that never emits is
+## simply one whose row never needs redrawing, which is why the hook is optional
+## rather than a fourth required member of the contract.
 ##
 ## Keys are read with defaults, so a unit that reports only some of them shows
 ## a dash for the rest instead of failing.
 
 const UNKNOWN := "—"
+
+## The optional hook above. Named once because it is used three times — connect,
+## disconnect, and the guard on each — and a typo in any of them would fail
+## silently, leaving exactly the stale row this was written to fix.
+const STATS_CHANGED := &"stats_changed"
 
 var _unit: Node3D = null
 var _health: Health = null
@@ -38,13 +52,9 @@ func show_unit(unit: Node3D) -> void:
 		hide()
 		return
 
-	var info: Dictionary = _unit.call("unit_info")
-	_name_label.text = str(info.get("name", "Unit"))
-	_stats_label.text = "DMG %s     ATK SPD %s     SPEED %s" % [
-		_format_number(info.get("damage")),
-		_format_attack_speed(info.get("attack_cooldown")),
-		_format_number(info.get("move_speed")),
-	]
+	_draw_stats()
+	if _unit.has_signal(STATS_CHANGED):
+		_unit.connect(STATS_CHANGED, _draw_stats)
 
 	_health = _unit.get("health") as Health
 	if _health != null:
@@ -55,17 +65,40 @@ func show_unit(unit: Node3D) -> void:
 	show()
 
 
+## Draw the name and the stats row from the unit's own report.
+##
+## Re-read every time rather than cached, which is the whole of the fix for issue
+## #65: a stat can move while the selection does not, so the values this row was
+## drawn from are not the values the unit currently has.
+func _draw_stats() -> void:
+	if not is_instance_valid(_unit):
+		return
+	var info: Dictionary = _unit.call("unit_info")
+	_name_label.text = str(info.get("name", "Unit"))
+	_stats_label.text = "DMG %s     ATK SPD %s     SPEED %s" % [
+		_format_number(info.get("damage")),
+		_format_attack_speed(info.get("attack_cooldown")),
+		_format_number(info.get("move_speed")),
+	]
+
+
 ## is_instance_valid, not a null check, for the reason UnitSelection records: a
 ## unit can leave the level without dying, so this can be holding a freed Health
 ## — a reference that is non-null and unusable at once. Ordering in
 ## scenes/main.gd happens to redirect the panel before anything is freed, but
 ## that protection lives in another folder, and the sibling class does not lean
 ## on it.
+##
+## Called before _unit is reassigned, so both disconnects still name the unit
+## they were made against.
 func _unsubscribe() -> void:
 	if is_instance_valid(_health) and _health.health_changed.is_connected(_on_health_changed):
 		_health.health_changed.disconnect(_on_health_changed)
 	_health = null
 	_hp_bar.show()
+	if is_instance_valid(_unit) and _unit.has_signal(STATS_CHANGED) \
+			and _unit.is_connected(STATS_CHANGED, _draw_stats):
+		_unit.disconnect(STATS_CHANGED, _draw_stats)
 
 
 func _on_health_changed(current: float, maximum: float) -> void:

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -24,7 +24,7 @@ placed one cell from a spawn.
 | `smoke_traversal.gd` | The hero walks start cell to boss room |
 | `smoke_combat.gd` | He kills, acquires his own targets, and heals afterwards |
 | `smoke_progression.gd` | Kills pay XP, levels pay points, and points pay stats |
-| `smoke_skills.gd` | The skill tree is sound, gates what it says, sells nothing it must not, and every node of it is reachable |
+| `smoke_skills.gd` | The skill tree is sound, gates what it says, sells nothing it must not, every node of it is reachable, and a stat that moves says so |
 
 ## Running them
 
@@ -165,6 +165,16 @@ PR, so the constraints run outward as well as in:
   tier, because a `SkillTree.depth()` returning a constant would collapse the
   panel to one row and satisfy every other check here: the same "how would you
   tell this from a function that does nothing" gap the cycle check exists for.
+- **`smoke_skills.gd` also holds the seam a screen bug was fixed on** (issue
+  #65). `scenes/ui/` reads `unit_info()` once at selection, so a stat moving
+  under it left the bar showing the pre-purchase damage; the hero now emits
+  `stats_changed` from his fold. What is asserted is not that the signal fires
+  but **when** — a listener redrawing from it must already be able to read the
+  new value, since a signal emitted before the write would leave the panel
+  permanently one purchase behind and looking exactly like the original bug. This
+  is the boundary case below in miniature: the invariant lives on the screen, the
+  only half of it checkable from here lives on the hero, and the difference is
+  worth knowing rather than papering over.
 - **It asserts all of that without reading a single `scenes/ui/` node**, which is
   the deliberate part. Everything the panel prints comes from the hero, so the
   hero is where it can be checked — and this folder's boundary below stays true.
@@ -195,7 +205,8 @@ frontmatter above is long. It reads `scenes/main.tscn` and the startup order
 `scenes/` owns, the command API and `killed` signal of `scenes/hero/` — plus his
 skill API (`gain_experience`, `spend_skill_point`, `skill_rank`,
 `skill_refusal`, `skill_problems`, `skill_summary`, `skill_catalogue` and the
-`skill_tree` export) since issues #8, #9 and #62 — and through that export the
+`skill_tree` export) since issues #8, #9 and #62, and his `unit_info()` report
+plus the `stats_changed` signal since #65 — and through that export the
 read side of `scenes/skills/`
 (`SkillTree.ids`, `node`, `cost_of_next_rank`, `total_cost`, `validate`, and a
 node's `max_rank` / `requires` / `effects`; `requires` is also *written*, on a

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -219,4 +219,4 @@ children — `current`/`max_health` on one, and `level`/`xp`/`skill_points`,
 It reads no `scenes/ui/` node: nothing here asserts anything about the screen,
 including the XP bar #8 added.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: f285e52 -->

--- a/tests/smoke_skills.gd
+++ b/tests/smoke_skills.gd
@@ -139,7 +139,32 @@ func _check() -> void:
 		hero.experience.skill_points == points_before - cost,
 		"%d -> %d points" % [points_before, hero.experience.skill_points])
 
-	# --- 5. buying the whole tree ---------------------------------------------
+	# --- 5. a stat that moves says so -----------------------------------------
+	# Issue #65. `scenes/ui/` reads unit_info() once, when a unit is selected, and
+	# has no way to notice a number changing under it — so the bar kept showing the
+	# damage the hero had before a rank was bought until the player selected
+	# something else and came back. `stats_changed` is the fix, and the half worth
+	# asserting is not *that* it fires but *when*: a listener redrawing from it has
+	# to be able to read the new value already, or the panel sits permanently one
+	# purchase behind and looks identical to the bug it replaced.
+	#
+	# Asserted here and not against the panel, because this folder reads no
+	# scenes/ui/ node — see its doc, and issue #55 for whether that should change.
+	var heard := {"count": 0, "damage": 0.0}
+	var on_stats := func() -> void:
+		heard["count"] += 1
+		heard["damage"] = float(hero.unit_info().get("damage", 0.0))
+	hero.connect(&"stats_changed", on_stats)
+	var damage_before := float(hero.unit_info().get("damage", 0.0))
+	var announced: bool = hero.spend_skill_point(&"strength")
+	check("buying a rank announces that the stats moved",
+		announced and heard["count"] == 1, "%d emission(s)" % heard["count"])
+	check("and a listener already reads the new number rather than the old one",
+		heard["damage"] > damage_before,
+		"%.1f -> %.1f dmg" % [damage_before, heard["damage"]])
+	hero.disconnect(&"stats_changed", on_stats)
+
+	# --- 6. buying the whole tree ---------------------------------------------
 	# Every node to its cap, in whatever order the sweep reaches them. That the
 	# order does not matter is the fold's property, not an accident: adds are
 	# summed against the authored base and scales multiply what is left.
@@ -161,7 +186,7 @@ func _check() -> void:
 		not hero.spend_skill_point(&"strength"),
 		hero.skill_refusal(&"strength"))
 
-	# --- 6. what a full build must still not be able to do --------------------
+	# --- 7. what a full build must still not be able to do --------------------
 	# See the header. Both numbers belong to other folders; this is the only
 	# place either is checked against what the tree sells.
 	var boss = _boss()


### PR DESCRIPTION
Found in playtesting: buy a rank of Strength and the unit info bar keeps showing
the old damage, until you select some other unit and select the hero back.

Fixes #65.

## What was wrong

Two things, and neither is the skill panel — this reproduces with the `1` and `2`
keys alone and has done since #8. #62 made it four times easier to hit by making
the panel the normal way to spend a point.

- `UnitInfoBar.show_unit()` read `unit_info()` **once** and then subscribed only
  to `Health.health_changed`. The DMG / ATK SPD / SPEED row was a snapshot.
- `UnitSelection.select_unit()` returns early when the unit is already selected,
  so the ordinary "click the ground to get back to the hero" fallback does not
  re-emit `selection_changed`. Hence a click away *and back* rather than one
  click — which is what made it look like a selection bug rather than a stale
  read.

The HP bar never had it, because it has been subscribed to `health_changed` all
along. That asymmetry is also why buying **Health** looked like it worked while
buying **Strength** looked like it did nothing.

## The fix

The hero emits `stats_changed`; the info bar subscribes to it on the unit it is
showing, beside the `Health` subscription it already had, and re-reads
`unit_info()` when it fires.

Three decisions in that worth reviewing:

- **Emitted from `_apply_skills()`, not from `spend_skill_point()`.** The fold is
  the one place a sellable stat is written, so an item, a buff or a respec moving
  one later announces itself with nothing new wired up. The alternative — having
  `scenes/main.gd` push a refresh on `skill_ranked_up` — puts a fact about the
  hero in a third folder, and goes stale silently the first time anything else
  moves a stat.
- **No payload.** A listener re-asks `unit_info()`, which is the report that
  already decides which numbers are worth showing. Handing over values would make
  this a second, competing answer to that question.
- **Optional on the unit contract.** Nothing moves a zombie's numbers after it
  spawns, so a unit that never emits is one whose row never needs redrawing —
  which is the old behaviour rather than a new fault. The cost is recorded in
  both folder docs: a future actor whose stats move and which forgets to emit is
  silently wrong, and it reads as a balance bug rather than a UI one.

## Test

`smoke_skills.gd` gains section 5. The assertion that matters is not that the
signal fires but **when**: a listener has to be able to read the new value
already, because a signal emitted before the write would leave the panel
permanently one purchase behind and looking identical to the original bug. It
measures `18.0 -> 20.0 dmg` read from inside the handler.

Asserted on the hero rather than against the panel, because `tests/` reads no
`scenes/ui/` node — see that folder's doc, and #55 for whether that boundary
should move. Worth being explicit that this leaves the actual redraw unproven by
CI; it was verified by playing the change.

## Docs

Second commit is the `depends-on` fan-out: **seven** docs flagged for a two-file
change, the widest yet, because the hero and the UI are each depended on by most
of the tree and this touched both. Four had something to correct beyond a stamp —
`scenes/` (the wiring rule is narrower than it reads), `scenes/enemies/` (a
zombie's silence is now a decision), `scenes/skills/` (the fold is idempotent in
its values, not its announcements), `scenes/ui/` (first signal taken from a unit
rather than a component). `scenes/map/` had nothing: its claim on the hero is the
respawn clearance measured against `acquire_radius`, untouched here.

## Checks

Full smoke suite green locally (25 checks in `smoke_skills.gd`), docs hook and
`--audit` both clean.
