### PR TITLE
Show where an order went, and let the hero be told to stand still

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,12 @@ is worth recording where rather than only in issue #40. That file holds two
 registries this doc explicitly does *not* own, so adding an input action forces
 an edit here to describe something `scenes/CLAUDE.md` is the owner of. PR #62 is
 the second recorded instance: it added `toggle_skills` and had nothing true to
-say here beyond this paragraph. Left as-is deliberately — the check cannot tell
+say here beyond this paragraph. **Issue #67 is the third**, adding
+`hold_position` and `stop_command` — and it settles the shape of the cost, which
+two instances could not: the misfire is **per commit, not per action**, so a
+change adding two actions pays exactly what one adding a single action pays. The
+tax does not scale with the work, which is most of the argument for leaving it.
+Left as-is deliberately — the check cannot tell
 which *section* of `project.godot` moved, and a rule that fires too often is a
 smaller fault than one that lets a renderer or physics change through unread.
 Note what it is not: the rest of the same-change rule, which fires on a folder's

--- a/project.godot
+++ b/project.godot
@@ -50,6 +50,14 @@ toggle_skills={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":75,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)]
 }
+hold_position={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":72,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)]
+}
+stop_command={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)]
+}
 
 [layer_names]
 

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -347,11 +347,16 @@ describes. See `scenes/enemies/CLAUDE.md`.
   `Hero.skill_ranked_up`, plus `xp_changed`, `leveled_up` and `points_changed`
   from the hero's `Experience` child — see "Progression" above. Issue #62 added
   `HUD.skill_rank_up_requested` and `HUD.skill_panel_toggled`, the second and
-  third signals to run from `scenes/ui/` back into the game. Unconsumed so
-  far: `Hero.move_ordered` and `Hero.attack_ordered` — this doc used to earmark
-  them "for the selection UI, issue #36", and that turned out to be wrong:
-  selection is deliberately inert and reads nothing about what the hero is
-  doing. They now have no planned consumer. `Zombie.died` is consumed **on the
+  third signals to run from `scenes/ui/` back into the game. **`Hero.attack_ordered`
+  is the last one still unconsumed**, and its two companions stopped being so in
+  issue #67: this doc earmarked all three "for the selection UI, issue #36",
+  which turned out to be wrong — selection is deliberately inert and reads
+  nothing about what the hero is doing — and then sat calling them unconsumed for
+  four issues until the order marker turned out to be what they were for after
+  all. `attack_ordered` still has no consumer, because a marker that tracks a
+  moving unit is a different feature from a ping on the ground. **All four of the
+  hero's acquiring paths emit it anyway**, which cross-review of PR #70 is what
+  made true. `Zombie.died` is consumed **on the
   boss and nowhere else** (issue #39) — every trash zombie's is still dropped.
   It was the other candidate XP hook and stayed unused: `Hero.killed` won it,
   because a death anything could have caused is the wrong signal to pay a hero
@@ -364,4 +369,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: c007ea1 -->
+<!-- verified-against: 4a9eb45 -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -364,4 +364,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 5b166d3 -->
+<!-- verified-against: c007ea1 -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -364,4 +364,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: 5b166d3 -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -377,4 +377,4 @@ files (it doesn't load the global class cache), so it reports a false
 "Could not find type" on scripts that reference `Hero`, `LevelMap`, or
 `RTSCamera`. Run the scene instead to check those.
 
-<!-- verified-against: 4a9eb45 -->
+<!-- verified-against: e9f8a21 -->

--- a/scenes/CLAUDE.md
+++ b/scenes/CLAUDE.md
@@ -8,8 +8,9 @@ Top-level game scenes and their scripts.
 
 - `main.tscn` — the game entry scene: a `NavigationRegion3D` wrapping the
   level map (`scenes/map/`), the instanced hero, `Enemies` and `Checkpoints`
-  holders, lighting, the RTS camera, and two instances from `scenes/ui/` — the
-  `HUD` and the `UnitSelection` node that holds the selection ring. The 40×40
+  holders, lighting, the RTS camera, and three instances from `scenes/ui/` — the
+  `HUD`, the `UnitSelection` node that holds the selection ring, and the
+  `OrderMarker` that pings where an order landed (issue #67). The 40×40
   test arena that lived here for issue #5 is gone; issue #6 replaced it with the
   real map, and issue #37 replaced that maze with an open single-path level.
 - `main.gd` — attached to the root. Owns the startup order, which is
@@ -313,6 +314,7 @@ describes. See `scenes/enemies/CLAUDE.md`.
   the folder that consumes it; this is only the inventory:
   `move_command` (right mouse), `select_command` (left mouse),
   `attack_move` (`A`), `cancel_command` (`Escape`),
+  `hold_position` (`H`), `stop_command` (`S`),
   `skill_strength` (`1`), `skill_health` (`2`), `toggle_skills` (`K`).
   Every letter-key action is bound to a *physical* keycode, so they land on the
   same keys whatever the keyboard layout.
@@ -334,7 +336,14 @@ describes. See `scenes/enemies/CLAUDE.md`.
   `HUD.restart_requested` in return.
 - `main.gd` consumes `Hero.died`, `Hero.health.health_changed`,
   `Hero.attack_move_armed_changed` and `Hero.select_clicked`, forwarding each to
-  `scenes/ui/`. Since issue #8 it also consumes `Hero.killed` and
+  `scenes/ui/`. Issue #67 added three more of the same shape —
+  `Hero.move_ordered` and `Hero.attack_move_ordered` to the `OrderMarker`, and
+  `Hero.holding_position_changed` to the `HUD`. The first two had been emitted
+  and unconsumed since issue #11, and **which of them fires is the whole of what
+  decides the marker's colour**: this script does not look at `current_order()`
+  to choose, because the hero already reports which order a click became and a
+  second reading of it here would be a second record that can disagree.
+  Since issue #8 it also consumes `Hero.killed` and
   `Hero.skill_ranked_up`, plus `xp_changed`, `leveled_up` and `points_changed`
   from the hero's `Experience` child — see "Progression" above. Issue #62 added
   `HUD.skill_rank_up_requested` and `HUD.skill_panel_toggled`, the second and

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -297,4 +297,4 @@ wider than this will not.
   the boss has no model of its own at all, so whatever it eventually wears is a
   separate question from what the horde does.
 
-<!-- verified-against: c007ea1 -->
+<!-- verified-against: 4a9eb45 -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -381,4 +381,4 @@ wider than this will not.
   the boss has no model of its own at all, so whatever it eventually wears is a
   separate question from what the horde does.
 
-<!-- verified-against: 4a9eb45 -->
+<!-- verified-against: e9f8a21 -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -297,4 +297,4 @@ wider than this will not.
   the boss has no model of its own at all, so whatever it eventually wears is a
   separate question from what the horde does.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: 5b166d3 -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -297,4 +297,4 @@ wider than this will not.
   the boss has no model of its own at all, so whatever it eventually wears is a
   separate question from what the horde does.
 
-<!-- verified-against: 5b166d3 -->
+<!-- verified-against: c007ea1 -->

--- a/scenes/enemies/CLAUDE.md
+++ b/scenes/enemies/CLAUDE.md
@@ -277,6 +277,15 @@ wider than this will not.
   nothing to it — `scenes/ui/` never issues an order. That folder also watches
   the `Health` child's `died` so the bar drops a corpse, which is why it is in
   the frontmatter above.
+- **What this folder claims about `scenes/hero/` is the group-and-methods
+  contract and the leash, and neither moves when he gains an order.** Stated
+  because issue #67 gave him two — hold position and stop — and the `depends-on`
+  graph duly flagged this doc, correctly and with nothing to find. A zombie
+  reacts to where the hero *is*, never to what he has been told to do, which is
+  what makes that whole class of change invisible from here. The one thing a new
+  order can reach is encounter *design* rather than this folder's code: a hero
+  who can be made to stand still is a hero who can hold a chokepoint, and
+  `scenes/map/` is where that is written down.
 - Spawned by `scenes/main.gd` from `LevelMap.zombie_spawns()` — the `Z` cells of
   `scenes/map/level_map.gd`, each carrying the checkpoint segment it belongs to.
   The spawner sets `position` *before* `add_child`, because `_ready()` captures

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -460,4 +460,4 @@ to touch. `tests/smoke_progression.gd` asserts it directly.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: 5b166d3 -->
+<!-- verified-against: c007ea1 -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -460,4 +460,4 @@ to touch. `tests/smoke_progression.gd` asserts it directly.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: 5b166d3 -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -495,4 +495,4 @@ to touch. `tests/smoke_progression.gd` asserts it directly.
 - Damages and is damaged by `scenes/enemies/zombie.gd`, which finds him through
   the `hero` group.
 
-<!-- verified-against: c007ea1 -->
+<!-- verified-against: e9f8a21 -->

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -108,6 +108,14 @@ answer is a decision:
   ordinary way would hand him straight back to the branch that repaths, and the
   hold would end the first time anything strayed near him.
 
+  It still emits `attack_ordered`, so **all four acquiring paths announce
+  themselves**. Cross-review of PR #70 caught that the first version did not:
+  the branch is `_engage()` minus the order change and the repath, and the
+  signal had been dropped along with them. Invisible today because nothing
+  consumes it — and that is the reason it was worth fixing rather than noting,
+  since the first listener would have found one acquisition silently missing in
+  a file nobody had touched.
+
   **A hold outlives the thing that walks into it.** `_finish_engagement()`
   returns early for `HOLD`, and without that line the order ends on the first
   kill: he stands his ground right up until the moment it matters and then

--- a/scenes/hero/CLAUDE.md
+++ b/scenes/hero/CLAUDE.md
@@ -36,6 +36,8 @@ the control model the whole game is styled after. Actions are in
 | `A` then left-click (`attack_move` + `select_command`) | attack it | attack-move there |
 | Left-click alone (`select_command`) | select it | select the hero back |
 | `A` again, or `Escape` (`cancel_command`) | disarms `A` | disarms `A` |
+| `H` (`hold_position`) | stand ground — see below | stand ground — see below |
+| `S` (`stop_command`) | drop the current order | drop the current order |
 | `1` / `2` (`skill_strength` / `skill_health`) | buys a rank — see Skills | buys a rank — see Skills |
 
 **`1` and `2` are the only inputs here that are not commands**, which is why the
@@ -62,17 +64,31 @@ first.
 
 Public order API — future AI, skills and tests should call these rather than
 poking the `NavigationAgent3D`: `command_move_to(point)`,
-`command_attack(target)`, `command_attack_move(point)`, `command_stop()`.
+`command_attack(target)`, `command_attack_move(point)`,
+`command_hold_position()`, `command_stop()`.
 Each cancels the previous order outright: the agent repaths and horizontal
 velocity is zeroed so the hero can't coast a frame along the abandoned heading.
+
+**`H` and `S` are not the same command, and collapsing them would lose the one
+that is harder to express.** `S` drops the current order and leaves him `IDLE`,
+which still acquires anything within `acquire_radius` and walks to it. `H` roots
+him: he swings at what comes within `attack_range` and does not travel for
+anything. "Stop doing that" and "stand exactly here" are separate instructions in
+the scheme this game copies, and only the second lets a player park him in a
+doorway and read the rest of the screen.
+
+Both disarm `A` first, on the rule the right-click handler already keeps — any
+command cancels an armed attack, or the arming outlives the command meant to
+replace it. `S` most obviously: a key meaning "cancel what you are doing" that
+left a half-issued attack command loaded would be the plainest possible surprise.
 
 `respawn_at(point)` is the one method outside that set that moves him, and it is
 not an order — see below.
 
 ## Which orders acquire targets
 
-Four orders (`IDLE`, `MOVE`, `ATTACK_TARGET`, `ATTACK_MOVE`), and the only
-interesting question is which of them pick up a target on their own. Every
+Five orders (`IDLE`, `MOVE`, `ATTACK_TARGET`, `ATTACK_MOVE`, `HOLD`), and the
+only interesting question is which of them pick up a target on their own. Every
 answer is a decision:
 
 - **`MOVE` does not.** A move order runs the gauntlet untouched. This is what
@@ -85,6 +101,23 @@ answer is a decision:
 - **`IDLE` does.** A hero standing still defends himself. This also removes the
   need for a separate retaliate-when-hit rule — nothing can reach him from
   outside `acquire_radius` in the first place.
+- **`HOLD` does, at a different radius, and that is the whole order** (issue
+  #67). It acquires at `attack_range` (2.2) rather than at `acquire_radius` (9),
+  so there is never anything to walk to, and it **stays in `HOLD` while
+  fighting** rather than switching to `ATTACK_TARGET` — taking a target the
+  ordinary way would hand him straight back to the branch that repaths, and the
+  hold would end the first time anything strayed near him.
+
+  **A hold outlives the thing that walks into it.** `_finish_engagement()`
+  returns early for `HOLD`, and without that line the order ends on the first
+  kill: he stands his ground right up until the moment it matters and then
+  quietly stops, which is worse than not having the command, because by then the
+  player has stopped watching him. `tests/smoke_orders.gd` asserts it, and was
+  run against the guard removed to prove it catches that exact failure.
+
+  The only way out of `HOLD` is `_clear_orders()`, which every other command,
+  death and respawn all route through — nothing else assigns the order away from
+  it. That is what makes `holding_position_changed` safe to emit from one place.
 
 **Automatic acquisition requires line of sight; clicking does not.** Both are
 deliberate and they are not the same question. A raycast against walls stops the
@@ -380,11 +413,24 @@ to touch. `tests/smoke_progression.gd` asserts it directly.
   the first bake resolve to the hero's own position.
 - Emits `select_clicked(screen_point)` for a bare left-click, consumed by
   `scenes/ui/` (via `scenes/main.gd`) as a selection.
-- Emits `move_ordered(world_point)` (move *and* attack-move) and
-  `attack_ordered(target)` — still unconsumed. This doc used to say they existed
-  for the selection UI in issue #36; that turned out to be wrong, because
-  selection is deliberately inert and reads nothing about what the hero is
-  doing. They now have no planned consumer.
+- Emits `move_ordered(world_point)` and, since issue #67,
+  `attack_move_ordered(world_point)` — **one signal each, where `move_ordered`
+  used to carry both**. They were one while nothing consumed either; the order
+  marker in `scenes/ui/` is the first thing to care, and it draws them in
+  different colours, so a listener has to be able to tell them apart. A flag on
+  one signal would have done the same job and read worse at every call site.
+  Both are consumed by `scenes/main.gd`, which forwards them to that marker.
+  `attack_ordered(target)` is **still unconsumed**: a marker on a moving unit is
+  a different thing from a ping on the ground, and #67 deliberately did not build
+  it. This doc used to say these existed for the selection UI in issue #36; that
+  turned out to be wrong, because selection is deliberately inert and reads
+  nothing about what the hero is doing.
+  Emits `holding_position_changed(holding)` (issue #67), consumed by
+  `scenes/main.gd` and forwarded to the HUD. A *state* rather than an event, and
+  reported for the same reason `attack_move_armed_changed` is: a mode the player
+  cannot see is a mode they forget they are in, and holding is invisible in the
+  world — a hero standing his ground and one who has finished walking look
+  identical until something wanders into reach.
   Emits `killed(victim)`, **consumed by `scenes/main.gd` since issue #8** after
   being emitted and dropped since #11. It fires from the swing that lands the
   killing blow, so attribution is exact rather than "something died" — which is

--- a/scenes/hero/hero.gd
+++ b/scenes/hero/hero.gd
@@ -26,6 +26,10 @@ extends CharacterBody3D
 ##   is reading the rest of the screen is not chewed on for free. It also makes
 ##   a separate retaliate-when-hit rule unnecessary: nothing can reach the hero
 ##   from outside [member acquire_radius] anyway.
+## - [b]HOLD does, at a different radius.[/b] It acquires at
+##   [member attack_range] rather than [member acquire_radius], so it takes what
+##   comes to it and never has anything to walk to — which is the whole of the
+##   difference from IDLE.
 ##
 ## [b]This script never names an enemy class.[/b] Targets are found through the
 ## "enemies" group and used through take_damage()/is_dead(), so scenes/hero/
@@ -56,6 +60,11 @@ signal holding_position_changed(holding: bool)
 
 ## Emitted when the hero is told to attack something — by right-click, by
 ## A+click, or by acquiring a target on his own.
+##
+## [b]All four acquiring paths fire it[/b], including a held hero taking what
+## walks into his reach. Still unconsumed, which is why that last one is worth
+## stating: a gap here would stay invisible until the first listener arrived, and
+## then be a bug in a file nobody had touched.
 signal attack_ordered(target: Node3D)
 
 ## Emitted when a target dies from this hero's damage. The XP hook for issue #8,
@@ -820,9 +829,20 @@ func _reassess() -> void:
 		# taking a target here by switching to ATTACK_TARGET would hand the hero
 		# straight back to the branch that repaths, and the hold would end the
 		# first time anything strayed near him.
+		#
+		# Everything _engage() does *except* the order change and the repath,
+		# which are the two things a hold must not do — so it is written out
+		# rather than called. The signal is not optional: [signal attack_ordered]
+		# says it fires when he takes a target on his own, and a held hero doing
+		# exactly that would otherwise be the one acquisition that never
+		# announced itself. Nothing consumes it yet, which is precisely why the
+		# gap would have gone unnoticed until something did.
 		Order.HOLD:
 			if not _is_valid_target(_target):
-				_target = _nearest_enemy_to(global_position, attack_range, true)
+				var found := _nearest_enemy_to(global_position, attack_range, true)
+				if found != null:
+					_target = found
+					attack_ordered.emit(found)
 
 		Order.MOVE:
 			pass

--- a/scenes/hero/hero.gd
+++ b/scenes/hero/hero.gd
@@ -32,8 +32,27 @@ extends CharacterBody3D
 ## does not depend on scenes/enemies/ — the dependency runs one way, enemies to
 ## hero. A second enemy type needs no change in here.
 
-## Emitted with the clamped destination of a move or attack-move order.
+## Emitted with the clamped destination of a plain move order.
+##
+## [b]Attack-move has its own signal since issue #67[/b], where this one used to
+## carry both. They were one signal while nothing consumed either; the order
+## marker is the first thing to care, and it draws them in different colours,
+## so a listener has to be able to tell them apart. A flag on one signal would
+## have done the same job and read worse at every call site.
 signal move_ordered(world_point: Vector3)
+
+## Emitted with the clamped destination of an attack-move order (issue #67).
+signal attack_move_ordered(world_point: Vector3)
+
+## Emitted when the hero is told to stand his ground, or to stop doing so
+## (issue #67).
+##
+## [b]A mode the player cannot see is a mode they will forget they are in[/b] —
+## the same reason [signal attack_move_armed_changed] exists, and the reason this
+## reports a *state* rather than an event. Holding is not visible in the world:
+## a hero standing his ground and a hero who has finished walking look identical
+## until something wanders into reach.
+signal holding_position_changed(holding: bool)
 
 ## Emitted when the hero is told to attack something — by right-click, by
 ## A+click, or by acquiring a target on his own.
@@ -77,6 +96,9 @@ enum Order {
 	ATTACK_TARGET,
 	## Walking somewhere, engaging whatever it meets and then resuming.
 	ATTACK_MOVE,
+	## Standing ground: swings at whatever comes within reach and never moves,
+	## not one step (issue #67).
+	HOLD,
 }
 
 ## Ground is physics layer 1, enemies are layer 4 — see the table in
@@ -543,6 +565,17 @@ func current_order() -> Order:
 	return _order
 
 
+## Whether he is currently standing his ground (issue #67).
+##
+## The same question as [code]current_order() == Order.HOLD[/code], and it exists
+## because `tests/` cannot ask it that way: that folder holds the hero untyped on
+## purpose, so naming the enum would make it fail to parse whenever the global
+## class cache is missing. Reads better than the comparison anyway, which is why
+## it is public rather than a note in the test.
+func is_holding_position() -> bool:
+	return _order == Order.HOLD
+
+
 ## The enemy the hero is currently attacking, or null.
 func current_target() -> Node3D:
 	return _target if _is_valid_target(_target) else null
@@ -586,15 +619,50 @@ func command_attack_move(world_point: Vector3) -> void:
 	_resume_point = reachable
 	_has_resume_point = true
 	_nav_agent.target_position = reachable
-	move_ordered.emit(reachable)
+	attack_move_ordered.emit(reachable)
 
 
-## Drop every order and hold position.
+## Stand ground: swing at whatever comes within [member attack_range] and do not
+## move for it (issue #67).
+##
+## [b]The difference from IDLE is the whole feature, and it is not "does he
+## fight".[/b] Both fight. An idle hero acquires anything within
+## [member acquire_radius] — nine units, four times his reach — and walks to it,
+## which is what makes him wander out of a doorway the player parked him in.
+## Holding acquires at reach and never travels, so the position the player chose
+## is the position he keeps.
+func command_hold_position() -> void:
+	# Already holding: re-pressing the key must not re-announce a state that has
+	# not changed, and there is nothing else to reset — he is standing still with
+	# no destination by definition.
+	if _order == Order.HOLD:
+		return
+	_clear_orders()
+	_order = Order.HOLD
+	# The agent is still holding the path from the last order. Left alone, the
+	# *next* order after this one is judged finished or not against a stale
+	# destination — the same trap respawn_at() documents.
+	_nav_agent.target_position = global_position
+	holding_position_changed.emit(true)
+
+
+## Drop every order and stand there. Bound to `S` since issue #67; it has existed
+## unbound since issue #5 as the public way to cancel an order.
+##
+## Note this leaves him IDLE rather than HOLD, and the two differ: he will still
+## acquire and walk to anything inside [member acquire_radius]. "Stop what you are
+## doing" and "stand exactly here" are separate commands in the scheme this game
+## copies, and collapsing them would leave no way to say the first.
 func command_stop() -> void:
 	_clear_orders()
 
 
 func _clear_orders() -> void:
+	# Before the assignment, so the state it reports is the one being left. This
+	# is the only path out of HOLD: every command routes through here, as do death
+	# and respawn, and nothing else assigns the order away from it — _reassess()
+	# and _finish_engagement() both leave a held hero held.
+	var was_holding := _order == Order.HOLD
 	_order = Order.IDLE
 	_target = null
 	_has_resume_point = false
@@ -602,6 +670,8 @@ func _clear_orders() -> void:
 	# the old one.
 	velocity.x = 0.0
 	velocity.z = 0.0
+	if was_holding:
+		holding_position_changed.emit(false)
 
 
 # --- Input -------------------------------------------------------------------
@@ -616,6 +686,21 @@ func _unhandled_input(event: InputEvent) -> void:
 
 	if event.is_action_pressed("cancel_command"):
 		_set_attack_move_armed(false)
+		return
+
+	# Both disarm `A` first, on the rule the right-click handler below already
+	# keeps: any command cancels an armed attack, or the arming survives the
+	# command that was meant to replace it. `S` is the more obvious of the two —
+	# a key that means "cancel what you are doing" leaving a half-issued attack
+	# command loaded would be the plainest possible surprise.
+	if event.is_action_pressed("hold_position"):
+		_set_attack_move_armed(false)
+		command_hold_position()
+		return
+
+	if event.is_action_pressed("stop_command"):
+		_set_attack_move_armed(false)
+		command_stop()
 		return
 
 	# Spending a point is not a command, so it deliberately does not disarm `A`
@@ -702,6 +787,8 @@ func _physics_process(delta: float) -> void:
 			_process_travel(delta)
 		Order.ATTACK_TARGET:
 			_process_attack(delta)
+		Order.HOLD:
+			_process_hold(delta)
 
 
 ## Order bookkeeping and target acquisition. Runs on the retarget tick, not
@@ -727,6 +814,16 @@ func _reassess() -> void:
 			if _horizontal_distance_to(_target.global_position) > attack_range:
 				_nav_agent.target_position = _on_navmesh(_target.global_position)
 
+		# Holding acquires like the two above and at a different radius, which is
+		# the entire behaviour: at reach rather than at [member acquire_radius],
+		# so there is never anything to walk to. It stays in HOLD while it does —
+		# taking a target here by switching to ATTACK_TARGET would hand the hero
+		# straight back to the branch that repaths, and the hold would end the
+		# first time anything strayed near him.
+		Order.HOLD:
+			if not _is_valid_target(_target):
+				_target = _nearest_enemy_to(global_position, attack_range, true)
+
 		Order.MOVE:
 			pass
 
@@ -742,6 +839,12 @@ func _engage(target: Node3D) -> void:
 ## The target is gone: resume the attack-move that was interrupted, or stand down.
 func _finish_engagement() -> void:
 	_target = null
+	# A hold outlives whatever walked into it. Without this the order would end on
+	# the first kill — the hero would stand his ground right up until the moment
+	# it mattered and then quietly stop, which is worse than not having the
+	# command, because the player has already stopped watching him.
+	if _order == Order.HOLD:
+		return
 	if _has_resume_point:
 		_order = Order.ATTACK_MOVE
 		_nav_agent.target_position = _resume_point
@@ -785,6 +888,38 @@ func _process_attack(delta: float) -> void:
 
 	_halt()
 	_face(to_target, delta)
+	if _attack_timer > 0.0:
+		return
+	_attack_timer = attack_cooldown
+	_swing(_target)
+
+
+## Standing ground (issue #67): swing at what is in reach, and do not move for
+## anything.
+##
+## Deliberately a near-copy of the tail of [method _process_attack] rather than a
+## share of it. What that method mostly *is* is the decision about closing on a
+## target — repath, or stand and face because the path is finished — and this
+## order exists precisely to have no such decision. Factoring the two together
+## would mean a helper whose first act is to branch on which caller it has.
+func _process_hold(delta: float) -> void:
+	_halt()
+	if not _is_valid_target(_target):
+		# _reassess() picks one up on the next tick if anything is in reach; until
+		# then, stand. Nothing here reaches for a target of its own, because that
+		# would run the group scan at 60 Hz rather than at RETARGET_INTERVAL.
+		return
+	var to_target := _target.global_position - global_position
+	to_target.y = 0.0
+	_face(to_target, delta)
+	# Range is re-tested every frame even though _reassess() only ever hands this
+	# order a target that was in reach when it looked, because the *target* moves:
+	# a zombie that walks back out between reassessments would otherwise be hit
+	# from beyond reach for up to a tick. Through the shared helper, so this is
+	# the same measurement _process_attack makes rather than a third one that
+	# happens to agree.
+	if _horizontal_distance_to(_target.global_position) > attack_range:
+		return
 	if _attack_timer > 0.0:
 		return
 	_attack_timer = attack_cooldown

--- a/scenes/main.gd
+++ b/scenes/main.gd
@@ -52,6 +52,7 @@ const SEGMENT_META := &"checkpoint_segment"
 @onready var _checkpoints_root: Node3D = $Checkpoints
 @onready var _hud: HUD = $HUD
 @onready var _selection: UnitSelection = $UnitSelection
+@onready var _order_marker: OrderMarker = $OrderMarker
 
 ## Where the hero comes back, one entry per checkpoint. Entry 0 is the start
 ## cell, so this is never empty and a death before the first pad still respawns.
@@ -92,6 +93,16 @@ func _ready() -> void:
 	# belongs to, and hands on the clicks his attack command did not take.
 	_hero.select_clicked.connect(_selection.select_at)
 	_selection.selection_changed.connect(_hud.show_unit)
+	# Order feedback (issue #67). Two signals rather than one because the marker
+	# draws them in different colours, and the hero is the only thing that knows
+	# which order a click became — this script deliberately does not, and reading
+	# `current_order()` here to pick a colour would make it a second record of
+	# something he already reports. `move_ordered` and `attack_ordered` had sat
+	# emitted-and-unconsumed since issue #11 waiting for a use; this is half of
+	# one, and `attack_ordered` is still waiting.
+	_hero.move_ordered.connect(_order_marker.show_move)
+	_hero.attack_move_ordered.connect(_order_marker.show_attack_move)
+	_hero.holding_position_changed.connect(_hud.set_holding_position)
 	# The wires that run the other way, from the HUD back into the game: the
 	# victory screen asks, this script decides what starting a run means — and
 	# since issue #62 the skill panel asks on the same terms.

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3]
+[gd_scene load_steps=10 format=3]
 
 [ext_resource type="Script" path="res://scenes/main.gd" id="1_main"]
 [ext_resource type="Script" path="res://scenes/rts_camera.gd" id="2_camera"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" path="res://scenes/map/level_map.tscn" id="4_level_map"]
 [ext_resource type="PackedScene" path="res://scenes/ui/hud.tscn" id="5_hud"]
 [ext_resource type="PackedScene" path="res://scenes/ui/unit_selection.tscn" id="6_selection"]
+[ext_resource type="PackedScene" path="res://scenes/ui/order_marker.tscn" id="7_order_marker"]
 
 [sub_resource type="Environment" id="Environment_main"]
 background_mode = 1
@@ -44,6 +45,8 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.1, 0)
 
 [node name="UnitSelection" parent="." node_paths=PackedStringArray("hero") instance=ExtResource("6_selection")]
 hero = NodePath("../Hero")
+
+[node name="OrderMarker" parent="." instance=ExtResource("7_order_marker")]
 
 [node name="RTSCamera" type="Camera3D" parent="." node_paths=PackedStringArray("target")]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 22.1, 14)

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -343,4 +343,4 @@ contiguous run of open cells without changing what the player sees.
   `scenes/hero/`, which is why it is in the frontmatter above. `Checkpoint`
   never names `Hero` as a type.
 
-<!-- verified-against: 5b166d3 -->
+<!-- verified-against: 4a9eb45 -->

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -343,4 +343,4 @@ contiguous run of open cells without changing what the player sees.
   `scenes/hero/`, which is why it is in the frontmatter above. `Checkpoint`
   never names `Hero` as a type.
 
-<!-- verified-against: 4a9eb45 -->
+<!-- verified-against: e9f8a21 -->

--- a/scenes/map/CLAUDE.md
+++ b/scenes/map/CLAUDE.md
@@ -148,7 +148,16 @@ passing needs either wider geometry or agent avoidance.
 
 What changed is where it applies. **Put a chokepoint where a queue is the
 encounter you want; put a clearing where units should spread out.** A design
-that needs units to pass now has somewhere to do it. The 0.2 of slack is why
+that needs units to pass now has somewhere to do it.
+
+**Issue #67 gave the player a way to use that deliberately**, which is worth
+knowing because it is the first thing to make a chokepoint a *tactic* rather
+than only a shape. `scenes/hero/`'s hold command roots the hero where he stands
+and stops him acquiring anything he would have to walk to, so a one-cell throat
+can now be held against a pack that has to arrive down it in single file. Before
+it, an idle hero picked up whatever came within nine units and left the throat to
+go and meet it — a player could only approximate holding by re-clicking, and lost
+the position the moment they looked away. The 0.2 of slack is why
 avoidance stays a plausible remedy rather than a hopeless one, and why this
 paragraph has to be re-checked if it is ever enabled.
 
@@ -334,4 +343,4 @@ contiguous run of open cells without changing what the player sees.
   `scenes/hero/`, which is why it is in the frontmatter above. `Checkpoint`
   never names `Hero` as a type.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: 5b166d3 -->

--- a/scenes/skills/CLAUDE.md
+++ b/scenes/skills/CLAUDE.md
@@ -146,4 +146,4 @@ plain `Resource` scripts. The declared edge on `scenes/hero/` is about the
 `scenes/hero/` is the only consumer today: it owns the ledger, the fold, and the
 key bindings. `tests/smoke_skills.gd` drives the tree through him.
 
-<!-- verified-against: 5b166d3 -->
+<!-- verified-against: 4a9eb45 -->

--- a/scenes/skills/CLAUDE.md
+++ b/scenes/skills/CLAUDE.md
@@ -152,4 +152,4 @@ plain `Resource` scripts. The declared edge on `scenes/hero/` is about the
 `scenes/hero/` is the only consumer today: it owns the ledger, the fold, and the
 key bindings. `tests/smoke_skills.gd` drives the tree through him.
 
-<!-- verified-against: 4a9eb45 -->
+<!-- verified-against: e9f8a21 -->

--- a/scenes/skills/CLAUDE.md
+++ b/scenes/skills/CLAUDE.md
@@ -146,4 +146,4 @@ plain `Resource` scripts. The declared edge on `scenes/hero/` is about the
 `scenes/hero/` is the only consumer today: it owns the ledger, the fold, and the
 key bindings. `tests/smoke_skills.gd` drives the tree through him.
 
-<!-- verified-against: 79c5b4d -->
+<!-- verified-against: 5b166d3 -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -397,4 +397,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: 5b166d3 -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -436,4 +436,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: 4a9eb45 -->
+<!-- verified-against: e9f8a21 -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -411,4 +411,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: b386caa -->
+<!-- verified-against: c007ea1 -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -222,26 +222,40 @@ orders. `scenes/main.gd` does not pick the colour either: the hero emits
 `move_ordered` and `attack_move_ordered` separately, so the *only* thing that
 decides which ping is drawn is the order the hero actually issued.
 
-**Green and red collide with `scenes/map/`'s zone markers, and that is accepted
-rather than missed.** The start cell is green (0.3, 0.9, 0.4) and the boss cell
+**Green and red collide with `scenes/map/`'s zone markers, which is why the ring
+carries a dark rim.** The start cell is green (0.3, 0.9, 0.4) and the boss cell
 red (0.95, 0.25, 0.2) — the exact constraint that pushed the selection ring to
-cyan and orange — so a move ping on the start cell and an attack-move ping on the
-boss cell are the two weakest reads in the game. Taken anyway, because the ring
-and the ping are not alike: the ring is **static** and marks a unit indefinitely,
-so a hue that sinks into the floor leaves the player unable to tell what is
-selected, while a ping is transient and animated — it lands at 1.7× and shrinks
-over ~0.6 s, and motion against a flat plate carries a hue difference that would
-defeat a still shape. Against that, recolouring would cost the one convention a
-new player already brings with them. If it ever does read badly, the fix is
-contrast *within* the marker — a dark rim — not a different colour.
+cyan and orange.
 
-**The material is duplicated in `_ready()`**, for the reason the ring and
+**This paragraph first said the collision was acceptable, and a screenshot
+disproved it.** The argument was that a ping is transient and animated where the
+selection ring is static, so motion would carry a hue difference that defeats a
+still shape. Then a move ping was captured landing on the green plate and there
+was **nothing there at all**. The reasoning about motion was not wrong; it was
+answering the wrong question, because a marker invisible in the frame the player
+looks at has already failed whatever it does over the next half second.
+
+So the contrast lives in the marker rather than in the palette: `Rim` is a
+slightly larger near-black torus a hair below the coloured ring. It keeps the one
+convention a new player arrives with — green means go, red means fight — and
+costs a second mesh. It also reads better on ordinary floor than the bare ring
+did, which was not the point but is worth knowing before anyone removes it.
+
+**The general lesson is the one #53 recorded and this repeated exactly.** A
+well-argued design decision is still a hypothesis, and the only thing that
+settles a *visual* one is looking at it. This claim survived being written down,
+re-read while writing the neighbouring paragraph, and reviewed by its author —
+and died to the first screenshot.
+
+**Both materials are duplicated in `_ready()`**, for the reason the ring and
 `scenes/enemies/` both record: sub-resources are shared between instances of a
-scene and this one is recoloured and faded at runtime.
+scene and these are recoloured and faded at runtime.
 
 **Fading needs both albedo alpha and emission energy.** Emission does not read
 alpha, so dropping opacity alone leaves a bright ring glowing on a transparent
-one — which looks like the ping never ends.
+one — which looks like the ping never ends. The rim fades on the same clock and
+scaled by its authored opacity, so the `.tscn` stays the one place that decides
+how dark it is, and the outline never outlives the thing it outlines.
 
 ## The hold indicator (issue #67)
 
@@ -397,4 +411,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: 5b166d3 -->
+<!-- verified-against: b386caa -->

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -19,6 +19,9 @@ five elements and one of them non-trivial.
 - `unit_selection.tscn` / `unit_selection.gd` (`class_name UnitSelection`) — a
   `Node3D` in `main.tscn` holding the selection ring. Owns *what* is selected;
   the HUD only draws it.
+- `order_marker.tscn` / `order_marker.gd` (`class_name OrderMarker`) — a `Node3D`
+  in `main.tscn`, on the same precedent: the ping that shows where an order
+  landed (issue #67). Green for a move, red for an attack-move. See below.
 - `skill_panel.tscn` / `skill_panel.gd` (`class_name SkillPanel`) — the skill
   tree as something clickable (issue #62), instanced inside `hud.tscn`. See
   below.
@@ -202,6 +205,53 @@ open this panel, so a player who acts on it immediately reads it straight across
 the panel's own title. Found by screenshotting the panel, not by reasoning about
 it.
 
+## The order marker (issue #67)
+
+A right-click used to produce movement and nothing else. In a top-down view with
+the hero often off-centre, that makes a click that was *received* look identical
+to one that was dropped — `scenes/hero/` has a whole rule about never dropping a
+click, written because dropped clicks read as an unresponsive hero, and this is
+the other half of it: an order the player cannot see is the same experience as no
+order at all.
+
+**It is inert, exactly as selection is**, and for the same reason. It reads no
+state, nothing reads it, and it holds no opinion about what the hero is doing —
+it is told where an order went and draws a ring there. That is what lets it hang
+straight off the hero's order signals without becoming a second record of his
+orders. `scenes/main.gd` does not pick the colour either: the hero emits
+`move_ordered` and `attack_move_ordered` separately, so the *only* thing that
+decides which ping is drawn is the order the hero actually issued.
+
+**Green and red collide with `scenes/map/`'s zone markers, and that is accepted
+rather than missed.** The start cell is green (0.3, 0.9, 0.4) and the boss cell
+red (0.95, 0.25, 0.2) — the exact constraint that pushed the selection ring to
+cyan and orange — so a move ping on the start cell and an attack-move ping on the
+boss cell are the two weakest reads in the game. Taken anyway, because the ring
+and the ping are not alike: the ring is **static** and marks a unit indefinitely,
+so a hue that sinks into the floor leaves the player unable to tell what is
+selected, while a ping is transient and animated — it lands at 1.7× and shrinks
+over ~0.6 s, and motion against a flat plate carries a hue difference that would
+defeat a still shape. Against that, recolouring would cost the one convention a
+new player already brings with them. If it ever does read badly, the fix is
+contrast *within* the marker — a dark rim — not a different colour.
+
+**The material is duplicated in `_ready()`**, for the reason the ring and
+`scenes/enemies/` both record: sub-resources are shared between instances of a
+scene and this one is recoloured and faded at runtime.
+
+**Fading needs both albedo alpha and emission energy.** Emission does not read
+alpha, so dropping opacity alone leaves a bright ring glowing on a transparent
+one — which looks like the ping never ends.
+
+## The hold indicator (issue #67)
+
+`set_holding_position(holding)` is the second element of the
+`set_attack_move_armed` kind, and it needs the treatment more rather than less.
+An armed attack command ends on the next click; a hold lasts until the player
+remembers it, and a held hero is indistinguishable in the world from one who has
+simply finished walking — right up until the player wonders why he is not
+chasing anything.
+
 ## The victory panel (issue #39)
 
 The boss dies, `scenes/main.gd` calls `show_victory()`, and a "VICTORY" heading,
@@ -309,8 +359,17 @@ difference worth stating rather than assuming.
 
 ## Dependencies / signals
 
-- Instanced by `scenes/main.tscn`; `UnitSelection.hero` is wired from there as a
-  `NodePath`, the way the camera's `target` is.
+- Instanced by `scenes/main.tscn` — the `HUD`, `UnitSelection` and, since issue
+  #67, `OrderMarker`. `UnitSelection.hero` is wired from there as a `NodePath`,
+  the way the camera's `target` is; the marker needs no wiring of its own,
+  because it is fed by method call like everything else here.
+- Consumes `Hero.move_ordered` and `Hero.attack_move_ordered` through
+  `scenes/main.gd` as `OrderMarker.show_move()` / `show_attack_move()`, and
+  `Hero.holding_position_changed` as `HUD.set_holding_position()` (issue #67).
+  Those two order signals had been emitted and unconsumed since issue #11; this
+  is their first consumer, and `Hero.attack_ordered` is still waiting for one —
+  a marker that tracks a moving unit is a different feature from a ping on the
+  ground, and #67 deliberately did not build it.
 - Consumes `Hero.select_clicked`, and `Health.health_changed` / `Health.died` on
   whatever is selected. `scenes/main.gd` also calls `set_hero_health()`,
   `set_attack_move_armed()`, `show_death()` / `hide_death()`,

--- a/scenes/ui/CLAUDE.md
+++ b/scenes/ui/CLAUDE.md
@@ -411,4 +411,4 @@ difference worth stating rather than assuming.
   *before* calling `select_unit(hero)`, because the info bar learns the initial
   selection from that signal and nothing re-sends it.
 
-<!-- verified-against: c007ea1 -->
+<!-- verified-against: 4a9eb45 -->

--- a/scenes/ui/hud.gd
+++ b/scenes/ui/hud.gd
@@ -43,6 +43,7 @@ const FLASH_FADE := 0.7
 @onready var _xp_value: Label = $XPBar/Value
 @onready var _skills_label: Label = $SkillsLabel
 @onready var _attack_move_label: Label = $AttackMoveLabel
+@onready var _hold_label: Label = $HoldLabel
 @onready var _death_label: Label = $DeathLabel
 @onready var _death_sub_label: Label = $DeathSubLabel
 @onready var _checkpoint_label: Label = $CheckpointLabel
@@ -153,6 +154,15 @@ func show_unit(unit: Node3D) -> void:
 ## mode the player cannot see is a mode they will forget they are in.
 func set_attack_move_armed(armed: bool) -> void:
 	_attack_move_label.visible = armed
+
+
+## Standing ground is the same kind of mode and gets the same treatment (issue
+## #67) — and it needs it more, not less. An armed attack command at least ends
+## on the next click; a hold lasts until the player remembers it, and a held hero
+## is indistinguishable in the world from one who has finished walking, right up
+## until the player wonders why he is not chasing anything.
+func set_holding_position(holding: bool) -> void:
+	_hold_label.visible = holding
 
 
 func show_death() -> void:

--- a/scenes/ui/hud.tscn
+++ b/scenes/ui/hud.tscn
@@ -83,6 +83,24 @@ text = "ATTACK — left-click a target, or the ground to attack-move"
 horizontal_alignment = 1
 vertical_alignment = 1
 
+[node name="HoldLabel" type="Label" parent="."]
+visible = false
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -280.0
+offset_top = -182.0
+offset_right = 280.0
+offset_bottom = -150.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_colors/font_color = Color(0.55, 0.82, 1, 1)
+theme_override_font_sizes/font_size = 22
+text = "HOLDING POSITION — S to stand down"
+horizontal_alignment = 1
+vertical_alignment = 1
+
 [node name="ControlsLabel" type="Label" parent="."]
 offset_left = 24.0
 offset_top = 18.0
@@ -92,6 +110,7 @@ theme_override_colors/font_color = Color(0.72, 0.76, 0.84, 1)
 text = "Right-click: move / attack
 Left-click: select a unit
 A + left-click: attack / attack-move
+H: hold position     S: stop
 1 / 2: spend a skill point
 K: skill tree"
 

--- a/scenes/ui/order_marker.gd
+++ b/scenes/ui/order_marker.gd
@@ -32,27 +32,33 @@ const GROUND_CLEARANCE := 0.06
 const START_SCALE := 1.7
 const END_SCALE := 1.0
 
-## [b]These collide with `scenes/map/`'s zone markers, and the collision is
-## accepted rather than missed.[/b] That folder paints the start cell green
-## (0.3, 0.9, 0.4) and the boss cell red (0.95, 0.25, 0.2), which is the exact
-## constraint that pushed the selection ring to cyan and orange — so a move ping
-## on the start cell and an attack-move ping on the boss cell are the two weakest
-## reads in the game.
+## [b]These collide with `scenes/map/`'s zone markers, which is why the ring has
+## a dark rim behind it.[/b] That folder paints the start cell green
+## (0.3, 0.9, 0.4) and the boss cell red (0.95, 0.25, 0.2) — the exact constraint
+## that pushed the selection ring to cyan and orange.
 ##
-## Taken anyway, because the two cases are not alike. The ring is *static* and
-## marks a unit indefinitely, so a hue that vanishes into the floor leaves a
-## player with no way to tell what is selected. A ping is transient and animated:
-## it arrives at 1.7× and shrinks over ~0.6 s, and motion against a flat plate is
-## legible at a hue difference that would defeat a still shape. Against that,
-## re-colouring these would cost the one convention a new player brings with
-## them. If it ever does read badly, the fix is contrast within the marker — a
-## dark rim — rather than a different colour.
+## The first version of this file argued the collision was acceptable: a ping is
+## transient and animated where the selection ring is static, so motion should
+## carry a hue difference that would defeat a still shape. **A screenshot of a
+## move ping landing on the green plate showed nothing there at all.** The
+## argument was not wrong about motion, but it was answering the wrong question —
+## a marker that is invisible for the frame the player looks at it has already
+## failed, whatever it does over the next half second.
+##
+## So the contrast is in the marker rather than in the palette, which keeps the
+## one convention a new player arrives with (green means go, red means fight) and
+## costs a second mesh. `Rim` is a slightly larger near-black torus a hair below
+## the coloured one; it reads as an outline on pale floor and as the whole shape
+## on a plate the same hue as the ring.
 const MOVE_COLOUR := Color(0.36, 1.0, 0.42)
 const ATTACK_COLOUR := Color(1.0, 0.3, 0.24)
 
 @onready var _ring: MeshInstance3D = $Ring
+@onready var _rim: MeshInstance3D = $Rim
 
 var _material: StandardMaterial3D = null
+var _rim_material: StandardMaterial3D = null
+var _rim_alpha := 1.0
 var _tween: Tween = null
 
 
@@ -63,6 +69,9 @@ func _ready() -> void:
 	# stops being true the failure mode is silent.
 	_material = _ring.get_surface_override_material(0).duplicate()
 	_ring.set_surface_override_material(0, _material)
+	_rim_material = _rim.get_surface_override_material(0).duplicate()
+	_rim.set_surface_override_material(0, _rim_material)
+	_rim_alpha = _rim_material.albedo_color.a
 	hide()
 
 
@@ -109,3 +118,7 @@ func _set_alpha(alpha: float) -> void:
 	# Emission does not read alpha, so a ring left glowing at zero opacity is a
 	# bright ring on a transparent one. Dimming both is what actually fades it.
 	_material.emission_energy_multiplier = alpha
+	# The rim fades with the ring rather than on its own clock, or the outline
+	# outlives the thing it is outlining — scaled by its authored opacity so the
+	# .tscn stays the one place that decides how dark it is.
+	_rim_material.albedo_color.a = alpha * _rim_alpha

--- a/scenes/ui/order_marker.gd
+++ b/scenes/ui/order_marker.gd
@@ -1,0 +1,111 @@
+class_name OrderMarker
+extends Node3D
+## The ping that shows where an order landed (issue #67).
+##
+## A right-click used to produce movement and nothing else, which in a top-down
+## view with the hero often off-centre makes a click that was *received* look
+## identical to one that was dropped. `scenes/hero/` has a rule that every click
+## produces an order, written because dropped clicks read as an unresponsive
+## hero; this is the other half of it, because an order the player cannot see is
+## the same experience as no order at all.
+##
+## [b]Green for a move, red for an attack-move[/b] — the RTS convention the whole
+## game is styled after, and the one thing about this the player already knows
+## before being told.
+##
+## [b]It is inert, exactly as selection is.[/b] It reads no state, is read by
+## nothing, and holds no opinion about what the hero is doing — it is told where
+## an order went and draws a ring there. That is what lets it be driven straight
+## from the hero's order signals without becoming a second record of his orders.
+
+## Life of one ping. Short: this answers "did that register", which is a question
+## the player has stopped asking within about half a second.
+const HOLD_TIME := 0.16
+const FADE_TIME := 0.42
+
+## How far the ring floats above the floor, matching the selection ring's
+## clearance for the same reason — unit and marker origins both sit on the floor.
+const GROUND_CLEARANCE := 0.06
+
+## Ring sizes, in metres. It lands wide and shrinks onto the point, which is what
+## makes the ping read as *arriving somewhere* rather than merely appearing.
+const START_SCALE := 1.7
+const END_SCALE := 1.0
+
+## [b]These collide with `scenes/map/`'s zone markers, and the collision is
+## accepted rather than missed.[/b] That folder paints the start cell green
+## (0.3, 0.9, 0.4) and the boss cell red (0.95, 0.25, 0.2), which is the exact
+## constraint that pushed the selection ring to cyan and orange — so a move ping
+## on the start cell and an attack-move ping on the boss cell are the two weakest
+## reads in the game.
+##
+## Taken anyway, because the two cases are not alike. The ring is *static* and
+## marks a unit indefinitely, so a hue that vanishes into the floor leaves a
+## player with no way to tell what is selected. A ping is transient and animated:
+## it arrives at 1.7× and shrinks over ~0.6 s, and motion against a flat plate is
+## legible at a hue difference that would defeat a still shape. Against that,
+## re-colouring these would cost the one convention a new player brings with
+## them. If it ever does read badly, the fix is contrast within the marker — a
+## dark rim — rather than a different colour.
+const MOVE_COLOUR := Color(0.36, 1.0, 0.42)
+const ATTACK_COLOUR := Color(1.0, 0.3, 0.24)
+
+@onready var _ring: MeshInstance3D = $Ring
+
+var _material: StandardMaterial3D = null
+var _tween: Tween = null
+
+
+func _ready() -> void:
+	# Duplicated for the reason `scenes/enemies/` and the selection ring both
+	# record: a scene's sub-resources are shared between instances, and this one
+	# is recoloured and faded at runtime. One marker exists today; if that ever
+	# stops being true the failure mode is silent.
+	_material = _ring.get_surface_override_material(0).duplicate()
+	_ring.set_surface_override_material(0, _material)
+	hide()
+
+
+## A move order landed at [param world_point]. Connected to
+## [signal Hero.move_ordered].
+func show_move(world_point: Vector3) -> void:
+	_ping(world_point, MOVE_COLOUR)
+
+
+## An attack-move order landed at [param world_point]. Connected to
+## [signal Hero.attack_move_ordered].
+func show_attack_move(world_point: Vector3) -> void:
+	_ping(world_point, ATTACK_COLOUR)
+
+
+## Drop a ping and let it fade.
+##
+## One marker re-used rather than an instance per click, and the tween is killed
+## first: clicking again before the last ping has faded is the single most
+## ordinary thing a player does with this, and it must show the *new* point
+## rather than queue behind the old one.
+func _ping(world_point: Vector3, colour: Color) -> void:
+	if _tween != null and _tween.is_valid():
+		_tween.kill()
+	global_position = world_point + Vector3.UP * GROUND_CLEARANCE
+	scale = Vector3.ONE * START_SCALE
+	_material.albedo_color = colour
+	_material.emission = colour
+	_set_alpha(1.0)
+	show()
+
+	_tween = create_tween()
+	_tween.set_parallel(true)
+	_tween.tween_property(self, "scale", Vector3.ONE * END_SCALE, HOLD_TIME + FADE_TIME) \
+		.set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
+	# Fade starts after the hold, so the ping is at full strength for the moment
+	# the player is actually looking for it.
+	_tween.tween_method(_set_alpha, 1.0, 0.0, FADE_TIME).set_delay(HOLD_TIME)
+	_tween.chain().tween_callback(hide)
+
+
+func _set_alpha(alpha: float) -> void:
+	_material.albedo_color.a = alpha
+	# Emission does not read alpha, so a ring left glowing at zero opacity is a
+	# bright ring on a transparent one. Dimming both is what actually fades it.
+	_material.emission_energy_multiplier = alpha

--- a/scenes/ui/order_marker.gd.uid
+++ b/scenes/ui/order_marker.gd.uid
@@ -1,0 +1,1 @@
+uid://dhfdx14nqewv

--- a/scenes/ui/order_marker.tscn
+++ b/scenes/ui/order_marker.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=4 format=3]
+
+[ext_resource type="Script" path="res://scenes/ui/order_marker.gd" id="1_marker"]
+
+[sub_resource type="TorusMesh" id="TorusMesh_marker"]
+inner_radius = 0.62
+outer_radius = 0.82
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_marker"]
+transparency = 1
+shading_mode = 0
+albedo_color = Color(0.36, 1, 0.42, 1)
+emission_enabled = true
+emission = Color(0.36, 1, 0.42, 1)
+
+[node name="OrderMarker" type="Node3D"]
+script = ExtResource("1_marker")
+
+[node name="Ring" type="MeshInstance3D" parent="."]
+cast_shadow = 0
+mesh = SubResource("TorusMesh_marker")
+surface_material_override/0 = SubResource("StandardMaterial3D_marker")

--- a/scenes/ui/order_marker.tscn
+++ b/scenes/ui/order_marker.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3]
+[gd_scene load_steps=6 format=3]
 
 [ext_resource type="Script" path="res://scenes/ui/order_marker.gd" id="1_marker"]
 
@@ -13,8 +13,23 @@ albedo_color = Color(0.36, 1, 0.42, 1)
 emission_enabled = true
 emission = Color(0.36, 1, 0.42, 1)
 
+[sub_resource type="TorusMesh" id="TorusMesh_rim"]
+inner_radius = 0.5
+outer_radius = 0.96
+
+[sub_resource type="StandardMaterial3D" id="StandardMaterial3D_rim"]
+transparency = 1
+shading_mode = 0
+albedo_color = Color(0.04, 0.04, 0.06, 0.85)
+
 [node name="OrderMarker" type="Node3D"]
 script = ExtResource("1_marker")
+
+[node name="Rim" type="MeshInstance3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.012, 0)
+cast_shadow = 0
+mesh = SubResource("TorusMesh_rim")
+surface_material_override/0 = SubResource("StandardMaterial3D_rim")
 
 [node name="Ring" type="MeshInstance3D" parent="."]
 cast_shadow = 0

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -229,4 +229,4 @@ children — `current`/`max_health` on one, and `level`/`xp`/`skill_points`,
 It reads no `scenes/ui/` node: nothing here asserts anything about the screen,
 including the XP bar #8 added.
 
-<!-- verified-against: 0bc0fe6 -->
+<!-- verified-against: 5b166d3 -->

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -260,4 +260,4 @@ children — `current`/`max_health` on one, and `level`/`xp`/`skill_points`,
 It reads no `scenes/ui/` node: nothing here asserts anything about the screen,
 including the XP bar #8 added.
 
-<!-- verified-against: 4a9eb45 -->
+<!-- verified-against: e9f8a21 -->

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -23,6 +23,7 @@ placed one cell from a spawn.
 | `smoke_startup.gd` | The level assembles as authored and the navmesh is real |
 | `smoke_traversal.gd` | The hero walks start cell to boss room |
 | `smoke_combat.gd` | He kills, acquires his own targets, and heals afterwards |
+| `smoke_orders.gd` | `S` stops him, and `H` roots him — including across a kill |
 | `smoke_progression.gd` | Kills pay XP, levels pay points, and points pay stats |
 | `smoke_skills.gd` | The skill tree is sound, gates what it says, sells nothing it must not, and every node of it is reachable |
 
@@ -145,6 +146,24 @@ PR, so the constraints run outward as well as in:
   and the failure mode is friendly rather than obviously wrong ("levelling feels
   stingy, give it a little something"). It is the first assertion here that is
   primarily **negative**: what must *not* have changed.
+- **`smoke_orders.gd` covers an order that is invisible when it breaks** (issue
+  #67). `HOLD` looks exactly like `IDLE` from every angle except the one that
+  matters: both stand, both fight back, and the difference only shows when
+  something comes within `acquire_radius` but outside reach — an idle hero walks
+  to it and a held one does not. A `HOLD` branch that fell through to IDLE's
+  behaviour would survive any amount of playing until the moment a player was
+  relying on it. Its second half is the `_finish_engagement()` guard, and that
+  one was **run against the guard removed** to prove it discriminates: without
+  it the order silently ends on the first kill.
+  It also carries this folder's sharpest lesson about writing tests here. The
+  first version picked the nearest zombie by distance and asserted an idle hero
+  would walk to it. He stood still — **correctly**, because that zombie was
+  behind rock, and automatic acquisition requires line of sight while this folder
+  has no way to ask whether there is any. The fix was to stop asserting what the
+  hero *should* target and wait for `current_target()` to fill, which proves
+  range and sight together in a question this folder is allowed to ask. **A test
+  that reaches for world state the hero reasons about differently is measuring
+  its own assumption.**
 - **`smoke_skills.gd` is where two cross-folder invariants stop being prose**
   (issue #9). The skill tree is authored in `scenes/skills/` and can silently
   undo a decision made somewhere else: `reach` could out-reach the end boss,
@@ -195,7 +214,9 @@ frontmatter above is long. It reads `scenes/main.tscn` and the startup order
 `scenes/` owns, the command API and `killed` signal of `scenes/hero/` — plus his
 skill API (`gain_experience`, `spend_skill_point`, `skill_rank`,
 `skill_refusal`, `skill_problems`, `skill_summary`, `skill_catalogue` and the
-`skill_tree` export) since issues #8, #9 and #62 — and through that export the
+`skill_tree` export) since issues #8, #9 and #62, plus `command_hold_position()`,
+`is_holding_position()`, `current_order()` and `current_target()` since #67 —
+and through that export the
 read side of `scenes/skills/`
 (`SkillTree.ids`, `node`, `cost_of_next_rank`, `total_cost`, `validate`, and a
 node's `max_rank` / `requires` / `effects`; `requires` is also *written*, on a

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -229,4 +229,4 @@ children — `current`/`max_health` on one, and `level`/`xp`/`skill_points`,
 It reads no `scenes/ui/` node: nothing here asserts anything about the screen,
 including the XP bar #8 added.
 
-<!-- verified-against: 5b166d3 -->
+<!-- verified-against: 4a9eb45 -->

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -154,7 +154,11 @@ PR, so the constraints run outward as well as in:
   behaviour would survive any amount of playing until the moment a player was
   relying on it. Its second half is the `_finish_engagement()` guard, and that
   one was **run against the guard removed** to prove it discriminates: without
-  it the order silently ends on the first kill.
+  it the order silently ends on the first kill. It closes with **both** ways out
+  of the order — a cancel and an ordinary move — because the claim being asserted
+  is that *every* command releases a hold, and the cancel alone only proves the
+  cancel. They share one choke point today; the second check is what would notice
+  that stopping being true. Cross-review of PR #70 asked for it.
   It also carries this folder's sharpest lesson about writing tests here. The
   first version picked the nearest zombie by distance and asserted an idle hero
   would walk to it. He stood still — **correctly**, because that zombie was

--- a/tests/smoke_orders.gd
+++ b/tests/smoke_orders.gd
@@ -1,0 +1,143 @@
+extends "res://tests/harness.gd"
+## The two commands issue #67 added actually command something: `S` stops, and
+## `H` stands ground rather than merely standing still for a moment.
+##
+## [b]Hold is the one that needs a test, and the reason is that it looks like
+## IDLE from every angle except the one that matters.[/b] Both stand, both fight
+## back, both leave the hero rooted for as long as nothing comes near. The
+## difference only shows when something *does*: an idle hero acquires anything
+## within `acquire_radius` — nine units, four times his reach — and walks to it,
+## and a held hero does not move at all. A `HOLD` branch that fell through to
+## IDLE's behaviour would pass every eyeball check in a running game right up
+## until the moment the player was relying on it.
+##
+## The second half is the trap this was written against. `_finish_engagement()`
+## drops the hero to IDLE when a target dies and there is no attack-move to
+## resume, so without a guard the hold ends **on the first kill** — he stands his
+## ground until it matters and then quietly stops, which is worse than not having
+## the command, because by then the player has looked away.
+##
+## [b]The setup is driven off the hero's own acquisition, and the first version
+## of this file is why.[/b] It picked the nearest zombie by distance and asserted
+## an idle hero would walk to it; he stood still, correctly, because that zombie
+## was behind rock — automatic acquisition requires line of sight and `tests/`
+## cannot ask whether it has any. Waiting for him to take a target is the same
+## question asked in a way this folder is allowed to ask it, and it proves range
+## and sight together.
+##
+## Nothing here reads a `scenes/ui/` node, so the marker #67 also added is not
+## covered; that boundary is this folder's, and issue #55 is where it is argued.
+
+## Frames to watch him stand. 2 s — long enough that a hero who was going to
+## walk has walked, since he covers 6 units a second.
+const WATCH_FRAMES := 120
+
+## How long to let him chase before taking the measurement away from him. Short
+## on purpose: he closes at 6 units a second against a 3.4 approach, so a longer
+## look would put him in melee and there would be nothing left to walk to.
+const CHASE_FRAMES := 20
+
+## What counts as having stayed put, and what counts as having moved. Bounds
+## rather than measured values: settling and turning in place put a held hero a
+## little off his mark, and a chase only has to cover half of a closing gap.
+const STAYED_PUT := 0.6
+const DEFINITELY_MOVED := 0.8
+
+
+func _check() -> void:
+	# --- 1. S cancels a move in flight ----------------------------------------
+	var start: Vector3 = hero.global_position
+	hero.command_move_to(level.boss_position())
+	await wait_for("a move order gets him under way", func() -> bool:
+		return hero.global_position.distance_to(start) > 1.5, 600)
+	hero.command_stop()
+	var stopped: Vector3 = hero.global_position
+	await step(WATCH_FRAMES)
+	check("and S stops him where he stands",
+		hero.global_position.distance_to(stopped) < STAYED_PUT,
+		"drifted %.2f units" % hero.global_position.distance_to(stopped))
+
+	# --- 2. an acquiring order takes a target and goes to it ------------------
+	# The contrast case, and it is what makes section 3 mean anything: "a held
+	# hero did not move" is equally satisfied by a hero who was never going to.
+	#
+	# Attack-move rather than a plain move, and the difference is not cosmetic. A
+	# MOVE order acquires nothing, so he walks past the zombie while it charges
+	# him, and by the time the order finishes and he stands idle it is already on
+	# top of him — measured at 2.79 units against a 2.2 reach, half a step to
+	# close, which is no test of whether he travels. ATTACK_MOVE acquires from the
+	# same branch of `_reassess()` that IDLE does, while he is still approaching,
+	# so the target is taken at a distance he genuinely has to cross.
+	var target = _nearest_living_enemy()
+	if not check("there is a zombie to walk toward", target != null):
+		return
+	hero.command_attack_move(target.global_position)
+	if not await wait_for("an acquiring order takes a target of its own",
+		func() -> bool: return hero.is_dead() or hero.current_target() != null, 1800):
+		return
+	if not check("and is alive to do something about it", not hero.is_dead()):
+		return
+	var reach_at_acquire := _distance_to_target()
+	check("which he has to walk to reach",
+		reach_at_acquire > hero.attack_range,
+		"%.2f units against a reach of %.1f" % [reach_at_acquire, hero.attack_range])
+
+	var chase_from: Vector3 = hero.global_position
+	await step(CHASE_FRAMES)
+	var chase_moved: float = hero.global_position.distance_to(chase_from)
+	check("and he closes on it", chase_moved > DEFINITELY_MOVED,
+		"moved %.2f units in %d frames" % [chase_moved, CHASE_FRAMES])
+
+	# --- 3. a held hero does not ----------------------------------------------
+	var gap_at_hold := _distance_to_target()
+	hero.command_hold_position()
+	check("H puts him in hold", hero.is_holding_position())
+	check("with the same target still out of reach", gap_at_hold > hero.attack_range,
+		"%.2f units" % gap_at_hold)
+	var held_from: Vector3 = hero.global_position
+	await step(WATCH_FRAMES)
+	var held_moved: float = hero.global_position.distance_to(held_from)
+	check("a held hero stands his ground instead of closing",
+		held_moved < STAYED_PUT,
+		"moved %.2f units, against %.2f while acquiring" % [held_moved, chase_moved])
+	if not check("and is alive to have held it", not hero.is_dead()):
+		return
+
+	# --- 4. and the hold outlives the kill ------------------------------------
+	# The guard in _finish_engagement(). Without it this is where the order ends,
+	# silently, at the first moment it was doing any work.
+	var killed_something := [false]
+	hero.connect(&"killed", func(_victim: Node3D) -> void: killed_something[0] = true)
+	if not await wait_for("something walks into him and dies for it",
+		func() -> bool: return killed_something[0] or hero.is_dead(), 1800):
+		return
+	if not check("he killed it rather than the other way round", not hero.is_dead()):
+		return
+	check("and he is still holding afterwards", hero.is_holding_position(),
+		"order is %d" % hero.current_order())
+
+	# --- 5. and any other order releases it -----------------------------------
+	hero.command_stop()
+	check("S stands him down again", not hero.is_holding_position())
+	done()
+
+
+func _nearest_living_enemy():
+	var best = null
+	var best_distance := INF
+	for enemy in living_enemies():
+		var distance: float = hero.global_position.distance_to(enemy.global_position)
+		if distance < best_distance:
+			best_distance = distance
+			best = enemy
+	return best
+
+
+## Distance to the enemy the hero has actually taken, or INF if he has none.
+## His target rather than the nearest body: those differ whenever the nearest is
+## behind rock, which is the mistake the header records.
+func _distance_to_target() -> float:
+	var target = hero.current_target()
+	if target == null:
+		return INF
+	return hero.global_position.distance_to(target.global_position)

--- a/tests/smoke_orders.gd
+++ b/tests/smoke_orders.gd
@@ -117,8 +117,17 @@ func _check() -> void:
 		"order is %d" % hero.current_order())
 
 	# --- 5. and any other order releases it -----------------------------------
+	# Both a cancel and an ordinary order, because the doc's claim is about *every*
+	# command routing through `_clear_orders()` and `S` alone only proves the
+	# cancel. They share one choke point today, so the second check is cheap
+	# insurance against that stopping being true rather than a separate risk.
 	hero.command_stop()
 	check("S stands him down again", not hero.is_holding_position())
+	hero.command_hold_position()
+	if not check("and he can be told to hold once more", hero.is_holding_position()):
+		return
+	hero.command_move_to(level.start_position())
+	check("a move order releases the hold too", not hero.is_holding_position())
 	done()
 
 

--- a/tests/smoke_orders.gd.uid
+++ b/tests/smoke_orders.gd.uid
@@ -1,0 +1,1 @@
+uid://5wxxl75dgoqi


### PR DESCRIPTION
Three parts of one complaint from playtesting: the command scheme is not legible
while you are playing it.

Fixes #67.

## Order markers

A right-click produced movement and nothing else, so a click that was *received*
looked identical to one that was dropped — the same confusion `scenes/hero/`'s
"every click produces an order" rule exists to prevent, still visible because the
order itself was invisible. A green ring pings a move, a red one an attack-move.

It lives in `scenes/ui/` on the precedent `UnitSelection` already sets: a `Node3D`
that folder owns, sitting in `main.tscn`, **inert** — it reads nothing, nothing
reads it, and `scenes/main.gd` does not pick the colour. Which of two signals
fired is the whole of that decision.

Which meant splitting `Hero.move_ordered`: it carried move *and* attack-move,
fine while nothing consumed it and not fine for the first listener that draws
them differently. Both signals had been emitted and unconsumed since #11; this is
their first consumer. `attack_ordered` is still waiting for one — a marker that
tracks a moving unit is a different feature, deliberately not built here.

## `H` holds position

A real `Order.HOLD`, not a flag. It acquires at `attack_range` rather than
`acquire_radius`, so there is never anything to walk to, and it **stays in
`HOLD` while fighting** — taking a target the ordinary way hands the hero
straight back to the branch that repaths.

`_finish_engagement()` returns early for `HOLD`, and that one line is the
difference between a command and a trap: without it the order ends on the first
kill, so he stands his ground right up until the moment it matters and then
quietly stops, by which time the player has looked away.

## `S` stops

`command_stop()` has existed unbound since #5. It leaves him `IDLE` rather than
`HOLD` deliberately — "stop doing that" and "stand exactly here" are separate
instructions, and only the second lets a player park him somewhere and read the
rest of the screen. Both keys disarm `A` first, on the rule the right-click
handler already keeps.

## The part worth reviewing: I got the colours wrong, and a screenshot said so

The first version shipped green/red with a paragraph in `scenes/ui/CLAUDE.md`
arguing the collision with `scenes/map/`'s green start plate and red boss plate
was acceptable — a ping is transient and animated where the selection ring is
static, so motion should carry a hue difference a still shape could not.

Then I screenshotted a move ping landing on the green plate. **Nothing was
there.** Not weak — absent.

The reasoning about motion was not wrong; it answered the wrong question, because
a marker invisible in the frame the player looks at has already failed whatever
it does over the next half second. So contrast moved into the marker — `Rim`, a
larger near-black torus under the coloured ring — which is the fix that same
paragraph had already named as the remedy. Green still means go, red still means
fight, and it reads better on ordinary floor too. The doc now records the
disproof instead of the claim.

**It is #53's lesson repeated exactly**: a well-argued design decision is still a
hypothesis, and a visual one is settled only by looking. This claim survived
being written down, re-read while its neighbour was written, and reviewed by its
author — and died to the first screenshot.

## `tests/smoke_orders.gd`

Covers the half that breaks invisibly, since `HOLD` looks exactly like `IDLE`
from every angle except the one that matters. **Run with the
`_finish_engagement()` guard removed to prove it discriminates** — without it,
`order is 0` after the kill.

Its own first version is the other thing worth reading: it picked the nearest
zombie by distance and asserted an idle hero would walk to it, and he stood
still — **correctly**, because that zombie was behind rock and automatic
acquisition requires line of sight. Driving the setup off `current_target()`
instead asks the same question in a way `tests/` is allowed to ask. Recorded in
that folder's doc: a test that reaches for world state the hero reasons about
differently is measuring its own assumption.

## Notes for the reviewer

- The root `CLAUDE.md` edit is the `project.godot` misfire (#40), third recorded
  instance. It settles the shape of the cost, which two instances could not: the
  tax is **per commit, not per action**, so two actions cost what one costs.
- `scenes/map/` gained a paragraph rather than a correction — hold-position turns
  "put a chokepoint where a queue is the encounter you want" from a shape into a
  tactic.
- One commit repoints stamps I orphaned with `--amend`. Same hazard the root doc
  documents for squash/rebase, via the one route repo settings cannot close.
- Nothing here tests the marker itself; that boundary is `tests/`', and #55 is
  where it is argued. It was verified by screenshot instead.

## Checks

Full suite green (15 new checks in `smoke_orders.gd`), docs hook and `--audit`
clean.

**Conflicts with #68 and #69** on `tests/CLAUDE.md` (all three add a row to the
file table) and on the `verified-against` stamps. Trivial merges; whichever lands
last wants a re-stamp at the merge commit rather than a re-audit.
