### PR TITLE
Give the boss numbers a reachable build can beat

### DIFF
--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -355,4 +355,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: 3e0c926 -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -363,4 +363,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 3e0c926 -->
+<!-- verified-against: f72a398 -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -113,8 +113,8 @@ change in `scenes/ui/`, because a unit describes itself to the info bar through
 
 | Export | Zombie | Boss | Why the boss's value |
 |--------|--------|------|----------------------|
-| `max_health` (on `Health`) | 30 | 240 | 20 hero swings — a fight with a shape, not a slog |
-| `attack_damage` | 9 | 25 | four hits kill a full-health hero |
+| `max_health` (on `Health`) | 30 | 190 | 16 hero swings — a fight with a shape, not a slog |
+| `attack_damage` | 9 | 18 | six hits kill a full-health hero |
 | `attack_cooldown` | 1.3 | 2.0 | the damage is huge, so it has to be dodgeable |
 | `attack_range` | 2.0 | 3.0 | **longer than the hero's 2.2** — see below |
 | `chase_speed` | 3.4 | 2.2 | slow enough that kiting is a real option |
@@ -176,8 +176,76 @@ changed is that they are now *encountered*. If either turns out to be wrong, it
 will be wrong in play rather than in a test, which is the first time that has
 been true of this table.
 
-The stats are a first pass and are meant to be argued with: nothing in the game
-was balanced against an end boss before there was one.
+## The first pass was unwinnable, and what measuring it settled (issue #66)
+
+The line below used to end this section by saying the stats were a first pass
+meant to be argued with. Playtesting made the argument: **no build a player can
+reach could kill the boss**, so the run could not be finished, and every check in
+the repo stayed green while that was true. What follows is measured against the
+real scene rather than reasoned about, which is the only reason it is trustworthy
+— the arithmetic done first got the level's XP yield wrong by nearly double.
+
+**What the level actually pays is 3 skill points.** 19 `Z` cells at 10 XP each is
+190 XP, which is level 4. Every estimate of this fight has to start there and not
+from the 26-point full build, which is level 27 and exists only in
+`tests/smoke_skills.gd`.
+
+| Hero, standing and trading | Old (240 hp / 25 dmg) | Now (190 / 18) |
+|---|---|---|
+| No points spent | dies, boss on 65% | dies, boss on 24% |
+| 3 points — the level's whole yield | dies, boss on 48% | **wins with 10/100 hp** |
+| Full 26-point build | wins with 50/150 | wins with 96/150 |
+
+**Only `max_health` and `attack_damage` moved.** Reach, cooldown, chase speed,
+the radii and the regeneration are all untouched, because each of those is a
+design statement and none of them was the fault.
+
+**The regeneration was not the fault, and that is the finding worth keeping.**
+It was the obvious suspect — the fight is unwinnable and the boss heals three
+times faster than the hero — so it was tested rather than assumed, by chipping it
+down and withdrawing to heal, six cycles, at three different regen rates:
+
+| Boss regen | Net progress per cycle |
+|---|---|
+| 12/s (shipped) | **exactly 0** — 240 → 240 over six cycles |
+| 4/s (matched to the hero's own) | ~0 — 240 → 224 over six cycles |
+| 0/s | 54 a cycle; the boss dies on the fifth |
+
+So turning it down would not have fixed anything: the walk back is ~14 s each
+way and the boss heals through all of it, which swamps the rate. Only removing
+regeneration entirely makes chipping work, and that would delete the design rule
+outright. **The rule was doing its job perfectly; the fight simply had no other
+way to be won.** Worth generalising, because the suspect the symptom names is not
+always the cause — "heals too fast" was a true description of the experience and
+the wrong diagnosis of it.
+
+**Retreating to the boss-room gate is not a disengage**, which nothing here said
+and the measurement found by accident. The boss follows to its leash limit, 22
+units from its post, and the gate is 24 — leaving it 2 units from a hero standing
+there, well inside his own 9-unit `acquire_radius`, so an idle hero re-acquires
+it on the next tick and the fight never breaks off at all. The disengage in the
+table above had to withdraw to the *previous* checkpoint, 84 units back. The
+"it can never follow the hero out of the room" bullet above is still true and is
+a different claim from "there is anywhere in the room to stand and heal", which
+is false.
+
+**The room is still the difficulty, and this is what keeps standing-and-trading
+from being the answer.** With the boss room's own zombies left alive, the same
+3-point hero dies with the boss on 43%. That is not a softer or harder version of
+the table above but a different fight: the points there are *paid for* by those
+kills, so a hero who has them has already cleared the room. Charging the gate
+without doing the level is the row that loses, and it loses for the right reason.
+
+`tests/smoke_boss.gd` holds the top-right cell of that table — it is the only
+assertion in the suite that the game can be completed, and it fails on the old
+numbers with the exact symptom playtesting reported.
+
+The stats are still meant to be argued with, and one is now weaker than it was:
+standing still and trading at full investment is a win by 10 hp, where the reach
+inversion says it should be a loss. It is a hair's-breadth win in the worst
+possible line of play, so the encounter still rewards moving — but if the fight
+ever reads as too forgiving, that cell is the one to push on, and pushing on it
+means `max_health` rather than the reach.
 
 **It does not aggro on the frame the hero respawns**, and that is the same
 invariant `scenes/map/` states for spawns rather than a second rule: the boss

--- a/scenes/enemies/boss.tscn
+++ b/scenes/enemies/boss.tscn
@@ -33,7 +33,7 @@ leash_radius = 22.0
 alert_delay = 1.0
 chase_speed = 2.2
 attack_range = 3.0
-attack_damage = 25.0
+attack_damage = 18.0
 attack_cooldown = 2.0
 xp_reward = 100.0
 regen_delay = 8.0
@@ -61,4 +61,4 @@ target_desired_distance = 1.0
 
 [node name="Health" type="Node" parent="."]
 script = ExtResource("2_health")
-max_health = 240.0
+max_health = 190.0

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -441,4 +441,4 @@ to touch. `tests/smoke_progression.gd` asserts it directly.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: 3e0c926 -->
+<!-- verified-against: f72a398 -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -140,9 +140,17 @@ Measured 1v1 against one zombie: ~18 HP lost per kill, ~6 s of fighting.
 **The end boss inverts the reach advantage deliberately** (issue #39): its 3.0
 beats his 2.2, where every zombie's 2.0 loses to it. So the row above is a
 baseline meant to be broken by one encounter rather than a rule about all of
-them — standing and trading is a fair fight against a zombie and a lost one
-against the boss, which is the entire difference between the two.
-`scenes/enemies/` holds those numbers and the reasoning.
+them. `scenes/enemies/` holds those numbers and the reasoning.
+
+**This paragraph used to end "and standing and trading is a lost fight against
+the boss", and issue #66 made that untrue rather than disproving it.** Those
+numbers were unwinnable by any build a player can reach, so they were lowered;
+at the ones that replaced them, a hero holding every point the level pays wins a
+stand-up fight by 10 of 100 hp. The inversion is intact and it still decides the
+encounter — that margin is one boss swing, in the worst line of play available,
+and the boss room's own zombies turn the same fight into a loss. But it is a
+margin now and not a rule, so **do not lean on "he cannot win by standing
+still"** without re-measuring it. The full table is in `scenes/enemies/`.
 
 **Out-of-combat regeneration** starts `regen_delay` after the last combat
 event, where *both* taking a hit and landing one count — a hero trading blows
@@ -414,4 +422,4 @@ to touch. `tests/smoke_progression.gd` asserts it directly.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: 3e0c926 -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -363,4 +363,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: 3e0c926 -->
+<!-- verified-against: f72a398 -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -338,4 +338,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: 3e0c926 -->

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -235,4 +235,4 @@ children — `current`/`max_health` on one, and `level`/`xp`/`skill_points`,
 It reads no `scenes/ui/` node: nothing here asserts anything about the screen,
 including the XP bar #8 added.
 
-<!-- verified-against: 3e0c926 -->
+<!-- verified-against: f72a398 -->

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -24,6 +24,7 @@ placed one cell from a spawn.
 | `smoke_traversal.gd` | The hero walks start cell to boss room |
 | `smoke_combat.gd` | He kills, acquires his own targets, and heals afterwards |
 | `smoke_progression.gd` | Kills pay XP, levels pay points, and points pay stats |
+| `smoke_boss.gd` | The run can be finished: a hero who did the level can kill the boss |
 | `smoke_skills.gd` | The skill tree is sound, gates what it says, sells nothing it must not, and every node of it is reachable |
 
 ## Running them
@@ -145,6 +146,21 @@ PR, so the constraints run outward as well as in:
   and the failure mode is friendly rather than obviously wrong ("levelling feels
   stingy, give it a little something"). It is the first assertion here that is
   primarily **negative**: what must *not* have changed.
+- **`smoke_boss.gd` asserts that the game has an ending** (issue #66), which
+  nothing did before and which turned out not to be true. The boss shipped in #39
+  with numbers its own doc called a first pass; no build a player can reach could
+  kill it, and the run was unfinishable for as long as that went unnoticed —
+  with every check here green, because none of them fought it.
+  Three things about it are deliberate. It funds the hero with **exactly** what
+  the level pays (19 kills, 3 points) rather than the full build every other test
+  here constructs, because a cap is checked at the cap and a *floor* has to be
+  checked at the floor. It **clears the room first**, which is not a softer fight
+  but the same one: those 19 kills are what paid for the points, so a hero
+  holding them has already done it. And it plays the fight **badly on purpose** —
+  walk in and stand there — so what it asserts is that a solution exists for a
+  player who has not mastered the encounter, never that the encounter is easy.
+  It was run against the old numbers to prove it discriminates, and it fails
+  there with the symptom playtesting reported.
 - **`smoke_skills.gd` is where two cross-folder invariants stop being prose**
   (issue #9). The skill tree is authored in `scenes/skills/` and can silently
   undo a decision made somewhere else: `reach` could out-reach the end boss,

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -224,4 +224,4 @@ children — `current`/`max_health` on one, and `level`/`xp`/`skill_points`,
 It reads no `scenes/ui/` node: nothing here asserts anything about the screen,
 including the XP bar #8 added.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: 3e0c926 -->

--- a/tests/smoke_boss.gd
+++ b/tests/smoke_boss.gd
@@ -1,0 +1,107 @@
+extends "res://tests/harness.gd"
+## The run can actually be finished (issue #66).
+##
+## [b]This is the only assertion in the suite that the game is completable[/b],
+## and it exists because the game was not: the boss shipped in #39 with numbers
+## its own folder doc called "a first pass", and playtesting found that no build
+## a player can reach could kill it. Every check was green throughout — nothing
+## here or anywhere else asserted that the last encounter has a solution.
+##
+## [b]What is measured, and why it is the boss alone.[/b] The hero is funded with
+## exactly the XP the level pays — one kill per `Z` cell, nothing invented — and
+## then fights the boss with the room cleared. That is not a softer fight than the
+## real one, which is the part worth following: the points being spent here are
+## *paid for* by those same kills, so a hero who has them has already cleared the
+## room by definition. Measured with the room still standing the fight is lost, as
+## it should be: that models charging the gate without doing the level, and such a
+## hero would not have the points either.
+##
+## [b]It is deliberately the worst play available.[/b] `command_attack` walks in
+## and stands there trading blows, which is exactly what the boss's longer reach
+## is designed to punish — see `scenes/enemies/`. So this asserts the floor: if
+## standing still and swinging wins by a hair, then moving wins properly, and the
+## encounter has a solution for a player who has not mastered it. It says nothing
+## about the ceiling.
+
+## What one zombie is worth. Read here rather than off a spawn, because the point
+## of the funding below is to reproduce *the level's whole yield*, and reading the
+## reward from the thing being counted would make it agree with itself.
+const XP_PER_ZOMBIE := 10.0
+
+## The margin that says the fight is still a fight. Generous on purpose — the
+## bound, not the measured value, is what is asserted, and the measurement (10 of
+## 100 hp) sits far outside it. If a hero change ever turns this red, that is the
+## signal and not a false alarm: re-measure and decide, do not widen it.
+const WALKOVER_FRACTION := 0.75
+
+## Frames to let the fight resolve. ~12 s measured; this is 60.
+const FIGHT_BUDGET := 3600
+
+
+func _check() -> void:
+	var boss := _find_boss()
+	if not check("the boss is standing in the level", boss != null):
+		return
+
+	# Isolate the encounter — see the header for why this is the real fight and
+	# not a softer one. remove_child before queue_free, the same ordering
+	# scenes/main.gd uses on respawn: a freed-but-still-parented zombie stays in
+	# the enemies group for one more frame and the hero can acquire it.
+	var cleared := 0
+	for enemy in get_nodes_in_group("enemies"):
+		if enemy != boss and is_instance_valid(enemy):
+			enemy.get_parent().remove_child(enemy)
+			enemy.queue_free()
+			cleared += 1
+
+	# Start him on the boss-room gate, which is where a player who has just armed
+	# that checkpoint begins. respawn_at() rather than a bare move, because it is
+	# the public method that both places him and fills him up — a test must not
+	# reach into the Health child to do the second half.
+	var gates: Array[PackedVector3Array] = level.checkpoints()
+	hero.respawn_at(gates[gates.size() - 1][0])
+	await step(10)
+
+	# The level's entire yield, and not a point more.
+	var spawns: Array[Dictionary] = level.zombie_spawns()
+	check("the cleared room is the level's whole zombie population",
+		cleared == spawns.size(), "%d cleared, %d spawns" % [cleared, spawns.size()])
+	hero.gain_experience(float(spawns.size()) * XP_PER_ZOMBIE)
+	var points: int = hero.experience.skill_points
+	check("killing every zombie in the level pays at least one point", points > 0,
+		"level %d, %d point(s) from %d kills"
+			% [hero.experience.level, points, spawns.size()])
+	# Damage is what a small pool buys best: Frenzy needs two ranks of Strength
+	# before it opens and then costs two a rank.
+	while hero.spend_skill_point(&"strength"):
+		pass
+	var info: Dictionary = hero.unit_info()
+	note("hero: %.0f hp, %.0f dmg / %.2f s = %.1f dps" % [
+		hero.health.max_health, info["damage"], info["attack_cooldown"],
+		float(info["damage"]) / float(info["attack_cooldown"])])
+	note("boss: %.0f hp, %.0f dmg / %.1f s, reach %.1f against his %.1f" % [
+		boss.health.max_health, boss.attack_damage, boss.attack_cooldown,
+		boss.attack_range, hero.attack_range])
+
+	hero.command_attack(boss)
+	await wait_for("the fight resolves", func() -> bool:
+		return hero.is_dead() or boss.is_dead(), FIGHT_BUDGET)
+	if not check("a hero who did the level can kill the boss", boss.is_dead(),
+		"boss left on %.0f/%.0f hp" % [boss.health.current, boss.health.max_health]):
+		return
+	check("and is alive at the end of it", not hero.is_dead())
+	note("won with %.0f/%.0f hp" % [hero.health.current, hero.health.max_health])
+	check("and it was not a walkover",
+		hero.health.current < hero.health.max_health * WALKOVER_FRACTION,
+		"%.0f of %.0f hp left" % [hero.health.current, hero.health.max_health])
+	done()
+
+
+## The boss by its own report rather than by node name or by class: it is the
+## same script and the same group as every zombie, and what makes it the boss is
+## what it calls itself.
+func _find_boss() -> Node3D:
+	for enemy in get_nodes_in_group("enemies"):
+		if is_instance_valid(enemy) and enemy.get("display_name") == "Zombie Warlord":
+			return enemy
+	return null


### PR DESCRIPTION
Playtesting reported the boss as impossible to kill, so nothing past it had ever
been seen in a real run. It was: a hero holding **every** skill point the level
pays still died with the boss on 48% of its health.

Fixes #66.

`max_health` 240 → 190 and `attack_damage` 25 → 18, in `boss.tscn`. Nothing else
moves.

## Measured, not argued

Everything below is from driving the real scene headless. That matters, because
the arithmetic I opened #66 with was **wrong**: I eyeballed the layout and said
the level pays 5 skill points. It pays **3** — 19 `Z` cells, 190 XP, level 4.
The issue body has been corrected.

Hero standing and trading, which is the worst play available:

| Hero | Old (240 hp / 25 dmg) | Now (190 / 18) |
|---|---|---|
| No points spent | dies, boss on 65% | dies, boss on 24% |
| 3 points — the level's whole yield | dies, boss on 48% | **wins with 10/100 hp** |
| Full 26-point build (level 27) | wins with 50/150 | wins with 96/150 |

## The regeneration was not the fault

It was the obvious suspect and the one the report named, so I tested it rather
than acting on it — chip the boss down, withdraw, heal, repeat, six cycles:

| Boss regen | Net progress per cycle |
|---|---|
| 12/s (shipped) | **exactly 0** — 240 → 240 over six cycles |
| 4/s (matched to the hero's own) | ~0 — 240 → 224 over six cycles |
| 0/s | 54 a cycle; boss dies on the fifth |

Turning it down fixes nothing. The walk back is ~14 s each way and the boss heals
through all of it, which swamps the rate; only deleting regeneration outright
makes chipping work, and that deletes the design rule with it. **The rule was
doing its job perfectly — the fight simply had no other way to be won.** So I
left it alone and fixed the thing that was actually broken.

## Two things found on the way

- **Retreating to the boss-room gate is not a disengage.** The boss follows to
  its leash limit, 22 units from its post, and the gate is 24 — leaving it 2
  units from a hero standing there, inside his own 9-unit `acquire_radius`, so an
  idle hero re-acquires and the fight never breaks. "It can never follow the hero
  out of the room" is still true and is a different claim from "there is anywhere
  in the room to stand and heal".
- **The room is still the difficulty.** With its zombies alive the same 3-point
  hero dies with the boss on 43%. Not a harder version of the table — a different
  fight, and the right one to lose: those kills are what pay for the points.

## `tests/smoke_boss.gd`

The first assertion in the suite that the game can be finished — nothing checked
it, which is how an unfinishable run shipped with every check green.

Funds the hero with exactly what the level pays rather than the full build the
rest of the suite constructs (a cap is checked at the cap; a **floor** has to be
checked at the floor), clears the room (the same 19 kills that paid for the
points, so this is the same fight and not a softer one), and plays it badly on
purpose — so it claims a floor, never a ceiling. **Run against the old numbers it
fails**, with the symptom playtesting reported: `boss left on 114/240 hp`.

## Reviewer's attention, please

**One design property got weaker and I want it argued with.** `scenes/hero/` said
"standing and trading is a lost fight against the boss". At these numbers it is a
win by 10 hp — one boss swing, in the worst line of play, and a loss outright
with the room alive. So the reach inversion still decides the encounter, but by a
margin rather than a rule. Both folder docs now say so and say not to lean on it
without re-measuring. If you would rather keep it absolute, `max_health` is the
number to push back up — not the reach, which `smoke_skills.gd` caps the tree
against.

## Checks

Full suite green (7 new checks in `smoke_boss.gd`), docs hook and `--audit`
clean. Docs: the `depends-on` graph flagged four; three had nothing to correct,
`scenes/hero/` had the claim above — the graph catching drift in a folder whose
own code did not change, which is the case it exists for.

**Conflicts with #68** on `tests/CLAUDE.md` (both add a row to the file table)
and on the `verified-against` stamps in `scenes/hero/`, `scenes/ui/` and
`tests/`. Both are trivial merges; whichever lands second wants a re-stamp at the
merge commit rather than a re-audit.
